### PR TITLE
[#19][BE] Black Formatter 전체 파이썬 파일 적용

### DIFF
--- a/backend/app/ai/routers/steps.py
+++ b/backend/app/ai/routers/steps.py
@@ -25,17 +25,23 @@ def generate_steps(step_id: UUID, db: Session = Depends(get_db)) -> dict:
 @router.post("/steps/{step_id}/accept")
 def accept_step(step_id: UUID) -> dict:
     """Step Accept (상태 판정) — TODO: AI 충족 판단 구현."""
-    return _ok({
-        "step_id": str(step_id),
-        "status": "ACCEPTED",
-        "is_current_required_step_completed": False,
-    })
+    return _ok(
+        {
+            "step_id": str(step_id),
+            "status": "ACCEPTED",
+            "is_current_required_step_completed": False,
+        }
+    )
 
 
-@router.post("/steps/{step_id}/notion-template", status_code=http_status.HTTP_201_CREATED)
+@router.post(
+    "/steps/{step_id}/notion-template", status_code=http_status.HTTP_201_CREATED
+)
 def create_notion_template(step_id: UUID) -> dict:
     """Required Step의 Notion 템플릿 페이지 생성 — TODO: Notion API 연동."""
-    return _ok({
-        "notion_page_id": "placeholder",
-        "notion_page_url": "https://notion.so/placeholder",
-    })
+    return _ok(
+        {
+            "notion_page_id": "placeholder",
+            "notion_page_url": "https://notion.so/placeholder",
+        }
+    )

--- a/backend/app/ai/services/orchestrator.py
+++ b/backend/app/ai/services/orchestrator.py
@@ -52,4 +52,10 @@ def generate_next_steps(payload: dict) -> dict:
 
 def generate_step_details(step_id: UUID, payload: dict) -> dict:
     # TODO: implement guide/dictionary/mentoring/template 생성
-    return {"step_id": str(step_id), "todo": [], "dictionary": [], "recommendations": [], "references": []}
+    return {
+        "step_id": str(step_id),
+        "todo": [],
+        "dictionary": [],
+        "recommendations": [],
+        "references": [],
+    }

--- a/backend/app/ai/services/rag.py
+++ b/backend/app/ai/services/rag.py
@@ -11,6 +11,8 @@ def retrieve(query: str, top_k: int = 5) -> list[dict]:
     resp = client.retrieve(
         knowledgeBaseId=settings.BEDROCK_KB_ID,
         retrievalQuery={"text": query},
-        retrievalConfiguration={"vectorSearchConfiguration": {"numberOfResults": top_k}},
+        retrievalConfiguration={
+            "vectorSearchConfiguration": {"numberOfResults": top_k}
+        },
     )
     return resp.get("retrievalResults", [])

--- a/backend/app/ai/services/step_service.py
+++ b/backend/app/ai/services/step_service.py
@@ -21,11 +21,15 @@ _EXAMPLE_STEP_NAMES = [
 ]
 
 
-def _insert_closure_rows(db: Session, step_id: uuid.UUID, parent_step_id: uuid.UUID | None) -> None:
+def _insert_closure_rows(
+    db: Session, step_id: uuid.UUID, parent_step_id: uuid.UUID | None
+) -> None:
     db.add(StepTree(ancestor=step_id, descendant=step_id, depth=0))
     if parent_step_id is None:
         return
-    parent_ancestors = db.query(StepTree).filter(StepTree.descendant == parent_step_id).all()
+    parent_ancestors = (
+        db.query(StepTree).filter(StepTree.descendant == parent_step_id).all()
+    )
     for row in parent_ancestors:
         db.add(StepTree(ancestor=row.ancestor, descendant=step_id, depth=row.depth + 1))
 
@@ -48,7 +52,9 @@ def generate_steps(db: Session, parent_step_id: uuid.UUID) -> list[Step]:
     chosen_names = random.sample(_EXAMPLE_STEP_NAMES, 3)  # 임시
 
     # 부모가 필수 Step 영역에 속하면 자식도 같은 영역에 속함
-    belonging_rs_id = parent_step.belonging_required_step_id or parent_step.required_step_id
+    belonging_rs_id = (
+        parent_step.belonging_required_step_id or parent_step.required_step_id
+    )
 
     steps: list[Step] = []
     for i, name in enumerate(chosen_names):

--- a/backend/app/business/routers/projects.py
+++ b/backend/app/business/routers/projects.py
@@ -29,11 +29,15 @@ def list_projects(
     keyword: str | None = Query(None),
     db: Session = Depends(get_db),
 ):
-    return _ok(project_service.list_projects(db, page, size, sort_by, sort_order, keyword))
+    return _ok(
+        project_service.list_projects(db, page, size, sort_by, sort_order, keyword)
+    )
 
 
 @router.patch("/{project_id}", status_code=http_status.HTTP_200_OK)
-def update_project(project_id: UUID, payload: ProjectUpdateRequest, db: Session = Depends(get_db)):
+def update_project(
+    project_id: UUID, payload: ProjectUpdateRequest, db: Session = Depends(get_db)
+):
     return _ok(project_service.update_project(db, project_id, payload))
 
 

--- a/backend/app/business/routers/steps.py
+++ b/backend/app/business/routers/steps.py
@@ -14,7 +14,9 @@ def _ok(data):
 
 
 @router.get("/tree")
-def get_step_tree(project_id: UUID, stage_id: UUID, db: Session = Depends(get_db)) -> dict:
+def get_step_tree(
+    project_id: UUID, stage_id: UUID, db: Session = Depends(get_db)
+) -> dict:
     """project_id + stage_id 기준 Step 트리 + Footprint 경로 반환."""
     response = step_service.get_step_tree(db, project_id, stage_id)
     return _ok(response.model_dump())

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -17,10 +17,14 @@ from app.core.schemas.project import (
 
 def create_project(db: Session, payload: ProjectCreateRequest) -> dict:
     if payload.name:
-        existing = db.query(Project).filter(
-            Project.name == payload.name,
-            Project.is_deleted == False,
-        ).first()
+        existing = (
+            db.query(Project)
+            .filter(
+                Project.name == payload.name,
+                Project.is_deleted == False,
+            )
+            .first()
+        )
         if existing:
             raise DuplicateProjectNameError()
 
@@ -37,19 +41,23 @@ def create_project(db: Session, payload: ProjectCreateRequest) -> dict:
 
     stages = db.query(Stage).order_by(Stage.sequence).all()
     for i, stage in enumerate(stages):
-        db.add(ProjectStage(
-            project_id=project.id,
-            stage_id=stage.id,
-            is_active=(i == 0),
-        ))
+        db.add(
+            ProjectStage(
+                project_id=project.id,
+                stage_id=stage.id,
+                is_active=(i == 0),
+            )
+        )
 
     required_steps = db.query(RequiredStep).all()
     for rs in required_steps:
-        db.add(ProjectRequiredStepStatus(
-            project_id=project.id,
-            required_step_id=rs.id,
-            is_fulfilled=False,
-        ))
+        db.add(
+            ProjectRequiredStepStatus(
+                project_id=project.id,
+                required_step_id=rs.id,
+                is_fulfilled=False,
+            )
+        )
 
     db.commit()
     db.refresh(project)
@@ -103,16 +111,22 @@ def list_projects(
     }
 
 
-def update_project(db: Session, project_id: UUID, payload: ProjectUpdateRequest) -> dict:
+def update_project(
+    db: Session, project_id: UUID, payload: ProjectUpdateRequest
+) -> dict:
     project = _get_project_or_raise(db, project_id)
 
     if payload.name is not None:
         # 이름 중복 체크
-        existing = db.query(Project).filter(
-            Project.name == payload.name,
-            Project.id != project_id,
-            Project.is_deleted == False,  # noqa: E712
-        ).first()
+        existing = (
+            db.query(Project)
+            .filter(
+                Project.name == payload.name,
+                Project.id != project_id,
+                Project.is_deleted == False,  # noqa: E712
+            )
+            .first()
+        )
         if existing:
             raise DuplicateProjectNameError()
         project.name = payload.name
@@ -131,15 +145,19 @@ def delete_project(db: Session, project_id: UUID) -> None:
 
 
 def _get_project_or_raise(db: Session, project_id: UUID) -> Project:
-    project = db.query(Project).filter(
-        Project.id == project_id,
-        Project.is_deleted == False,  # noqa: E712
-    ).first()
+    project = (
+        db.query(Project)
+        .filter(
+            Project.id == project_id,
+            Project.is_deleted == False,  # noqa: E712
+        )
+        .first()
+    )
     if not project:
         raise ProjectNotFoundError()
     return project
 
-    
+
 def _get_current_stage_number(db: Session, project_id: UUID) -> int:
     """is_active=True인 Stage의 sequence를 반환."""
     row = (

--- a/backend/app/business/services/stage_service.py
+++ b/backend/app/business/services/stage_service.py
@@ -9,10 +9,14 @@ from app.core.schemas.stage import StageListItem, StageListResponse
 
 
 def list_stages(db: Session, project_id: UUID) -> dict:
-    project = db.query(Project).filter(
-        Project.id == project_id,
-        Project.is_deleted == False,  # noqa: E712
-    ).first()
+    project = (
+        db.query(Project)
+        .filter(
+            Project.id == project_id,
+            Project.is_deleted == False,  # noqa: E712
+        )
+        .first()
+    )
     if not project:
         raise ProjectNotFoundError()
 

--- a/backend/app/business/services/step_service.py
+++ b/backend/app/business/services/step_service.py
@@ -7,7 +7,9 @@ from app.core.models.step import Step
 from app.core.schemas.step import StepTreeNode, StepTreeResponse
 
 
-def get_step_tree(db: Session, project_id: uuid.UUID, stage_id: uuid.UUID) -> StepTreeResponse:
+def get_step_tree(
+    db: Session, project_id: uuid.UUID, stage_id: uuid.UUID
+) -> StepTreeResponse:
     """Step 트리 + Footprint 경로를 조립하여 반환."""
     steps = (
         db.query(Step)
@@ -28,15 +30,22 @@ def _build_current_path(steps: list[Step]) -> list[uuid.UUID]:
 
     current_path: list[uuid.UUID] = []
     current = next(
-        (s for s in steps
-         if s.id in accepted_ids
-         and (s.parent_step_id is None or s.parent_step_id not in accepted_ids)),
+        (
+            s
+            for s in steps
+            if s.id in accepted_ids
+            and (s.parent_step_id is None or s.parent_step_id not in accepted_ids)
+        ),
         None,
     )
     while current is not None:
         current_path.append(current.id)
         current = next(
-            (s for s in steps if s.parent_step_id == current.id and s.id in accepted_ids),
+            (
+                s
+                for s in steps
+                if s.parent_step_id == current.id and s.id in accepted_ids
+            ),
             None,
         )
     return current_path

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 from app.core.config import settings
 
-
 engine = create_engine(settings.DATABASE_URL, pool_pre_ping=True, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -4,7 +4,12 @@ from fastapi import status as http_status
 class PocoError(Exception):
     """Poco 도메인 예외 기반 클래스."""
 
-    def __init__(self, code: str, message: str, status_code: int = http_status.HTTP_500_INTERNAL_SERVER_ERROR):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        status_code: int = http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+    ):
         self.code = code
         self.message = message
         self.status_code = status_code
@@ -13,54 +18,98 @@ class PocoError(Exception):
 
 class InvalidInputError(PocoError):
     def __init__(self, message: str = "요청 파라미터 형식이 올바르지 않습니다."):
-        super().__init__(code="INVALID_INPUT", message=message, status_code=http_status.HTTP_400_BAD_REQUEST)
+        super().__init__(
+            code="INVALID_INPUT",
+            message=message,
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+        )
 
 
 class DuplicateProjectNameError(PocoError):
     def __init__(self, message: str = "이미 존재하는 프로젝트 이름입니다."):
-        super().__init__(code="DUPLICATE_PROJECT_NAME", message=message, status_code=http_status.HTTP_409_CONFLICT)
+        super().__init__(
+            code="DUPLICATE_PROJECT_NAME",
+            message=message,
+            status_code=http_status.HTTP_409_CONFLICT,
+        )
 
 
 class StepAlreadyAcceptedError(PocoError):
     def __init__(self, message: str = "이미 Accept된 Step입니다."):
-        super().__init__(code="STEP_ALREADY_ACCEPTED", message=message, status_code=http_status.HTTP_409_CONFLICT)
+        super().__init__(
+            code="STEP_ALREADY_ACCEPTED",
+            message=message,
+            status_code=http_status.HTTP_409_CONFLICT,
+        )
 
 
 class InvalidRollbackTargetError(PocoError):
     def __init__(self, message: str = "롤백할 수 없는 대상입니다."):
-        super().__init__(code="INVALID_ROLLBACK_TARGET", message=message, status_code=http_status.HTTP_400_BAD_REQUEST)
+        super().__init__(
+            code="INVALID_ROLLBACK_TARGET",
+            message=message,
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+        )
 
 
 class ProjectNotFoundError(PocoError):
     def __init__(self, message: str = "프로젝트를 찾을 수 없습니다."):
-        super().__init__(code="PROJECT_NOT_FOUND", message=message, status_code=http_status.HTTP_404_NOT_FOUND)
+        super().__init__(
+            code="PROJECT_NOT_FOUND",
+            message=message,
+            status_code=http_status.HTTP_404_NOT_FOUND,
+        )
 
 
 class StageNotFoundError(PocoError):
     def __init__(self, message: str = "Stage를 찾을 수 없습니다."):
-        super().__init__(code="STAGE_NOT_FOUND", message=message, status_code=http_status.HTTP_404_NOT_FOUND)
+        super().__init__(
+            code="STAGE_NOT_FOUND",
+            message=message,
+            status_code=http_status.HTTP_404_NOT_FOUND,
+        )
 
 
 class StepNotFoundError(PocoError):
     def __init__(self, message: str = "Step을 찾을 수 없습니다."):
-        super().__init__(code="STEP_NOT_FOUND", message=message, status_code=http_status.HTTP_404_NOT_FOUND)
+        super().__init__(
+            code="STEP_NOT_FOUND",
+            message=message,
+            status_code=http_status.HTTP_404_NOT_FOUND,
+        )
 
 
 class ProjectNotInitializedError(PocoError):
     def __init__(self, message: str = "초기화되지 않은 프로젝트입니다."):
-        super().__init__(code="PROJECT_NOT_INITIALIZED", message=message, status_code=http_status.HTTP_400_BAD_REQUEST)
+        super().__init__(
+            code="PROJECT_NOT_INITIALIZED",
+            message=message,
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+        )
 
 
 class StepGenerationLimitError(PocoError):
     def __init__(self, message: str = "Step 추가생성 횟수를 초과했습니다. (최대 6개)"):
-        super().__init__(code="STEP_GENERATION_LIMIT", message=message, status_code=http_status.HTTP_400_BAD_REQUEST)
+        super().__init__(
+            code="STEP_GENERATION_LIMIT",
+            message=message,
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+        )
 
 
 class AIGenerationFailedError(PocoError):
     def __init__(self, message: str = "AI Step 생성에 실패했습니다."):
-        super().__init__(code="AI_GENERATION_FAILED", message=message, status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE)
+        super().__init__(
+            code="AI_GENERATION_FAILED",
+            message=message,
+            status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
 
 
 class NotionAPIFailedError(PocoError):
     def __init__(self, message: str = "Notion 템플릿 생성에 실패했습니다."):
-        super().__init__(code="NOTION_API_FAILED", message=message, status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE)
+        super().__init__(
+            code="NOTION_API_FAILED",
+            message=message,
+            status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
+        )

--- a/backend/app/core/models/project.py
+++ b/backend/app/core/models/project.py
@@ -11,7 +11,9 @@ from app.core.database import Base
 class Project(Base):
     __tablename__ = "project"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     name: Mapped[str] = mapped_column(String, nullable=False)
     prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
     duration_month: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -24,7 +26,10 @@ class Project(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     project_stages: Mapped[list["ProjectStage"]] = relationship(
@@ -39,13 +44,17 @@ class ProjectStage(Base):
     __tablename__ = "project_stages"
 
     project_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("project.id", ondelete="CASCADE"), primary_key=True
+        UUID(as_uuid=True),
+        ForeignKey("project.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     stage_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stage.id", ondelete="CASCADE"), primary_key=True
     )
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     project: Mapped["Project"] = relationship(back_populates="project_stages")
     stage: Mapped["Stage"] = relationship(back_populates="project_stages")  # noqa: F821

--- a/backend/app/core/models/project_required_step_status.py
+++ b/backend/app/core/models/project_required_step_status.py
@@ -14,13 +14,19 @@ class ProjectRequiredStepStatus(Base):
     __tablename__ = "project_required_step_status"
 
     project_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("project.id", ondelete="CASCADE"), primary_key=True
+        UUID(as_uuid=True),
+        ForeignKey("project.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     required_step_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("required_step.id", ondelete="CASCADE"), primary_key=True
+        UUID(as_uuid=True),
+        ForeignKey("required_step.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     is_fulfilled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    fulfilled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    fulfilled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     project: Mapped["Project"] = relationship()  # noqa: F821
     required_step: Mapped["RequiredStep"] = relationship()  # noqa: F821

--- a/backend/app/core/models/required_step.py
+++ b/backend/app/core/models/required_step.py
@@ -9,9 +9,13 @@ from app.core.database import Base
 
 class RequiredStep(Base):
     __tablename__ = "required_step"
-    __table_args__ = (UniqueConstraint("stage_id", "sequence", name="uq_required_step_stage_seq"),)
+    __table_args__ = (
+        UniqueConstraint("stage_id", "sequence", name="uq_required_step_stage_seq"),
+    )
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     stage_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stage.id"), nullable=False
     )
@@ -23,8 +27,12 @@ class RequiredStep(Base):
     # AI 판단 근거 컬럼
     goal: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     entry_criteria: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
-    fulfillment_aspects: Mapped[list] = mapped_column(JSONB, nullable=False, server_default="[]")
-    fulfillment_threshold: Mapped[int] = mapped_column(Integer, nullable=False, server_default="2")
+    fulfillment_aspects: Mapped[list] = mapped_column(
+        JSONB, nullable=False, server_default="[]"
+    )
+    fulfillment_threshold: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="2"
+    )
     doj_reference: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     stage: Mapped["Stage"] = relationship(back_populates="required_steps")  # noqa: F821

--- a/backend/app/core/models/stage.py
+++ b/backend/app/core/models/stage.py
@@ -10,7 +10,9 @@ from app.core.database import Base
 class Stage(Base):
     __tablename__ = "stage"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     name: Mapped[str] = mapped_column(String, nullable=False)
     sequence: Mapped[int] = mapped_column(Integer, nullable=False, unique=True)
 

--- a/backend/app/core/models/step.py
+++ b/backend/app/core/models/step.py
@@ -12,7 +12,9 @@ from app.core.enums import StepStatus
 class Step(Base):
     __tablename__ = "step"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("project.id", ondelete="CASCADE"), nullable=False
     )
@@ -29,7 +31,9 @@ class Step(Base):
         UUID(as_uuid=True), ForeignKey("required_step.id"), nullable=True
     )
     name: Mapped[str] = mapped_column(String, nullable=False)
-    status: Mapped[str] = mapped_column(String, nullable=False, default=StepStatus.READY)
+    status: Mapped[str] = mapped_column(
+        String, nullable=False, default=StepStatus.READY
+    )
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
@@ -44,7 +48,9 @@ class Step(Base):
         back_populates="parent", foreign_keys="Step.parent_step_id"
     )
     parent: Mapped["Step | None"] = relationship(
-        back_populates="children", foreign_keys="Step.parent_step_id", remote_side="Step.id"
+        back_populates="children",
+        foreign_keys="Step.parent_step_id",
+        remote_side="Step.id",
     )
     required_step: Mapped["RequiredStep | None"] = relationship(  # noqa: F821
         foreign_keys="Step.required_step_id"

--- a/backend/scripts/seed_dummy_steps.py
+++ b/backend/scripts/seed_dummy_steps.py
@@ -43,7 +43,9 @@ from app.core.models.stage import Stage  # noqa: E402
 from app.core.models.step import Step, StepContent, StepTree  # noqa: E402
 
 
-def _add_closure(db: Session, step_id: uuid.UUID, parent_step_id: uuid.UUID | None) -> None:
+def _add_closure(
+    db: Session, step_id: uuid.UUID, parent_step_id: uuid.UUID | None
+) -> None:
     """Closure Table에 자기 자신 + 조상 경로 삽입."""
     db.add(StepTree(ancestor=step_id, descendant=step_id, depth=0))
     if parent_step_id is None:
@@ -83,11 +85,13 @@ def _make_step(
     _add_closure(db, step.id, parent_step_id)
 
     if dictionary or mentoring:
-        db.add(StepContent(
-            step_id=step.id,
-            dictionary=dictionary,
-            mentoring=mentoring,
-        ))
+        db.add(
+            StepContent(
+                step_id=step.id,
+                dictionary=dictionary,
+                mentoring=mentoring,
+            )
+        )
 
     return step
 
@@ -96,7 +100,9 @@ def run() -> None:
     db = SessionLocal()
     try:
         # 1) 첫 번째 프로젝트 가져오기 (없으면 에러)
-        project = db.query(Project).filter(Project.is_deleted == False).first()  # noqa: E712
+        project = (
+            db.query(Project).filter(Project.is_deleted == False).first()
+        )  # noqa: E712
         if not project:
             print("❌ 프로젝트가 없습니다. 먼저 프로젝트를 생성하세요.")
             return
@@ -123,13 +129,17 @@ def run() -> None:
         sid = stage1.id
 
         # 4) 기존 Step 데이터 삭제 (해당 프로젝트 + Stage)
-        existing = db.query(Step).filter(Step.project_id == pid, Step.stage_id == sid).all()
+        existing = (
+            db.query(Step).filter(Step.project_id == pid, Step.stage_id == sid).all()
+        )
         if existing:
             ids = [s.id for s in existing]
             db.query(StepTree).filter(
                 (StepTree.ancestor.in_(ids)) | (StepTree.descendant.in_(ids))
             ).delete(synchronize_session=False)
-            db.query(StepContent).filter(StepContent.step_id.in_(ids)).delete(synchronize_session=False)
+            db.query(StepContent).filter(StepContent.step_id.in_(ids)).delete(
+                synchronize_session=False
+            )
             db.query(Step).filter(Step.id.in_(ids)).delete(synchronize_session=False)
             db.flush()
 
@@ -158,96 +168,225 @@ def run() -> None:
         # └── 경쟁사 조사 (CANCELED)
 
         # Level 0: R1 문제/기회 정의 (required, ACCEPTED)
-        s1 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=None,
-                        name="문제/기회 정의", status=StepStatus.ACCEPTED, sort_order=1,
-                        required_step_id=rs1.id, belonging_required_step_id=rs1.id,
-                        dictionary="문제 정의: 해결하고자 하는 핵심 문제를 명확히 기술하는 활동",
-                        mentoring="좋은 문제 정의가 좋은 솔루션의 시작입니다.")
+        s1 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=None,
+            name="문제/기회 정의",
+            status=StepStatus.ACCEPTED,
+            sort_order=1,
+            required_step_id=rs1.id,
+            belonging_required_step_id=rs1.id,
+            dictionary="문제 정의: 해결하고자 하는 핵심 문제를 명확히 기술하는 활동",
+            mentoring="좋은 문제 정의가 좋은 솔루션의 시작입니다.",
+        )
 
         # Level 1: R1의 자식 2개 (ACCEPTED 1개만)
-        s2 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s1.id,
-                        name="아이디어 브레인스토밍", status=StepStatus.ACCEPTED, sort_order=1,
-                        belonging_required_step_id=rs1.id,
-                        dictionary="브레인스토밍: 판단 없이 아이디어를 최대한 많이 생성하는 기법",
-                        mentoring="양을 먼저 확보하세요. 판단은 나중에!")
+        s2 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s1.id,
+            name="아이디어 브레인스토밍",
+            status=StepStatus.ACCEPTED,
+            sort_order=1,
+            belonging_required_step_id=rs1.id,
+            dictionary="브레인스토밍: 판단 없이 아이디어를 최대한 많이 생성하는 기법",
+            mentoring="양을 먼저 확보하세요. 판단은 나중에!",
+        )
 
-        s3 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s1.id,
-                        name="경쟁사 조사", status=StepStatus.CANCELED, sort_order=2,
-                        belonging_required_step_id=rs1.id)
+        s3 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s1.id,
+            name="경쟁사 조사",
+            status=StepStatus.CANCELED,
+            sort_order=2,
+            belonging_required_step_id=rs1.id,
+        )
 
         # Level 2: s2(브레인스토밍)의 자식 3개 (ACCEPTED 1개만)
