### PR TITLE
[#19][BE] 리팩토링

### DIFF
--- a/backend/app/business/routers/stages.py
+++ b/backend/app/business/routers/stages.py
@@ -16,4 +16,4 @@ def _ok(data):
 
 @router.get("", status_code=http_status.HTTP_200_OK)
 def list_stages(project_id: UUID, db: Session = Depends(get_db)):
-    return _ok(stage_service.list_stages(db, project_id))
+    return _ok(stage_service.list_stages(db, project_id).model_dump())

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -189,6 +189,7 @@ def _to_project_response(db: Session, project: ProjectModel) -> ProjectResponse:
         updated_at=project.updated_at,
     )
 
+
 def _generate_default_name(db: Session) -> str:
     base = "새 프로젝트"
     existing_names = (

--- a/backend/app/business/services/stage_service.py
+++ b/backend/app/business/services/stage_service.py
@@ -9,7 +9,7 @@ from app.core.models.stage import Stage as StageModel
 from app.core.schemas.stage import StageListItem, StageListResponse
 
 
-def list_stages(db: Session, project_id: UUID) -> dict:
+def list_stages(db: Session, project_id: UUID) -> StageListResponse:
     project = (
         db.query(ProjectModel)
         .filter(
@@ -22,8 +22,8 @@ def list_stages(db: Session, project_id: UUID) -> dict:
         raise ProjectNotFoundError()
 
     rows = (
-        db.query(ProjectStageModel, Stage)
-        .join(Stage, StageModel.id == ProjectStageModel.stage_id)
+        db.query(ProjectStageModel, StageModel)
+        .join(StageModel, StageModel.id == ProjectStageModel.stage_id)
         .filter(ProjectStageModel.project_id == project_id)
         .order_by(StageModel.sequence)
         .all()
@@ -39,4 +39,4 @@ def list_stages(db: Session, project_id: UUID) -> dict:
         for ps, stage in rows
     ]
 
-    return StageListResponse(stages=stages).model_dump()
+    return StageListResponse(stages=stages)

--- a/backend/app/business/services/step_service.py
+++ b/backend/app/business/services/step_service.py
@@ -3,8 +3,14 @@ import uuid
 from sqlalchemy.orm import Session
 
 from app.core.enums import StepStatus
+from app.core.models.required_step import RequiredStep as RequiredStepModel
 from app.core.models.step import Step as StepModel
-from app.core.schemas.step import StepTreeNode, StepTreeResponse
+from app.core.schemas.step import (
+    RequiredStepItem,
+    RequiredStepListResponse,
+    StepTreeNode,
+    StepTreeResponse,
+)
 
 
 def get_step_tree(
@@ -12,7 +18,7 @@ def get_step_tree(
 ) -> StepTreeResponse:
     """Step 트리 + Footprint 경로를 조립하여 반환."""
     steps = (
-        db.query(Step)
+        db.query(StepModel)
         .filter(StepModel.project_id == project_id, StepModel.stage_id == stage_id)
         .order_by(StepModel.sort_order)
         .all()
@@ -22,6 +28,27 @@ def get_step_tree(
     roots = _build_tree(steps)
 
     return StepTreeResponse(current_path=current_path, steps=roots)
+
+
+def get_required_steps(db: Session, stage_id: uuid.UUID) -> RequiredStepListResponse:
+    """특정 Stage의 Required Step 목록 조회."""
+    required_steps = (
+        db.query(RequiredStepModel)
+        .filter(RequiredStepModel.stage_id == stage_id)
+        .order_by(RequiredStepModel.sequence)
+        .all()
+    )
+    return RequiredStepListResponse(
+        required_step=[
+            RequiredStepItem(
+                step_id=rs.id,
+                name=rs.name,
+                stage_id=rs.stage_id,
+                sequence=rs.sequence,
+            )
+            for rs in required_steps
+        ]
+    )
 
 
 def _build_current_path(steps: list[StepModel]) -> list[uuid.UUID]:
@@ -73,28 +100,3 @@ def _build_tree(steps: list[StepModel]) -> list[StepTreeNode]:
             roots.append(node)
 
     return roots
-
-
-from app.core.models.required_step import RequiredStep as RequiredStepModel
-from app.core.schemas.step import RequiredStepItem, RequiredStepListResponse
-
-
-def get_required_steps(db: Session, stage_id: uuid.UUID) -> RequiredStepListResponse:
-    """특정 Stage의 Required Step 목록 조회."""
-    required_steps = (
-        db.query(RequiredStep)
-        .filter(RequiredStepModel.stage_id == stage_id)
-        .order_by(RequiredStepModel.sequence)
-        .all()
-    )
-    return RequiredStepListResponse(
-        required_step=[
-            RequiredStepItem(
-                step_id=rs.id,
-                name=rs.name,
-                stage_id=rs.stage_id,
-                sequence=rs.sequence,
-            )
-            for rs in required_steps
-        ]
-    )

--- a/backend/app/core/schemas/project.py
+++ b/backend/app/core/schemas/project.py
@@ -10,7 +10,7 @@ class ProjectCreateRequest(BaseModel):
     member_count: int
     description: Optional[str] = None
     constraint: Optional[str] = None
-    prompt: str 
+    prompt: str
 
 
 class ProjectUpdateRequest(BaseModel):
@@ -34,13 +34,14 @@ class ProjectListItemResponse(BaseModel):
     name: str
     current_stage_sequence: int
     is_deleted: bool
-    member_count: int
-    duration_month: int
-    description: str | None
-    constraint: str | None
-    prompt: str
+    member_count: Optional[int] = None
+    duration_month: Optional[int] = None
+    description: Optional[str] = None
+    constraint: Optional[str] = None
+    prompt: Optional[str] = None
     created_at: datetime
     updated_at: datetime
+
 
 class ProjectListResponse(BaseModel):
     projects: list[ProjectListItemResponse]

--- a/backend/app/core/seeds/required_step.py
+++ b/backend/app/core/seeds/required_step.py
@@ -14,6 +14,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "문제/기회 정의",
         "toast_message": "문제/기회 정의서를 완성했습니다! 🎯",
         "template_description": "해결하고자 하는 핵심 문제 또는 기회를 명확히 기술하는 문서입니다. 문제 배경, 현재 상황, 기대 효과를 포함합니다.",
+        "goal": "프로젝트가 해결하려는 핵심 문제 또는 기회를 명확히 정의한다.",
+        "entry_criteria": "프로젝트 초기 아이디어가 존재하며 사용자가 해결하고 싶은 문제를 인지하고 있다.",
+        "fulfillment_aspects": [
+            "문제 배경 기술",
+            "현재 상황 분석",
+            "기대 효과 명시",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch3 - Initiation",
     },
     {
         "stage_sequence": 1,
@@ -21,6 +30,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "목표 사용자 분석",
         "toast_message": "목표 사용자 분석을 완료했습니다! 👥",
         "template_description": "타겟 사용자 그룹과 페르소나를 정의하는 문서입니다. 사용자 특성, 니즈, 페인 포인트를 포함합니다.",
+        "goal": "프로젝트가 대상으로 하는 사용자 그룹과 페르소나를 구체화한다.",
+        "entry_criteria": "문제/기회가 정의되어 있고 잠재 사용자에 대한 가설이 존재한다.",
+        "fulfillment_aspects": [
+            "타겟 사용자 그룹 정의",
+            "페르소나 작성",
+            "사용자 니즈/페인 포인트 도출",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch3 - Stakeholder Analysis",
     },
     {
         "stage_sequence": 1,
@@ -28,6 +46,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "유사 서비스 분석",
         "toast_message": "유사 서비스 분석을 완료했습니다! 🔍",
         "template_description": "경쟁사 및 유사 서비스를 벤치마킹하는 문서입니다. 강점·약점 비교표와 차별화 포인트를 포함합니다.",
+        "goal": "경쟁사 및 유사 서비스를 분석하여 차별화 포인트를 도출한다.",
+        "entry_criteria": "타겟 사용자가 정의되어 있고 비교할 만한 유사 서비스가 식별되어 있다.",
+        "fulfillment_aspects": [
+            "경쟁사 식별",
+            "강점·약점 비교",
+            "차별화 포인트 도출",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch4 - Market Analysis",
     },
     {
         "stage_sequence": 1,
@@ -35,6 +62,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "핵심 개념 정의",
         "toast_message": "핵심 개념 정의를 완료했습니다! 💡",
         "template_description": "프로젝트의 핵심 가치 제안과 차별점을 정의하는 문서입니다. 솔루션 개요, 핵심 기능 아이디어, 기대 가치를 포함합니다.",
+        "goal": "프로젝트의 핵심 가치 제안과 솔루션 개념을 구체화한다.",
+        "entry_criteria": "유사 서비스 분석이 완료되어 차별화 방향이 정해져 있다.",
+        "fulfillment_aspects": [
+            "솔루션 개요 작성",
+            "핵심 기능 아이디어 도출",
+            "기대 가치 명시",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch4 - System Concept Development",
     },
     # ── Stage 2: 프로젝트 계획 (Ch5) ──────────────────────────────────────
     {
@@ -43,6 +79,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "프로젝트 범위 정의",
         "toast_message": "프로젝트 범위 정의서를 완성했습니다! 📋",
         "template_description": "In/Out Scope와 WBS를 정의하는 문서입니다. 주요 기능 목록, 제외 항목, 산출물 목록을 포함합니다.",
+        "goal": "프로젝트의 In/Out Scope와 작업 분할 구조(WBS)를 명확히 한다.",
+        "entry_criteria": "핵심 개념이 정의되어 있고 주요 기능 후보가 도출되어 있다.",
+        "fulfillment_aspects": [
+            "In Scope 기능 명시",
+            "Out of Scope 명시",
+            "WBS 작성",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch5 - Project Planning",
     },
     {
         "stage_sequence": 2,
@@ -50,6 +95,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "일정 계획 수립",
         "toast_message": "일정 계획을 완성했습니다! 📅",
         "template_description": "마일스톤과 세부 일정을 계획하는 문서입니다. Gantt 차트, 스프린트 계획, 주요 마일스톤 일정을 포함합니다.",
+        "goal": "프로젝트 마일스톤과 세부 일정을 계획한다.",
+        "entry_criteria": "프로젝트 범위가 정의되어 있고 주요 산출물이 식별되어 있다.",
+        "fulfillment_aspects": [
+            "마일스톤 정의",
+            "세부 일정 작성",
+            "스프린트 계획 수립",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch5 - Schedule Planning",
     },
     {
         "stage_sequence": 2,
@@ -57,6 +111,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "리소스 계획 수립",
         "toast_message": "리소스 계획을 완성했습니다! 👨‍💻",
         "template_description": "팀 구성과 역할 분담을 계획하는 문서입니다. 팀원별 담당 역할, 필요 기술 스택, 협업 도구 계획을 포함합니다.",
+        "goal": "팀 구성과 역할 분담, 필요 기술 스택을 계획한다.",
+        "entry_criteria": "일정이 수립되어 있고 작업 단위가 식별되어 있다.",
+        "fulfillment_aspects": [
+            "팀원 역할 정의",
+            "필요 기술 스택 결정",
+            "협업 도구 선정",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch5 - Resource Planning",
     },
     {
         "stage_sequence": 2,
@@ -64,6 +127,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "리스크 분석",
         "toast_message": "리스크 분석을 완료했습니다! ⚠️",
         "template_description": "프로젝트 리스크를 식별하고 대응 계획을 수립하는 문서입니다. 리스크 목록, 발생 가능성·영향도 매트릭스, 완화 전략을 포함합니다.",
+        "goal": "프로젝트 리스크를 식별하고 대응 전략을 수립한다.",
+        "entry_criteria": "일정·리소스 계획이 수립되어 있고 잠재 리스크가 식별 가능한 상태다.",
+        "fulfillment_aspects": [
+            "리스크 목록 도출",
+            "발생 가능성·영향도 평가",
+            "완화 전략 수립",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch5 - Risk Management",
     },
     # ── Stage 3: 요구사항 정의 (Ch6) ──────────────────────────────────────
     {
@@ -72,6 +144,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "기능 요구사항 정의",
         "toast_message": "기능 요구사항 정의서를 완성했습니다! ✅",
         "template_description": "시스템이 수행해야 할 기능을 명세하는 문서입니다. 기능 목록, 우선순위, 입출력 조건을 포함합니다.",
+        "goal": "시스템이 수행해야 할 기능을 상세히 명세한다.",
+        "entry_criteria": "프로젝트 범위가 정의되어 있고 주요 기능 후보가 도출되어 있다.",
+        "fulfillment_aspects": [
+            "기능 목록 작성",
+            "우선순위 부여",
+            "입출력 조건 명시",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch6 - Functional Requirements",
     },
     {
         "stage_sequence": 3,
@@ -79,6 +160,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "비기능 요구사항 정의",
         "toast_message": "비기능 요구사항 정의서를 완성했습니다! 🔧",
         "template_description": "성능·보안·가용성 등 품질 요구사항을 정의하는 문서입니다. 응답시간 목표, 보안 정책, 확장성 요건을 포함합니다.",
+        "goal": "성능·보안·가용성 등 시스템 품질 요구사항을 정의한다.",
+        "entry_criteria": "기능 요구사항이 정리되어 있고 시스템 운영 환경 가정이 있다.",
+        "fulfillment_aspects": [
+            "성능 목표 명시",
+            "보안 정책 정의",
+            "가용성·확장성 요건 명시",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch6 - Non-Functional Requirements",
     },
     {
         "stage_sequence": 3,
@@ -86,6 +176,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "사용자 스토리 작성",
         "toast_message": "사용자 스토리를 완성했습니다! 📖",
         "template_description": "사용자 관점의 기능 시나리오를 정의하는 문서입니다. As-a / I-want / So-that 형식의 스토리 목록과 인수 기준을 포함합니다.",
+        "goal": "사용자 관점에서 기능 시나리오와 인수 기준을 명확히 한다.",
+        "entry_criteria": "기능 요구사항이 정의되어 있고 페르소나가 식별되어 있다.",
+        "fulfillment_aspects": [
+            "As-a / I-want / So-that 스토리 작성",
+            "인수 기준(Acceptance Criteria) 명시",
+            "우선순위 부여",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch6 - User Stories",
     },
     {
         "stage_sequence": 3,
@@ -93,6 +192,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "요구사항 확정",
         "toast_message": "요구사항 확정을 완료했습니다! 📌",
         "template_description": "이해관계자 검토 후 요구사항 기준선을 확정하는 문서입니다. 검토 의견 반영 내역, 최종 기능 목록, 승인 내역을 포함합니다.",
+        "goal": "이해관계자 검토를 거쳐 요구사항 기준선을 확정한다.",
+        "entry_criteria": "기능·비기능·사용자 스토리가 모두 정리되어 있다.",
+        "fulfillment_aspects": [
+            "이해관계자 검토 의견 반영",
+            "최종 기능 목록 확정",
+            "기준선 승인",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch6 - Requirements Baseline",
     },
     # ── Stage 4: 설계 (Ch7) ───────────────────────────────────────────────
     {
@@ -101,6 +209,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "시스템 아키텍처 설계",
         "toast_message": "시스템 아키텍처 설계를 완료했습니다! 🏗️",
         "template_description": "전체 시스템 구조와 컴포넌트를 설계하는 문서입니다. 아키텍처 다이어그램, 기술 스택 선택 근거, 배포 구성을 포함합니다.",
+        "goal": "시스템의 전체 구조와 컴포넌트, 기술 스택을 결정한다.",
+        "entry_criteria": "요구사항 기준선이 확정되어 있다.",
+        "fulfillment_aspects": [
+            "아키텍처 다이어그램 작성",
+            "기술 스택 선택 근거 명시",
+            "배포 구성 정의",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch7 - System Architecture",
     },
     {
         "stage_sequence": 4,
@@ -108,6 +225,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "데이터베이스 설계",
         "toast_message": "데이터베이스 설계를 완료했습니다! 🗄️",
         "template_description": "ERD와 데이터 모델을 설계하는 문서입니다. 엔티티 정의, 관계도, 인덱스 전략을 포함합니다.",
+        "goal": "ERD와 데이터 모델, 인덱스 전략을 설계한다.",
+        "entry_criteria": "시스템 아키텍처가 결정되어 있고 핵심 도메인이 식별되어 있다.",
+        "fulfillment_aspects": [
+            "엔티티 정의",
+            "관계 다이어그램(ERD) 작성",
+            "인덱스 전략 명시",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch7 - Data Design",
     },
     {
         "stage_sequence": 4,
@@ -115,6 +241,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "API 설계",
         "toast_message": "API 설계를 완료했습니다! 🔌",
         "template_description": "RESTful API 명세와 인터페이스를 정의하는 문서입니다. 엔드포인트 목록, 요청/응답 스키마, 인증 방식을 포함합니다.",
+        "goal": "외부 인터페이스인 RESTful API 명세를 정의한다.",
+        "entry_criteria": "데이터 모델과 시스템 아키텍처가 결정되어 있다.",
+        "fulfillment_aspects": [
+            "엔드포인트 목록 작성",
+            "요청/응답 스키마 정의",
+            "인증 방식 결정",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch7 - Interface Design",
     },
     {
         "stage_sequence": 4,
@@ -122,6 +257,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "UI/UX 설계",
         "toast_message": "UI/UX 설계를 완료했습니다! 🎨",
         "template_description": "화면 설계와 사용자 인터페이스 프로토타입을 작성하는 문서입니다. 화면 흐름도, 와이어프레임, 인터랙션 가이드를 포함합니다.",
+        "goal": "화면 흐름과 인터페이스 프로토타입을 설계한다.",
+        "entry_criteria": "사용자 스토리와 API 설계가 완료되어 있다.",
+        "fulfillment_aspects": [
+            "화면 흐름도 작성",
+            "와이어프레임 작성",
+            "인터랙션 가이드 명시",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch7 - UI/UX Design",
     },
     # ── Stage 5: 개발 (Ch8) ───────────────────────────────────────────────
     {
@@ -130,6 +274,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "개발 환경 구성",
         "toast_message": "개발 환경 구성을 완료했습니다! ⚙️",
         "template_description": "개발 환경 셋업과 CI/CD 파이프라인을 구성하는 문서입니다. 로컬 환경 설정, 브랜치 전략, 자동화 파이프라인 구성을 포함합니다.",
+        "goal": "개발에 필요한 로컬 환경과 CI/CD 파이프라인을 구축한다.",
+        "entry_criteria": "기술 스택과 배포 구성이 결정되어 있다.",
+        "fulfillment_aspects": [
+            "로컬 환경 셋업",
+            "브랜치 전략 정의",
+            "CI/CD 파이프라인 구성",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch8 - Development Environment",
     },
     {
         "stage_sequence": 5,
@@ -137,6 +290,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "핵심 기능 개발",
         "toast_message": "핵심 기능 개발을 완료했습니다! 🚀",
         "template_description": "주요 비즈니스 로직 구현 내역을 기록하는 문서입니다. 구현된 기능 목록, 주요 기술 결정 사항, 알려진 제약 사항을 포함합니다.",
+        "goal": "주요 비즈니스 로직과 핵심 기능을 구현한다.",
+        "entry_criteria": "개발 환경이 구축되어 있고 설계 문서가 존재한다.",
+        "fulfillment_aspects": [
+            "핵심 기능 구현 완료",
+            "주요 기술 결정 기록",
+            "알려진 제약 사항 명시",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch8 - Core Implementation",
     },
     {
         "stage_sequence": 5,
@@ -144,6 +306,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "API 구현 및 통합",
         "toast_message": "API 구현 및 통합을 완료했습니다! 🔗",
         "template_description": "Backend API와 Frontend 연동 구현 내역을 기록하는 문서입니다. API 구현 현황, 통합 테스트 결과, 미구현 항목을 포함합니다.",
+        "goal": "Backend API와 Frontend 연동을 구현하고 통합한다.",
+        "entry_criteria": "API 설계가 완료되어 있고 핵심 기능이 일부 구현되어 있다.",
+        "fulfillment_aspects": [
+            "API 구현 완료",
+            "Frontend 연동 완료",
+            "통합 테스트 결과 기록",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch8 - Integration",
     },
     {
         "stage_sequence": 5,
@@ -151,6 +322,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "코드 리뷰 및 리팩토링",
         "toast_message": "코드 리뷰 및 리팩토링을 완료했습니다! ✨",
         "template_description": "코드 품질 검토와 개선 내역을 기록하는 문서입니다. 리뷰 체크리스트, 발견된 이슈 및 개선 사항, 기술 부채 목록을 포함합니다.",
+        "goal": "코드 품질을 검토하고 개선한다.",
+        "entry_criteria": "핵심 기능과 통합이 완료되어 있다.",
+        "fulfillment_aspects": [
+            "리뷰 체크리스트 작성",
+            "발견된 이슈 개선",
+            "기술 부채 목록 정리",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch8 - Code Review",
     },
     # ── Stage 6: 테스트 및 검증 (Ch9) ────────────────────────────────────
     {
@@ -159,6 +339,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "단위 테스트 작성",
         "toast_message": "단위 테스트 작성을 완료했습니다! 🧪",
         "template_description": "각 컴포넌트별 단위 테스트 구현 내역을 기록하는 문서입니다. 테스트 커버리지 목표, 주요 테스트 케이스, 커버리지 측정 결과를 포함합니다.",
+        "goal": "각 컴포넌트별 단위 테스트를 작성하고 커버리지를 확보한다.",
+        "entry_criteria": "핵심 기능이 구현되어 있다.",
+        "fulfillment_aspects": [
+            "커버리지 목표 명시",
+            "주요 테스트 케이스 작성",
+            "커버리지 측정 결과 기록",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch9 - Unit Testing",
     },
     {
         "stage_sequence": 6,
@@ -166,6 +355,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "통합 테스트 수행",
         "toast_message": "통합 테스트를 완료했습니다! 🔄",
         "template_description": "시스템 통합 테스트와 결함 수정 내역을 기록하는 문서입니다. 통합 테스트 시나리오, 발견된 결함 목록 및 수정 내역을 포함합니다.",
+        "goal": "시스템 전반의 통합 테스트를 수행하고 결함을 수정한다.",
+        "entry_criteria": "단위 테스트가 통과하고 주요 컴포넌트가 통합되어 있다.",
+        "fulfillment_aspects": [
+            "통합 테스트 시나리오 작성",
+            "결함 목록 정리",
+            "수정 내역 기록",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch9 - Integration Testing",
     },
     {
         "stage_sequence": 6,
@@ -173,6 +371,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "사용자 인수 테스트",
         "toast_message": "사용자 인수 테스트를 완료했습니다! 👤",
         "template_description": "실제 사용자 관점에서 시스템을 검증하는 문서입니다. UAT 시나리오, 사용자 피드백, 최종 수정 내역을 포함합니다.",
+        "goal": "실제 사용자 관점에서 UAT를 수행하고 피드백을 반영한다.",
+        "entry_criteria": "통합 테스트가 통과하고 시스템이 안정 동작한다.",
+        "fulfillment_aspects": [
+            "UAT 시나리오 작성",
+            "사용자 피드백 수집",
+            "최종 수정 내역 기록",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch9 - User Acceptance Testing",
     },
     {
         "stage_sequence": 6,
@@ -180,6 +387,15 @@ REQUIRED_STEP_DATA: list[dict] = [
         "name": "배포 및 운영 준비",
         "toast_message": "배포 및 운영 준비를 완료했습니다! 🎉",
         "template_description": "운영 환경 배포와 모니터링 체계를 구축하는 문서입니다. 배포 절차서, 운영 모니터링 구성, 장애 대응 매뉴얼을 포함합니다.",
+        "goal": "운영 환경에 배포하고 모니터링·장애 대응 체계를 구축한다.",
+        "entry_criteria": "UAT가 완료되어 있고 배포 가능한 상태다.",
+        "fulfillment_aspects": [
+            "배포 절차서 작성",
+            "운영 모니터링 구성",
+            "장애 대응 매뉴얼 작성",
+        ],
+        "fulfillment_threshold": 2,
+        "doj_reference": "DOJ SDLC Ch9 - Deployment & Operations",
     },
 ]
 
@@ -202,6 +418,11 @@ def run(db: Session) -> None:
                 "sequence": item["sequence"],
                 "toast_message": item["toast_message"],
                 "template_description": item["template_description"],
+                "goal": item["goal"],
+                "entry_criteria": item["entry_criteria"],
+                "fulfillment_aspects": item["fulfillment_aspects"],
+                "fulfillment_threshold": item["fulfillment_threshold"],
+                "doj_reference": item["doj_reference"],
             }
         )
 
@@ -216,6 +437,15 @@ def run(db: Session) -> None:
                 "template_description": insert(
                     RequiredStep
                 ).excluded.template_description,
+                "goal": insert(RequiredStep).excluded.goal,
+                "entry_criteria": insert(RequiredStep).excluded.entry_criteria,
+                "fulfillment_aspects": insert(
+                    RequiredStep
+                ).excluded.fulfillment_aspects,
+                "fulfillment_threshold": insert(
+                    RequiredStep
+                ).excluded.fulfillment_threshold,
+                "doj_reference": insert(RequiredStep).excluded.doj_reference,
             },
         )
     )


### PR DESCRIPTION
## PR 요약
- design.md와 코드 비교 점검 후 발견된 NameError / 스키마 불일치 / 시드 데이터 누락 항목 일괄 수정

## 변경 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

### 🐛 버그 수정 (호출 시 NameError로 즉시 터지던 부분)
- `business/services/step_service.py`: `Step`, `RequiredStep` 미정의 (별칭만 import) → `StepModel`, `RequiredStepModel` 적용
- `business/services/stage_service.py`: `Stage` 미정의 → `StageModel` 적용

### 📦 스키마 / 응답 정합성
- `ProjectListItemResponse`의 `member_count`, `duration_month`, `prompt`, `constraint`, `description`을 Optional 처리 (DB nullable 컬럼인데 직렬화 시 ValidationError 발생 가능했던 부분)
- `stage_service`가 dict 대신 `StageListResponse` Pydantic 객체를 반환하도록 변경 → 라우터에서 `.model_dump()` 호출하도록 일관성 통일

### 🌱 시드 데이터 보강
- `required_step` 24개 항목 모두에 `goal`, `entry_criteria`, `fulfillment_aspects`, `fulfillment_threshold`, `doj_reference` 채움 (AI 충족 판단 근거 컬럼)

### 🧹 코드 정리
- `business/services/step_service.py` import 상단으로 모음
- `get_required_steps` 함수 위치 정돈

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [x] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- 이번 PR과 짝지어 design.md도 함께 정리됨 (`current_stage_number` → `current_stage_sequence`, `Ready` → `READY`, `StageListItem.is_active` 추가, Step Tree 라우트 `project_id` + `stage_id` 통일)
- DB 마이그레이션은 모델 변경이 없으므로 불필요 (시드 재실행만 필요)