### PR TITLE
[#15][BE] 프로젝트 스키마 정리 및 기본 이름 넘버링 적용

### DIFF
--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -134,6 +134,10 @@ def update_project(
         project.name = payload.name
     if payload.description is not None:
         project.description = payload.description
+    if payload.duration_months is not None:
+        project.duration_month = payload.duration_months
+    if payload.member_count is not None:
+        project.member_count = payload.member_count
 
     db.commit()
     db.refresh(project)

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -179,7 +179,7 @@ def _to_project_response(db: Session, project: ProjectModel) -> ProjectResponse:
     return ProjectResponse(
         project_id=project.id,
         name=project.name,
-        current_stage_sequencer=_get_current_stage_sequence(db, project.id),
+        current_stage_sequence=_get_current_stage_sequence(db, project.id),
         is_deleted=project.is_deleted,
         created_at=project.created_at,
         updated_at=project.updated_at,

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -96,7 +96,7 @@ def list_projects(
             ProjectListItemResponse(
                 project_id=p.id,
                 name=p.name,
-                current_stage_number=_get_current_stage_number(db, p.id),
+                current_stage_sequence=_get_current_stage_sequence(db, p.id),
                 is_deleted=p.is_deleted,
                 member_count=p.member_count,
                 duration_month=p.duration_month,
@@ -160,7 +160,7 @@ def _get_project_or_raise(db: Session, project_id: UUID) -> ProjectModel:
     return project
 
 
-def _get_current_stage_number(db: Session, project_id: UUID) -> int:
+def _get_current_stage_sequence(db: Session, project_id: UUID) -> int:
     """is_active=True인 Stage의 sequence를 반환."""
     row = (
         db.query(StageModel.sequence)
@@ -179,7 +179,7 @@ def _to_project_response(db: Session, project: ProjectModel) -> ProjectResponse:
     return ProjectResponse(
         project_id=project.id,
         name=project.name,
-        current_stage_number=_get_current_stage_number(db, project.id),
+        current_stage_sequencer=_get_current_stage_sequence(db, project.id),
         is_deleted=project.is_deleted,
         created_at=project.created_at,
         updated_at=project.updated_at,

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -33,7 +33,7 @@ def create_project(db: Session, payload: ProjectCreateRequest) -> ProjectRespons
             raise DuplicateProjectNameError()
 
     project = ProjectModel(
-        name=payload.name if payload.name is not None else "새 프로젝트",
+        name=payload.name if payload.name is not None else _generate_default_name(db),
         duration_month=payload.duration_months,
         member_count=payload.member_count,
         description=payload.description,
@@ -184,3 +184,23 @@ def _to_project_response(db: Session, project: ProjectModel) -> ProjectResponse:
         created_at=project.created_at,
         updated_at=project.updated_at,
     )
+
+def _generate_default_name(db: Session) -> str:
+    base = "새 프로젝트"
+    existing_names = (
+        db.query(ProjectModel.name)
+        .filter(
+            ProjectModel.name.ilike(f"{base}%"),
+            ProjectModel.is_deleted == False,
+        )
+        .all()
+    )
+    existing_names = {row[0] for row in existing_names}
+
+    if base not in existing_names:
+        return base
+
+    count = 2
+    while f"{base} ({count})" in existing_names:
+        count += 1
+    return f"{base} ({count})"

--- a/backend/app/core/schemas/project.py
+++ b/backend/app/core/schemas/project.py
@@ -16,6 +16,8 @@ class ProjectCreateRequest(BaseModel):
 class ProjectUpdateRequest(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
+    duration_months: Optional[int] = None
+    member_count: Optional[int] = None
 
 
 class ProjectResponse(BaseModel):

--- a/backend/app/core/schemas/project.py
+++ b/backend/app/core/schemas/project.py
@@ -10,7 +10,7 @@ class ProjectCreateRequest(BaseModel):
     member_count: int
     description: Optional[str] = None
     constraint: Optional[str] = None
-    prompt: str
+    prompt: str 
 
 
 class ProjectUpdateRequest(BaseModel):
@@ -21,7 +21,8 @@ class ProjectUpdateRequest(BaseModel):
 class ProjectResponse(BaseModel):
     project_id: UUID
     name: str
-    current_stage_number: int
+    current_stage_sequence: int
+    is_completed: bool
     is_deleted: bool
     created_at: datetime
     updated_at: datetime
@@ -30,19 +31,12 @@ class ProjectResponse(BaseModel):
 class ProjectListItemResponse(BaseModel):
     project_id: UUID
     name: str
-    current_stage_number: int
+    current_stage_sequence: int
     is_deleted: bool
-    member_count: int | None
-    duration_month: int | None
+    member_count: int
+    duration_month: int
     description: str | None
     constraint: str | None
     prompt: str
     created_at: datetime
     updated_at: datetime
-
-
-class ProjectListResponse(BaseModel):
-    projects: list[ProjectListItemResponse]
-    total_count: int
-    page: int
-    size: int

--- a/backend/app/core/schemas/project.py
+++ b/backend/app/core/schemas/project.py
@@ -22,7 +22,6 @@ class ProjectResponse(BaseModel):
     project_id: UUID
     name: str
     current_stage_sequence: int
-    is_completed: bool
     is_deleted: bool
     created_at: datetime
     updated_at: datetime

--- a/backend/app/core/schemas/project.py
+++ b/backend/app/core/schemas/project.py
@@ -40,3 +40,9 @@ class ProjectListItemResponse(BaseModel):
     prompt: str
     created_at: datetime
     updated_at: datetime
+
+class ProjectListResponse(BaseModel):
+    projects: list[ProjectListItemResponse]
+    total_count: int
+    page: int
+    size: int


### PR DESCRIPTION
## PR 요약
- `is_completed` 필드 제거 및 `stage_number` → `stage_sequence` 필드명 변경
- 프로젝트 생성 시 기본 이름을 넘버링 방식으로 변경 (`새 프로젝트`, `새 프로젝트 (2)` ...)
- 프로젝트 수정 가능 필드 추가 (duration_months, member_count)

## 변경 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- 

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