-        s5 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s2.id,
-                        name="핵심 문제 도출", status=StepStatus.ACCEPTED, sort_order=1,
-                        belonging_required_step_id=rs1.id,
-                        mentoring="브레인스토밍 결과에서 가장 임팩트 있는 문제를 선별하세요.")
+        s5 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s2.id,
+            name="핵심 문제 도출",
+            status=StepStatus.ACCEPTED,
+            sort_order=1,
+            belonging_required_step_id=rs1.id,
+            mentoring="브레인스토밍 결과에서 가장 임팩트 있는 문제를 선별하세요.",
+        )
 
-        s6 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s2.id,
-                        name="시장 규모 추정", status=StepStatus.CANCELED, sort_order=2,
-                        belonging_required_step_id=rs1.id)
+        s6 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s2.id,
+            name="시장 규모 추정",
+            status=StepStatus.CANCELED,
+            sort_order=2,
+            belonging_required_step_id=rs1.id,
+        )
 
-        s7 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s2.id,
-                        name="사용자 페인포인트 정리", status=StepStatus.CANCELED, sort_order=3,
-                        belonging_required_step_id=rs1.id)
+        s7 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s2.id,
+            name="사용자 페인포인트 정리",
+            status=StepStatus.CANCELED,
+            sort_order=3,
+            belonging_required_step_id=rs1.id,
+        )
 
         # Level 3: s5(핵심 문제 도출)의 자식 3개 (ACCEPTED 1개만 = R2)
