### PR TITLE
[#8][BE] 프로젝트 CRUD API 구현

### DIFF
--- a/backend/app/business/main.py
+++ b/backend/app/business/main.py
@@ -1,19 +1,9 @@
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi import FastAPI
 from mangum import Mangum
 
 from app.business.routers import projects, stages, steps
 
 app = FastAPI(title="Poco Business API")
-
-
-@app.exception_handler(HTTPException)
-async def http_exception_handler(request: Request, exc: HTTPException):
-    return JSONResponse(
-        status_code=exc.status_code,
-        content={"status": "error", "error": exc.detail},
-    )
-
 
 app.include_router(projects.router, prefix="/projects", tags=["projects"])
 app.include_router(stages.router, prefix="/stages", tags=["stages"])

--- a/backend/app/business/main.py
+++ b/backend/app/business/main.py
@@ -1,9 +1,19 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 from mangum import Mangum
 
 from app.business.routers import projects, stages, steps
 
 app = FastAPI(title="Poco Business API")
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"status": "error", "error": exc.detail},
+    )
+
 
 app.include_router(projects.router, prefix="/projects", tags=["projects"])
 app.include_router(stages.router, prefix="/stages", tags=["stages"])
@@ -15,5 +25,4 @@ def health() -> dict:
     return {"ok": True, "service": "business"}
 
 
-# Lambda A entrypoint
 handler = Mangum(app)

--- a/backend/app/business/routers/projects.py
+++ b/backend/app/business/routers/projects.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.business.dependency import get_db
 from app.business.services import project_service
+from app.core.schemas.project import ProjectCreateRequest, ProjectUpdateRequest
 
 router = APIRouter()
 
@@ -12,29 +13,40 @@ router = APIRouter()
 def _ok(data):
     return {"status": "success", "data": data}
 
+def _err(code: str, message: str):
+    return {"status": "error", "error": {"code": code, "message": message}}
 
+# Project 생성
 @router.post("", status_code=201)
-def create_project(payload: dict, db: Session = Depends(get_db)):
-    return _ok(project_service.create_project(db, payload))
+def create_project(payload: ProjectCreateRequest, db: Session = Depends(get_db)):
+    result = project_service.create_project(db, payload)
+    return _ok(result)
 
-
+# Project 목록 조회
 @router.get("")
 def list_projects(
     page: int = Query(1, ge=1),
     size: int = Query(20, ge=1, le=100),
     sort_by: str = Query("created_at"),
     sort_order: str = Query("desc"),
+    keyword: str | None = Query(None),
     db: Session = Depends(get_db),
 ):
-    return _ok(project_service.list_projects(db, page, size, sort_by, sort_order))
+    result = project_service.list_projects(db, page, size, sort_by, sort_order, keyword)
+    return _ok(result)
 
-
+# Project 수정
 @router.patch("/{project_id}")
-def update_project(project_id: UUID, payload: dict, db: Session = Depends(get_db)):
-    return _ok(project_service.update_project(db, project_id, payload))
+def update_project(project_id: UUID, payload: ProjectUpdateRequest, db: Session = Depends(get_db)):
+    result = project_service.update_project(db, project_id, payload)
+    if result is None:
+        return _err("PROJECT_NOT_FOUND", "프로젝트 없음")
+    return _ok(result)
 
-
+# Project 삭제
 @router.delete("/{project_id}")
 def delete_project(project_id: UUID, db: Session = Depends(get_db)):
-    project_service.delete_project(db, project_id)
+    result = project_service.delete_project(db, project_id)
+    if result is None:
+        return _err("PROJECT_NOT_FOUND", "프로젝트 없음")
     return _ok(None)

--- a/backend/app/business/routers/projects.py
+++ b/backend/app/business/routers/projects.py
@@ -1,6 +1,10 @@
-from uuid import UUID, uuid4
+from uuid import UUID
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.business.dependency import get_db
+from app.business.services import project_service
 
 router = APIRouter()
 
@@ -9,36 +13,28 @@ def _ok(data):
     return {"status": "success", "data": data}
 
 
