### PR TITLE
[#34][AI] LLM Client 구현

### DIFF
--- a/ai/clients/llm.py
+++ b/ai/clients/llm.py
@@ -1,0 +1,182 @@
+"""Bedrock Claude LLM 클라이언트.
+
+boto3 bedrock-runtime 클라이언트를 의존성 주입받아, 프롬프트를 호출하고
+응답을 Pydantic 스키마로 검증한다. 스키마/JSON 실패는 재시도, Bedrock API
+에러는 즉시 raise한다.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from json import JSONDecodeError
+from typing import Any, TypeVar
+
+from botocore.exceptions import BotoCoreError, ClientError
+from pydantic import BaseModel, ValidationError
+
+from ai.exceptions import AIGenerationFailedError, BedrockAPIError
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+_ANTHROPIC_VERSION = "bedrock-2023-05-31"
+
+
+def _log(level: int, event: str, **fields: Any) -> None:
+    """JSON 직렬화된 단일 라인을 표준 logging으로 emit."""
+    payload = {"event": event, **fields}
+    logger.log(level, json.dumps(payload, ensure_ascii=False, default=str))
+
+
+class LLMClient:
+    """Bedrock Claude 호출 + Pydantic 스키마 검증 래퍼."""
+
+    def __init__(
+        self,
+        bedrock_client: Any,
+        model_id: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+    ) -> None:
+        self.bedrock_client = bedrock_client
+        self.model_id = model_id
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+
+    async def invoke(
+        self,
+        prompt: str,
+        expected_schema: type[T],
+        max_retries: int = 2,
+    ) -> T:
+        """Claude를 호출하여 expected_schema로 검증된 인스턴스를 반환.
+
+        - JSON 파싱 실패 / 스키마 불일치 → max_retries 까지 재시도
+        - Bedrock API 에러(ClientError, BotoCoreError) → 즉시 BedrockAPIError
+        - 재시도 초과 → AIGenerationFailedError (불일치 필드 details 포함)
+        """
+        correlation_id = str(uuid.uuid4())
+        request_body = json.dumps(
+            {
+                "anthropic_version": _ANTHROPIC_VERSION,
+                "max_tokens": self.max_tokens,
+                "temperature": self.temperature,
+                "messages": [{"role": "user", "content": prompt}],
+            }
+        )
+
+        _log(
+            logging.INFO,
+            "llm_invoke_start",
+            correlation_id=correlation_id,
+            model_id=self.model_id,
+            max_retries=max_retries,
+            prompt_len=len(prompt),
+            schema=expected_schema.__name__,
+        )
+
+        last_error: dict[str, Any] | None = None
+
+        for attempt in range(max_retries + 1):
+            try:
+                response = self.bedrock_client.invoke_model(
+                    modelId=self.model_id,
+                    body=request_body,
+                    contentType="application/json",
+                    accept="application/json",
+                )
+            except (ClientError, BotoCoreError) as exc:
+                error_details = {
+                    "correlation_id": correlation_id,
+                    "model_id": self.model_id,
+                    "attempt": attempt,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                }
+                _log(logging.ERROR, "llm_bedrock_api_error", **error_details)
+                raise BedrockAPIError(
+                    message="Bedrock API 호출에 실패했습니다.",
+                    details=error_details,
+                ) from exc
+
+            try:
+                raw = response["body"].read()
+                envelope = json.loads(raw)
+                text = envelope["content"][0]["text"]
+                payload = json.loads(text)
+                validated = expected_schema.model_validate(payload)
+            except JSONDecodeError as exc:
+                last_error = {
+                    "type": "json_decode_error",
+                    "message": str(exc),
+                    "attempt": attempt,
+                }
+                _log(
+                    logging.WARNING,
+                    "llm_invoke_retry",
+                    correlation_id=correlation_id,
+                    model_id=self.model_id,
+                    attempt=attempt,
+                    reason="json_decode_error",
+                    error=str(exc),
+                )
+                continue
+            except ValidationError as exc:
+                last_error = {
+                    "type": "schema_validation_error",
+                    "schema": expected_schema.__name__,
+                    "errors": exc.errors(),
+                    "attempt": attempt,
+                }
+                _log(
+                    logging.WARNING,
+                    "llm_invoke_retry",
+                    correlation_id=correlation_id,
+                    model_id=self.model_id,
+                    attempt=attempt,
+                    reason="schema_validation_error",
+                    schema=expected_schema.__name__,
+                    errors=exc.errors(),
+                )
+                continue
+            except (KeyError, IndexError, TypeError) as exc:
+                last_error = {
+                    "type": "malformed_response",
+                    "message": str(exc),
+                    "attempt": attempt,
+                }
+                _log(
+                    logging.WARNING,
+                    "llm_invoke_retry",
+                    correlation_id=correlation_id,
+                    model_id=self.model_id,
+                    attempt=attempt,
+                    reason="malformed_response",
+                    error=str(exc),
+                )
+                continue
+
+            _log(
+                logging.INFO,
+                "llm_invoke_success",
+                correlation_id=correlation_id,
+                model_id=self.model_id,
+                attempt=attempt,
+                schema=expected_schema.__name__,
+            )
+            return validated
+
+        details = {
+            "correlation_id": correlation_id,
+            "model_id": self.model_id,
+            "max_retries": max_retries,
+            "last_error": last_error,
+        }
+        _log(logging.ERROR, "llm_invoke_failed", **details)
+        raise AIGenerationFailedError(
+            message="AI 생성에 실패했습니다 (재시도 초과).",
+            details=details,
+        )

--- a/ai/tests/test_config.py
+++ b/ai/tests/test_config.py
@@ -1,7 +1,5 @@
 """ai/config.py 단위 테스트."""
 
-import os
-
 import pytest
 
 from ai.config import AISettings
@@ -12,31 +10,28 @@ class TestAISettings:
 
     def test_default_values(self):
         settings = AISettings(_env_file=None)
-        assert settings.AWS_REGION == "ap-northeast-2"
-        assert settings.MODEL_ID == "anthropic.claude-3-5-sonnet-20241022-v2:0"
-        assert settings.KB_A_ID == ""
-        assert settings.KB_B_ID == ""
+        assert settings.AWS_REGION == "us-east-1"
+        assert settings.MODEL_ID == "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        assert settings.KB_ID == "ZAEWSDQVP1"
         assert settings.MAX_TOKENS == 4096
         assert settings.TEMPERATURE == 0.7
 
     def test_env_override(self, monkeypatch):
-        monkeypatch.setenv("AWS_REGION", "us-east-1")
-        monkeypatch.setenv("MODEL_ID", "anthropic.claude-3-haiku-20240307-v1:0")
-        monkeypatch.setenv("KB_A_ID", "kb-a-123")
-        monkeypatch.setenv("KB_B_ID", "kb-b-456")
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        monkeypatch.setenv("MODEL_ID", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+        monkeypatch.setenv("KB_ID", "kb-test-123")
         monkeypatch.setenv("MAX_TOKENS", "2048")
         monkeypatch.setenv("TEMPERATURE", "0.3")
 
         settings = AISettings(_env_file=None)
-        assert settings.AWS_REGION == "us-east-1"
-        assert settings.MODEL_ID == "anthropic.claude-3-haiku-20240307-v1:0"
-        assert settings.KB_A_ID == "kb-a-123"
-        assert settings.KB_B_ID == "kb-b-456"
+        assert settings.AWS_REGION == "us-west-2"
+        assert settings.MODEL_ID == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        assert settings.KB_ID == "kb-test-123"
         assert settings.MAX_TOKENS == 2048
         assert settings.TEMPERATURE == pytest.approx(0.3)
 
     def test_partial_env_override(self, monkeypatch):
-        monkeypatch.setenv("KB_A_ID", "kb-only-a")
+        monkeypatch.setenv("KB_ID", "kb-override")
         settings = AISettings(_env_file=None)
-        assert settings.KB_A_ID == "kb-only-a"
-        assert settings.KB_B_ID == ""  # default preserved
+        assert settings.KB_ID == "kb-override"
+        assert settings.AWS_REGION == "us-east-1"  # default preserved

--- a/ai/tests/test_llm_client.py
+++ b/ai/tests/test_llm_client.py
@@ -1,0 +1,282 @@
+"""ai/clients/llm.py 단위 테스트."""
+
+import io
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+from pydantic import BaseModel
+
+from ai.clients.llm import LLMClient
+from ai.exceptions import AIErrorCode, AIGenerationFailedError, BedrockAPIError
+
+MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+
+class _Schema(BaseModel):
+    """테스트용 단순 스키마."""
+
+    answer: str
+    score: int
+
+
+def _make_response(text_payload: str) -> dict:
+    """Bedrock invoke_model 응답 형태를 모방한 dict."""
+    envelope = {"content": [{"type": "text", "text": text_payload}]}
+    return {"body": io.BytesIO(json.dumps(envelope).encode("utf-8"))}
+
+
+def _valid_response() -> dict:
+    return _make_response(json.dumps({"answer": "ok", "score": 42}))
+
+
+def _malformed_json_response() -> dict:
+    return _make_response("{not valid json")
+
+
+def _schema_violation_response() -> dict:
+    # answer가 누락 → ValidationError 발생
+    return _make_response(json.dumps({"score": 1}))
+
+
+@pytest.fixture
+def bedrock_mock() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def client(bedrock_mock: MagicMock) -> LLMClient:
+    return LLMClient(
+        bedrock_client=bedrock_mock,
+        model_id=MODEL_ID,
+        max_tokens=128,
+        temperature=0.5,
+    )
+
+
+class TestInvokeSuccess:
+    @pytest.mark.asyncio
+    async def test_invoke_returns_validated_instance(
+        self, client: LLMClient, bedrock_mock: MagicMock
+    ):
+        bedrock_mock.invoke_model.return_value = _valid_response()
+
+        result = await client.invoke("hello", _Schema)
+
+        assert isinstance(result, _Schema)
+        assert result.answer == "ok"
+        assert result.score == 42
+
+    @pytest.mark.asyncio
+    async def test_invoke_passes_correct_request_body(
+        self, client: LLMClient, bedrock_mock: MagicMock
+    ):
+        bedrock_mock.invoke_model.return_value = _valid_response()
+
+        await client.invoke("질문 내용", _Schema)
+
+        call_kwargs = bedrock_mock.invoke_model.call_args.kwargs
+        assert call_kwargs["modelId"] == MODEL_ID
+        assert call_kwargs["contentType"] == "application/json"
+
+        body = json.loads(call_kwargs["body"])
+        assert body["anthropic_version"] == "bedrock-2023-05-31"
+        assert body["max_tokens"] == 128
+        assert body["temperature"] == 0.5
+        assert body["messages"] == [{"role": "user", "content": "질문 내용"}]
+
+
+class TestInvokeRetryOnRetryableErrors:
+    @pytest.mark.asyncio
+    async def test_json_decode_error_then_success(
+        self, client: LLMClient, bedrock_mock: MagicMock
+    ):
+        bedrock_mock.invoke_model.side_effect = [
+            _malformed_json_response(),
+            _valid_response(),
+        ]
+
+        result = await client.invoke("p", _Schema, max_retries=2)
+
+        assert result.answer == "ok"
+        assert bedrock_mock.invoke_model.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_validation_error_then_success(
+        self, client: LLMClient, bedrock_mock: MagicMock
+    ):
+        bedrock_mock.invoke_model.side_effect = [
+            _schema_violation_response(),
+            _valid_response(),
+        ]
+
+        result = await client.invoke("p", _Schema, max_retries=2)
+
+        assert result.answer == "ok"
+        assert bedrock_mock.invoke_model.call_count == 2
+
+
+class TestInvokeRetryExhaustion:
+    @pytest.mark.asyncio
+    async def test_schema_mismatch_three_attempts_then_fails(
+        self, client: LLMClient, bedrock_mock: MagicMock
+    ):
+        bedrock_mock.invoke_model.side_effect = [
+            _schema_violation_response(),
+            _schema_violation_response(),
+            _schema_violation_response(),
+        ]
+
+        with pytest.raises(AIGenerationFailedError) as exc_info:
+            await client.invoke("p", _Schema, max_retries=2)
+
+        # max_retries=2 → 1 + 2 = 3회 호출
+        assert bedrock_mock.invoke_model.call_count == 3
+        err = exc_info.value
+        assert err.code == AIErrorCode.AI_GENERATION_FAILED
+        assert err.details["max_retries"] == 2
+        assert err.details["last_error"]["type"] == "schema_validation_error"
+        # 불일치 필드 상세 — 'answer' 누락이 errors에 포함되어야 함
+        errors = err.details["last_error"]["errors"]
+        assert any("answer" in str(e.get("loc", "")) for e in errors)
+
+    @pytest.mark.asyncio
+    async def test_json_decode_error_exhausts_retries(
+        self, client: LLMClient, bedrock_mock: MagicMock
+    ):
+        bedrock_mock.invoke_model.side_effect = [
+            _malformed_json_response(),
+            _malformed_json_response(),
+            _malformed_json_response(),
+        ]
+
+        with pytest.raises(AIGenerationFailedError) as exc_info:
+            await client.invoke("p", _Schema, max_retries=2)
+
+        assert bedrock_mock.invoke_model.call_count == 3
+        assert exc_info.value.details["last_error"]["type"] == "json_decode_error"
+
+
+class TestBedrockApiErrorImmediate:
+    @pytest.mark.asyncio
+    async def test_client_error_raises_immediately_without_retry(
+        self, client: LLMClient, bedrock_mock: MagicMock
+    ):
+        client_error = ClientError(
+            error_response={
+                "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}
+            },
+            operation_name="InvokeModel",
+        )
+        bedrock_mock.invoke_model.side_effect = client_error
+
+        with pytest.raises(BedrockAPIError) as exc_info:
+            await client.invoke("p", _Schema, max_retries=2)
+
+        # 재시도 없음 — 정확히 1회만 호출
+        assert bedrock_mock.invoke_model.call_count == 1
+        err = exc_info.value
+        assert err.code == AIErrorCode.BEDROCK_API_ERROR
+        assert err.details["error_type"] == "ClientError"
+        assert "correlation_id" in err.details
+
+
+class TestCorrelationIdLogging:
+    @pytest.mark.asyncio
+    async def test_correlation_id_present_in_start_and_success_logs(
+        self,
+        client: LLMClient,
+        bedrock_mock: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        bedrock_mock.invoke_model.return_value = _valid_response()
+
+        with caplog.at_level(logging.INFO, logger="ai.clients.llm"):
+            await client.invoke("p", _Schema)
+
+        assert len(caplog.records) >= 2
+        events = []
+        correlation_ids = set()
+        for rec in caplog.records:
+            data = json.loads(rec.message)
+            events.append(data["event"])
+            if "correlation_id" in data:
+                correlation_ids.add(data["correlation_id"])
+
+        assert "llm_invoke_start" in events
+        assert "llm_invoke_success" in events
+        # 호출당 정확히 1개의 correlation_id가 모든 로그에 공유되어야 함
+        assert len(correlation_ids) == 1
+
+    @pytest.mark.asyncio
+    async def test_correlation_id_in_error_logs(
+        self,
+        client: LLMClient,
+        bedrock_mock: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        bedrock_mock.invoke_model.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDenied", "Message": "no"}},
+            operation_name="InvokeModel",
+        )
+
+        with caplog.at_level(logging.INFO, logger="ai.clients.llm"):
+            with pytest.raises(BedrockAPIError):
+                await client.invoke("p", _Schema)
+
+        error_records = [
+            json.loads(r.message)
+            for r in caplog.records
+            if r.levelno >= logging.ERROR
+        ]
+        assert any(
+            r.get("event") == "llm_bedrock_api_error" and "correlation_id" in r
+            for r in error_records
+        )
+
+    @pytest.mark.asyncio
+    async def test_correlation_id_unique_per_invocation(
+        self, client: LLMClient, bedrock_mock: MagicMock, caplog: pytest.LogCaptureFixture
+    ):
+        bedrock_mock.invoke_model.side_effect = lambda **_: _valid_response()
+
+        with caplog.at_level(logging.INFO, logger="ai.clients.llm"):
+            await client.invoke("p1", _Schema)
+            await client.invoke("p2", _Schema)
+
+        ids = set()
+        for rec in caplog.records:
+            data = json.loads(rec.message)
+            if data.get("event") == "llm_invoke_start":
+                ids.add(data["correlation_id"])
+
+        assert len(ids) == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_logs_include_attempt_and_correlation_id(
+        self,
+        client: LLMClient,
+        bedrock_mock: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        bedrock_mock.invoke_model.side_effect = [
+            _schema_violation_response(),
+            _valid_response(),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="ai.clients.llm"):
+            await client.invoke("p", _Schema, max_retries=2)
+
+        retry_records = [
+            json.loads(r.message)
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        ]
+        assert len(retry_records) == 1
+        retry = retry_records[0]
+        assert retry["event"] == "llm_invoke_retry"
+        assert retry["reason"] == "schema_validation_error"
+        assert retry["attempt"] == 0
+        assert "correlation_id" in retry


### PR DESCRIPTION
## PR 요약
- Bedrock Claude 호출을 감싸는 LLM Client 구현 + 단위 테스트

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `ai/clients/llm.py`: LLMClient 클래스 구현 — invoke_model 호출, JSON 파싱, Pydantic 스키마 검증, 재시도 로직 (max_retries=2), 구조화된 JSON 로깅 (correlation_id 포함)
- `ai/tests/test_llm_client.py`: mock 기반 단위 테스트 11개 (정상 호출, JSON 파싱 실패 재시도, 스키마 불일치 재시도, Bedrock API 에러, correlation_id 로깅 검증)
- `ai/tests/test_config.py`: KB_A_ID/KB_B_ID → KB_ID 변경에 맞춰 테스트 수정

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- LLM Client는 Step Generator, Required Step Judge, Side Panel Generator가 공통으로 사용하는 핵심 인프라 모듈
- boto3 sync API를 async 시그니처로 감싸는 구조 (Lambda에서 asyncio.run으로 호출 예정)
- 실제 Bedrock 호출 테스트는 CloudShell에서 별도 진행 예정