-        s4 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s5.id,
-                        name="목표 사용자 분석", status=StepStatus.ACCEPTED, sort_order=1,
-                        required_step_id=rs2.id, belonging_required_step_id=rs2.id,
-                        dictionary="페르소나: 타겟 사용자를 대표하는 가상의 인물 프로필",
-                        mentoring="사용자를 깊이 이해하면 제품의 방향이 명확해집니다.")
+        s4 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s5.id,
+            name="목표 사용자 분석",
+            status=StepStatus.ACCEPTED,
+            sort_order=1,
+            required_step_id=rs2.id,
+            belonging_required_step_id=rs2.id,
+            dictionary="페르소나: 타겟 사용자를 대표하는 가상의 인물 프로필",
+            mentoring="사용자를 깊이 이해하면 제품의 방향이 명확해집니다.",
+        )
 
-        s11 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s5.id,
-                         name="문제 우선순위 정하기", status=StepStatus.CANCELED, sort_order=2,
-                         belonging_required_step_id=rs1.id)
+        s11 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s5.id,
+            name="문제 우선순위 정하기",
+            status=StepStatus.CANCELED,
+            sort_order=2,
+            belonging_required_step_id=rs1.id,
+        )
 
-        s13 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s5.id,
-                         name="문제 검증 설문", status=StepStatus.CANCELED, sort_order=3,
-                         belonging_required_step_id=rs1.id)
+        s13 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s5.id,
+            name="문제 검증 설문",
+            status=StepStatus.CANCELED,
+            sort_order=3,
+            belonging_required_step_id=rs1.id,
+        )
 
         # Level 4: s4(R2 목표 사용자 분석)의 자식 3개 (ACCEPTED 1개만)