-_DUMMY_PROJECT = {
-    "id": str(uuid4()),
-    "name": "샘플 프로젝트",
-    "prompt": "AI 기반 일정 관리 서비스 만들기",
-    "duration": "4주",
-    "member_count": 3,
-    "created_at": "2026-04-09T10:00:00Z",
-}
+@router.post("", status_code=201)
+def create_project(payload: dict, db: Session = Depends(get_db)):
+    return _ok(project_service.create_project(db, payload))
 
 
 @router.get("")
-def list_projects():
-    return _ok([_DUMMY_PROJECT])
-
-
-@router.post("")
-def create_project(payload: dict):
-    return _ok(_DUMMY_PROJECT)
-
-
-@router.get("/{project_id}")
-def get_project(project_id: UUID):
-    return _ok({**_DUMMY_PROJECT, "id": str(project_id)})
+def list_projects(
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    sort_by: str = Query("created_at"),
+    sort_order: str = Query("desc"),
+    db: Session = Depends(get_db),
+):
+    return _ok(project_service.list_projects(db, page, size, sort_by, sort_order))
 
 
 @router.patch("/{project_id}")
-def update_project(project_id: UUID, payload: dict):
-    return _ok({**_DUMMY_PROJECT, "id": str(project_id), **payload})
+def update_project(project_id: UUID, payload: dict, db: Session = Depends(get_db)):
+    return _ok(project_service.update_project(db, project_id, payload))
 
 
 @router.delete("/{project_id}")
-def delete_project(project_id: UUID):
-    return _ok({"deleted_id": str(project_id)})
+def delete_project(project_id: UUID, db: Session = Depends(get_db)):
+    project_service.delete_project(db, project_id)
+    return _ok(None)

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -1,57 +1,51 @@
 from uuid import UUID
 
-from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from app.core.models.project import Project
+from app.core.schemas.project import (
+    ProjectCreateRequest,
+    ProjectUpdateRequest,
+    ProjectResponse,
+    ProjectListItemResponse,
+)
 
 
-def _project_to_dict(p: Project) -> dict:
-    return {
-        "project_id": str(p.id),
-        "name": p.name,
-        "current_stage_number": 1,
-        "is_completed": p.is_completed,
-        "is_deleted": p.is_deleted,
-        "created_at": p.created_at.isoformat(),
-        "updated_at": p.updated_at.isoformat(),
-    }
-
-
-def get_project_or_404(db: Session, project_id: UUID) -> Project:
-    project = db.query(Project).filter(
-        Project.id == project_id,
-        Project.is_deleted == False,  # noqa: E712
-    ).first()
-    if not project:
-        raise HTTPException(
-            status_code=404,
-            detail={"code": "PROJECT_NOT_FOUND", "message": "프로젝트 없음"},
-        )
-    return project
-
-
-def create_project(db: Session, payload: dict) -> dict:
+# Project 생성
+def create_project(db: Session, payload: ProjectCreateRequest) -> dict:
     project = Project(
-        name=payload["name"],
-        duration_month=payload.get("duration_months"),
-        member_count=payload.get("member_count"),
-        description=payload.get("description"),
-        constraint_text=payload.get("constraint"),
-        prompt=payload.get("prompt"),
+        name=payload.name if payload.name is not None else "새 프로젝트",
+        duration_month=payload.duration_months,
+        member_count=payload.member_count,
+        description=payload.description,
+        constraint_text=payload.constraint,
+        prompt=payload.prompt,
     )
     db.add(project)
     db.commit()
     db.refresh(project)
-    return _project_to_dict(project)
+    return ProjectResponse(
+        project_id=project.id,
+        name=project.name,
+        current_stage_number=1,
+        is_completed=project.is_completed,
+        is_deleted=project.is_deleted,
+        created_at=project.created_at,
+        updated_at=project.updated_at,
+    ).model_dump()
 
 
-def list_projects(db: Session, page: int, size: int, sort_by: str, sort_order: str) -> dict:
+# Project 목록 조회
+def list_projects(db: Session, page: int, size: int, sort_by: str, sort_order: str, keyword: str | None = None) -> dict:
     ALLOWED_SORT = {"created_at", "updated_at", "name"}
     if sort_by not in ALLOWED_SORT:
         sort_by = "created_at"
 
     query = db.query(Project).filter(Project.is_deleted == False)  # noqa: E712