-        s8 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s4.id,
-                        name="페르소나 작성", status=StepStatus.ACCEPTED, sort_order=1,
-                        belonging_required_step_id=rs2.id,
-                        dictionary="페르소나: 이름, 나이, 직업, 목표, 불편함 등을 구체적으로 설정",
-                        mentoring="최소 2개 이상의 페르소나를 만들어보세요.")
+        s8 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s4.id,
+            name="페르소나 작성",
+            status=StepStatus.ACCEPTED,
+            sort_order=1,
+            belonging_required_step_id=rs2.id,
+            dictionary="페르소나: 이름, 나이, 직업, 목표, 불편함 등을 구체적으로 설정",
+            mentoring="최소 2개 이상의 페르소나를 만들어보세요.",
+        )
 
-        s9 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s4.id,
-                        name="타겟 시장 세분화", status=StepStatus.CANCELED, sort_order=2,
-                        belonging_required_step_id=rs2.id)
+        s9 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s4.id,
+            name="타겟 시장 세분화",
+            status=StepStatus.CANCELED,
+            sort_order=2,
+            belonging_required_step_id=rs2.id,
+        )
 
-        s10 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s4.id,
-                         name="사용자 인터뷰 계획", status=StepStatus.CANCELED, sort_order=3,
-                         belonging_required_step_id=rs2.id)
+        s10 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s4.id,
+            name="사용자 인터뷰 계획",
+            status=StepStatus.CANCELED,
+            sort_order=3,
+            belonging_required_step_id=rs2.id,
+        )
 
         # Level 5: s8(페르소나 작성)의 자식 3개 (ACCEPTED 1개만)