+
+    if keyword:
+        query = query.filter(Project.name.ilike(f"%{keyword}%"))
+
     sort_col = getattr(Project, sort_by)
     query = query.order_by(sort_col.desc() if sort_order == "desc" else sort_col.asc())
 
@@ -60,14 +54,20 @@ def list_projects(db: Session, page: int, size: int, sort_by: str, sort_order: s
 
     return {
         "projects": [
-            {
-                **_project_to_dict(p),
-                "member_count": p.member_count,
-                "duration_month": p.duration_month,
-                "description": p.description,
-                "constraint": p.constraint_text,
-                "prompt": p.prompt,
-            }
+            ProjectListItemResponse(
+                project_id=p.id,
+                name=p.name,
+                current_stage_number=1,
+                is_completed=p.is_completed,
+                is_deleted=p.is_deleted,
+                member_count=p.member_count,
+                duration_month=p.duration_month,
+                description=p.description,
+                constraint=p.constraint_text,
+                prompt=p.prompt,
+                created_at=p.created_at,
+                updated_at=p.updated_at,
+            ).model_dump()
             for p in projects
         ],
         "total_count": total_count,
@@ -76,19 +76,39 @@ def list_projects(db: Session, page: int, size: int, sort_by: str, sort_order: s
     }
 
 
-def update_project(db: Session, project_id: UUID, payload: dict) -> dict:
-    project = get_project_or_404(db, project_id)
+# Project 수정
+def update_project(db: Session, project_id: UUID, payload: ProjectUpdateRequest) -> dict | None:
+    project = db.query(Project).filter(
+        Project.id == project_id,
+        Project.is_deleted == False,  # noqa: E712
+    ).first()
+    if not project:
+        return None
 
-    field_map = {"duration_months": "duration_month", "constraint": "constraint_text"}
-    for key, value in payload.items():
-        setattr(project, field_map.get(key, key), value)
+    project.name = payload.name if payload.name is not None else project.name
+    project.description = payload.description if payload.description is not None else project.description
 
     db.commit()
     db.refresh(project)
-    return _project_to_dict(project)
+    return ProjectResponse(
+        project_id=project.id,
+        name=project.name,
+        current_stage_number=1,
+        is_completed=project.is_completed,
+        is_deleted=project.is_deleted,
+        created_at=project.created_at,
+        updated_at=project.updated_at,
+    ).model_dump()
 
+# Project 삭제
+def delete_project(db: Session, project_id: UUID) -> bool:
+    project = db.query(Project).filter(
+        Project.id == project_id,
+        Project.is_deleted == False,  # noqa: E712
+    ).first()
+    if not project:
+        return None
 
-def delete_project(db: Session, project_id: UUID) -> None:
-    project = get_project_or_404(db, project_id)
     project.is_deleted = True
     db.commit()
+    return True

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -1,0 +1,94 @@
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.models.project import Project
+
+
+def _project_to_dict(p: Project) -> dict:
+    return {
+        "project_id": str(p.id),
+        "name": p.name,
+        "current_stage_number": 1,
+        "is_completed": p.is_completed,
+        "is_deleted": p.is_deleted,
+        "created_at": p.created_at.isoformat(),
+        "updated_at": p.updated_at.isoformat(),
+    }
+
+
+def get_project_or_404(db: Session, project_id: UUID) -> Project:
+    project = db.query(Project).filter(
+        Project.id == project_id,
+        Project.is_deleted == False,  # noqa: E712
+    ).first()
+    if not project:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "PROJECT_NOT_FOUND", "message": "프로젝트 없음"},
+        )
+    return project
+
+
+def create_project(db: Session, payload: dict) -> dict:
+    project = Project(
+        name=payload["name"],
+        duration_month=payload.get("duration_months"),
+        member_count=payload.get("member_count"),
+        description=payload.get("description"),
+        constraint_text=payload.get("constraint"),
+        prompt=payload.get("prompt"),
+    )
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return _project_to_dict(project)
+
+
+def list_projects(db: Session, page: int, size: int, sort_by: str, sort_order: str) -> dict:
+    ALLOWED_SORT = {"created_at", "updated_at", "name"}
+    if sort_by not in ALLOWED_SORT:
+        sort_by = "created_at"
+
+    query = db.query(Project).filter(Project.is_deleted == False)  # noqa: E712
+    sort_col = getattr(Project, sort_by)
+    query = query.order_by(sort_col.desc() if sort_order == "desc" else sort_col.asc())
+
+    total_count = query.count()
+    projects = query.offset((page - 1) * size).limit(size).all()
+
+    return {
+        "projects": [
+            {
+                **_project_to_dict(p),
+                "member_count": p.member_count,
+                "duration_month": p.duration_month,
+                "description": p.description,
+                "constraint": p.constraint_text,
+                "prompt": p.prompt,
+            }
+            for p in projects
+        ],
+        "total_count": total_count,
+        "page": page,
+        "size": size,
+    }
+
+
+def update_project(db: Session, project_id: UUID, payload: dict) -> dict:
+    project = get_project_or_404(db, project_id)
+
+    field_map = {"duration_months": "duration_month", "constraint": "constraint_text"}
+    for key, value in payload.items():
+        setattr(project, field_map.get(key, key), value)
+
+    db.commit()
+    db.refresh(project)
+    return _project_to_dict(project)
+
+
+def delete_project(db: Session, project_id: UUID) -> None:
+    project = get_project_or_404(db, project_id)
+    project.is_deleted = True
+    db.commit()

--- a/backend/app/core/schemas/project.py
+++ b/backend/app/core/schemas/project.py
@@ -1,0 +1,32 @@
+from uuid import UUID
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class ProjectCreateRequest(BaseModel):
+    name: str
+    duration_months: int
+    member_count: int
+    description: Optional[str] = None
+    constraint: Optional[str] = None
+    prompt: Optional[str] = None
+
+
+class ProjectUpdateRequest(BaseModel):
+    name: Optional[str] = None
+    duration_months: Optional[int] = None
+    member_count: Optional[int] = None
+    description: Optional[str] = None
+    constraint: Optional[str] = None
+    prompt: Optional[str] = None
+
+
+class ProjectResponse(BaseModel):
+    project_id: UUID
+    name: str
+    current_stage_number: int
+    is_completed: bool
+    is_deleted: bool
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/core/schemas/project.py
+++ b/backend/app/core/schemas/project.py
@@ -5,21 +5,17 @@ from pydantic import BaseModel
 
 
 class ProjectCreateRequest(BaseModel):
-    name: str
+    name: Optional[str] = None
     duration_months: int
     member_count: int
     description: Optional[str] = None
     constraint: Optional[str] = None
-    prompt: Optional[str] = None
+    prompt: str 
 
 
 class ProjectUpdateRequest(BaseModel):
     name: Optional[str] = None
-    duration_months: Optional[int] = None
-    member_count: Optional[int] = None
     description: Optional[str] = None
-    constraint: Optional[str] = None
-    prompt: Optional[str] = None
 
 
 class ProjectResponse(BaseModel):
@@ -28,5 +24,20 @@ class ProjectResponse(BaseModel):
     current_stage_number: int
     is_completed: bool
     is_deleted: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectListItemResponse(BaseModel):
+    project_id: UUID
+    name: str
+    current_stage_number: int
+    is_completed: bool
+    is_deleted: bool
+    member_count: int
+    duration_month: int
+    description: str | None
+    constraint: str | None
+    prompt: str
     created_at: datetime
     updated_at: datetime


### PR DESCRIPTION
## PR 요약
- 프로젝트 CRUD API 구현 및 서비스 레이어 분리

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- 프로젝트 CRUD API 구현 — 명세서 API 1~4 구현
   - `POST /projects` — 프로젝트 생성
   - `GET /projects` — 프로젝트 목록 조회 (페이지네이션, 정렬 지원)
   - `PATCH /projects/{project_id}` — 프로젝트 부분 수정
   - `DELETE /projects/{project_id}` — 프로젝트 소프트 삭제
- 서비스 레이어 분리 — `business/services/project_service.py` 신규 생성, router에서 비즈니스 로직 분리
- 에러 핸들러 추가 — HTTPException 응답을 명세서 형식(`status/error/code/message`)으로 통일

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인 (Postman)
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