-        s14 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s8.id,
-                         name="사용자 여정 맵", status=StepStatus.ACCEPTED, sort_order=1,
-                         belonging_required_step_id=rs2.id,
-                         dictionary="사용자 여정 맵: 사용자가 서비스를 이용하는 전체 과정을 시각화",
-                         mentoring="터치포인트별 감정 변화를 함께 기록하세요.")
+        s14 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s8.id,
+            name="사용자 여정 맵",
+            status=StepStatus.ACCEPTED,
+            sort_order=1,
+            belonging_required_step_id=rs2.id,
+            dictionary="사용자 여정 맵: 사용자가 서비스를 이용하는 전체 과정을 시각화",
+            mentoring="터치포인트별 감정 변화를 함께 기록하세요.",
+        )
 
-        s15 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s8.id,
-                         name="사용자 니즈 분류", status=StepStatus.CANCELED, sort_order=2,
-                         belonging_required_step_id=rs2.id)
+        s15 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s8.id,
+            name="사용자 니즈 분류",
+            status=StepStatus.CANCELED,
+            sort_order=2,
+            belonging_required_step_id=rs2.id,
+        )
 
-        s18 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s8.id,
-                         name="사용자 세그먼트 정의", status=StepStatus.CANCELED, sort_order=3,
-                         belonging_required_step_id=rs2.id)
+        s18 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s8.id,
+            name="사용자 세그먼트 정의",
+            status=StepStatus.CANCELED,
+            sort_order=3,
+            belonging_required_step_id=rs2.id,
+        )
 
         # Level 6: s14(사용자 여정 맵)의 자식 3개 (모두 READY = 현재 선택 대기)
-        s19 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s14.id,
-                         name="터치포인트별 개선 기회 도출", status=StepStatus.READY, sort_order=1,
-                         belonging_required_step_id=rs2.id)
+        s19 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s14.id,
+            name="터치포인트별 개선 기회 도출",
+            status=StepStatus.READY,
+            sort_order=1,
+            belonging_required_step_id=rs2.id,
+        )
 
-        s16 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s14.id,
-                         name="유사 서비스 분석", status=StepStatus.READY, sort_order=2,
-                         required_step_id=rs3.id, belonging_required_step_id=rs3.id,
-                         dictionary="벤치마킹: 경쟁사 및 유사 서비스의 강점·약점을 비교 분석",
-                         mentoring="최소 3개 이상의 유사 서비스를 분석해보세요.")
+        s16 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s14.id,
+            name="유사 서비스 분석",
+            status=StepStatus.READY,
+            sort_order=2,
+            required_step_id=rs3.id,
+            belonging_required_step_id=rs3.id,
+            dictionary="벤치마킹: 경쟁사 및 유사 서비스의 강점·약점을 비교 분석",
+            mentoring="최소 3개 이상의 유사 서비스를 분석해보세요.",
+        )
 
-        s17 = _make_step(db, project_id=pid, stage_id=sid, parent_step_id=s14.id,
-                         name="사용자 감정 곡선 작성", status=StepStatus.READY, sort_order=3,
-                         belonging_required_step_id=rs2.id)
+        s17 = _make_step(
+            db,
+            project_id=pid,
+            stage_id=sid,
+            parent_step_id=s14.id,
+            name="사용자 감정 곡선 작성",
+            status=StepStatus.READY,
+            sort_order=3,
+            belonging_required_step_id=rs2.id,
+        )
 
         db.commit()
 
@@ -256,7 +395,9 @@ def run() -> None:
         print(f"   Stage: {stage1.name} ({sid})")
         print(f"   Required Steps: R1={rs1.name}, R2={rs2.name}, R3={rs3.name}")
         print(f"   ACCEPTED: 6개, CANCELED: 10개, READY: 3개")
-        print(f"   current_path: R1 → 브레인스토밍 → 핵심문제도출 → R2 → 페르소나 → 여정맵")
+        print(
+            f"   current_path: R1 → 브레인스토밍 → 핵심문제도출 → R2 → 페르소나 → 여정맵"
+        )
 
     finally:
         db.close()

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -3,6 +3,7 @@
 사용법: python seed.py [stage]
 인자 없이 실행하면 모든 시드를 삽입한다.
 """
+
 import sys
 
 from app.core.database import SessionLocal


### PR DESCRIPTION
## PR 요약
- 백엔드 전체 파이썬 파일에 Black Formatter 일괄 적용

## 변경 유형
- [x] 리팩토링

## 변경 사항
- `black` 포매터 기준으로 18개 파일 코드 스타일 통일
- 들여쓰기, 줄 길이, 공백, 괄호 등 포맷 정규화
- 로직 변경 없음 (순수 포맷 변경)

### 대상 파일
- `app/ai/routers/steps.py`
- `app/ai/services/orchestrator.py`, `rag.py`, `step_service.py`
- `app/business/routers/projects.py`, `steps.py`
- `app/business/services/project_service.py`, `stage_service.py`, `step_service.py`
- `app/core/database.py`, `exceptions.py`
- `app/core/models/project.py`, `project_required_step_status.py`, `required_step.py`, `stage.py`, `step.py`
- `scripts/seed_dummy_steps.py`
- `seed.py`

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 불필요한 코드 및 주석 제거

## 참고 사항
- 향후 `pre-commit` 훅 또는 CI에 Black 검사 추가 권장