### PR TITLE
[#36][AI] RAG Client 구현

### DIFF
--- a/ai/clients/rag.py
+++ b/ai/clients/rag.py
@@ -1,0 +1,129 @@
+"""Bedrock Knowledge Base RAG 클라이언트.
+
+boto3 bedrock-agent-runtime 클라이언트를 의존성 주입받아 KB를 검색하고
+RetrievedChunk 리스트를 반환한다. 검색 실패는 비치명적으로 처리한다.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from ai.schemas.common import RetrievedChunk
+
+logger = logging.getLogger(__name__)
+
+
+def _log(level: int, event: str, **fields: Any) -> None:
+    payload = {"event": event, **fields}
+    logger.log(level, json.dumps(payload, ensure_ascii=False, default=str))
+
+
+def _parse_chunks(retrieval_results: list[dict]) -> list[RetrievedChunk]:
+    chunks: list[RetrievedChunk] = []
+    for item in retrieval_results:
+        try:
+            text = item["content"]["text"]
+            score = item.get("score", 0.0)
+            chunks.append(RetrievedChunk(text=text, relevance_score=score))
+        except (KeyError, TypeError):
+            continue
+    return chunks
+
+
+class RAGClient:
+    """Bedrock Knowledge Base 검색 래퍼."""
+
+    def __init__(self, bedrock_agent_client: Any, kb_id: str) -> None:
+        self.bedrock_agent_client = bedrock_agent_client
+        self.kb_id = kb_id
+
+    async def search_doj(self, query: str, num_results: int = 5) -> list[RetrievedChunk]:
+        """DOJ 문서 KB를 검색하여 RetrievedChunk 리스트를 반환.
+
+        검색 실패 시 빈 리스트를 반환한다 (비치명적).
+        """
+        correlation_id = str(uuid.uuid4())
+        _log(
+            logging.INFO,
+            "rag_search_doj_start",
+            correlation_id=correlation_id,
+            kb_id=self.kb_id,
+            query_len=len(query),
+            num_results=num_results,
+        )
+        try:
+            response = self.bedrock_agent_client.retrieve(
+                knowledgeBaseId=self.kb_id,
+                retrievalQuery={"text": query},
+                retrievalConfiguration={
+                    "vectorSearchConfiguration": {"numberOfResults": num_results}
+                },
+            )
+            chunks = _parse_chunks(response.get("retrievalResults", []))
+            _log(
+                logging.INFO,
+                "rag_search_doj_success",
+                correlation_id=correlation_id,
+                kb_id=self.kb_id,
+                num_chunks=len(chunks),
+            )
+            return chunks
+        except Exception as exc:
+            _log(
+                logging.WARNING,
+                "rag_search_doj_failed",
+                correlation_id=correlation_id,
+                kb_id=self.kb_id,
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+            return []
+
+    async def search_custom(self, query: str, num_results: int = 3) -> list[RetrievedChunk]:
+        """커스텀 문서 KB를 검색하여 RetrievedChunk 리스트를 반환.
+
+        검색 실패 시 빈 리스트를 반환한다 (비치명적).
+
+        TODO: Data Source 필터링 추가 예정
+              retrievalConfiguration에 filter 조건을 추가하여
+              DOJ Data Source와 Custom Data Source를 분리한다.
+        """
+        correlation_id = str(uuid.uuid4())
+        _log(
+            logging.INFO,
+            "rag_search_custom_start",
+            correlation_id=correlation_id,
+            kb_id=self.kb_id,
+            query_len=len(query),
+            num_results=num_results,
+        )
+        try:
+            response = self.bedrock_agent_client.retrieve(
+                knowledgeBaseId=self.kb_id,
+                retrievalQuery={"text": query},
+                retrievalConfiguration={
+                    "vectorSearchConfiguration": {"numberOfResults": num_results}
+                },
+            )
+            chunks = _parse_chunks(response.get("retrievalResults", []))
+            _log(
+                logging.INFO,
+                "rag_search_custom_success",
+                correlation_id=correlation_id,
+                kb_id=self.kb_id,
+                num_chunks=len(chunks),
+            )
+            return chunks
+        except Exception as exc:
+            _log(
+                logging.WARNING,
+                "rag_search_custom_failed",
+                correlation_id=correlation_id,
+                kb_id=self.kb_id,
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+            return []

--- a/ai/tests/test_rag_client.py
+++ b/ai/tests/test_rag_client.py
@@ -1,0 +1,223 @@
+"""ai/clients/rag.py 단위 테스트."""
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from ai.clients.rag import RAGClient
+from ai.schemas.common import RetrievedChunk
+
+KB_ID = "ZAEWSDQVP1"
+
+
+def _retrieve_response(items: list[dict]) -> dict:
+    return {"retrievalResults": items}
+
+
+def _chunk_item(text: str, score: float) -> dict:
+    return {"content": {"text": text}, "score": score}
+
+
+@pytest.fixture
+def agent_mock() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def client(agent_mock: MagicMock) -> RAGClient:
+    return RAGClient(bedrock_agent_client=agent_mock, kb_id=KB_ID)
+
+
+# ---------------------------------------------------------------------------
+# search_doj
+# ---------------------------------------------------------------------------
+
+
+class TestSearchDoj:
+    @pytest.mark.asyncio
+    async def test_returns_retrieved_chunks(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.return_value = _retrieve_response(
+            [_chunk_item("DOJ 문서 A", 0.92), _chunk_item("DOJ 문서 B", 0.85)]
+        )
+
+        result = await client.search_doj("소프트웨어 개발")
+
+        assert len(result) == 2
+        assert all(isinstance(c, RetrievedChunk) for c in result)
+        assert result[0].text == "DOJ 문서 A"
+        assert result[0].relevance_score == pytest.approx(0.92)
+        assert result[1].text == "DOJ 문서 B"
+        assert result[1].relevance_score == pytest.approx(0.85)
+
+    @pytest.mark.asyncio
+    async def test_passes_correct_params(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.return_value = _retrieve_response([])
+
+        await client.search_doj("쿼리 내용", num_results=7)
+
+        agent_mock.retrieve.assert_called_once_with(
+            knowledgeBaseId=KB_ID,
+            retrievalQuery={"text": "쿼리 내용"},
+            retrievalConfiguration={"vectorSearchConfiguration": {"numberOfResults": 7}},
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_results_returns_empty_list(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.return_value = _retrieve_response([])
+
+        result = await client.search_doj("쿼리")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_empty_list(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDeniedException", "Message": "no"}},
+            operation_name="Retrieve",
+        )
+
+        result = await client.search_doj("쿼리")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_api_error_logs_warning(
+        self, client: RAGClient, agent_mock: MagicMock, caplog: pytest.LogCaptureFixture
+    ):
+        agent_mock.retrieve.side_effect = RuntimeError("timeout")
+
+        with caplog.at_level(logging.WARNING, logger="ai.clients.rag"):
+            await client.search_doj("쿼리")
+
+        warning_records = [
+            json.loads(r.message) for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert any(r.get("event") == "rag_search_doj_failed" for r in warning_records)
+        assert any("correlation_id" in r for r in warning_records)
+
+    @pytest.mark.asyncio
+    async def test_api_error_does_not_raise(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.side_effect = Exception("unexpected")
+
+        # 예외가 전파되지 않아야 한다
+        result = await client.search_doj("쿼리")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_item_is_skipped(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.return_value = _retrieve_response(
+            [
+                {"content": {"text": "정상 항목"}, "score": 0.8},
+                {"broken": True},  # content 키 없음 → 스킵
+                {"content": {"text": "두번째 정상"}, "score": 0.6},
+            ]
+        )
+
+        result = await client.search_doj("쿼리")
+
+        assert len(result) == 2
+        assert result[0].text == "정상 항목"
+        assert result[1].text == "두번째 정상"
+
+    @pytest.mark.asyncio
+    async def test_success_log_contains_correlation_id(
+        self, client: RAGClient, agent_mock: MagicMock, caplog: pytest.LogCaptureFixture
+    ):
+        agent_mock.retrieve.return_value = _retrieve_response([])
+
+        with caplog.at_level(logging.INFO, logger="ai.clients.rag"):
+            await client.search_doj("쿼리")
+
+        records = [json.loads(r.message) for r in caplog.records]
+        start = next(r for r in records if r["event"] == "rag_search_doj_start")
+        success = next(r for r in records if r["event"] == "rag_search_doj_success")
+        assert start["correlation_id"] == success["correlation_id"]
+
+
+# ---------------------------------------------------------------------------
+# search_custom
+# ---------------------------------------------------------------------------
+
+
+class TestSearchCustom:
+    @pytest.mark.asyncio
+    async def test_returns_retrieved_chunks(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.return_value = _retrieve_response(
+            [_chunk_item("커스텀 문서 A", 0.78)]
+        )
+
+        result = await client.search_custom("요구사항")
+
+        assert len(result) == 1
+        assert result[0].text == "커스텀 문서 A"
+        assert result[0].relevance_score == pytest.approx(0.78)
+
+    @pytest.mark.asyncio
+    async def test_passes_correct_params(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.return_value = _retrieve_response([])
+
+        await client.search_custom("쿼리", num_results=3)
+
+        agent_mock.retrieve.assert_called_once_with(
+            knowledgeBaseId=KB_ID,
+            retrievalQuery={"text": "쿼리"},
+            retrievalConfiguration={"vectorSearchConfiguration": {"numberOfResults": 3}},
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_results_returns_empty_list(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.return_value = _retrieve_response([])
+
+        result = await client.search_custom("쿼리")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_empty_list(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.side_effect = ClientError(
+            error_response={"Error": {"Code": "ThrottlingException", "Message": "rate"}},
+            operation_name="Retrieve",
+        )
+
+        result = await client.search_custom("쿼리")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_api_error_logs_warning(
+        self, client: RAGClient, agent_mock: MagicMock, caplog: pytest.LogCaptureFixture
+    ):
+        agent_mock.retrieve.side_effect = RuntimeError("connection error")
+
+        with caplog.at_level(logging.WARNING, logger="ai.clients.rag"):
+            await client.search_custom("쿼리")
+
+        warning_records = [
+            json.loads(r.message) for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert any(r.get("event") == "rag_search_custom_failed" for r in warning_records)
+        assert any("correlation_id" in r for r in warning_records)
+
+    @pytest.mark.asyncio
+    async def test_api_error_does_not_raise(self, client: RAGClient, agent_mock: MagicMock):
+        agent_mock.retrieve.side_effect = Exception("unexpected")
+
+        result = await client.search_custom("쿼리")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_success_log_contains_correlation_id(
+        self, client: RAGClient, agent_mock: MagicMock, caplog: pytest.LogCaptureFixture
+    ):
+        agent_mock.retrieve.return_value = _retrieve_response([])
+
+        with caplog.at_level(logging.INFO, logger="ai.clients.rag"):
+            await client.search_custom("쿼리")
+
+        records = [json.loads(r.message) for r in caplog.records]
+        start = next(r for r in records if r["event"] == "rag_search_custom_start")
+        success = next(r for r in records if r["event"] == "rag_search_custom_success")
+        assert start["correlation_id"] == success["correlation_id"]


### PR DESCRIPTION
## PR 요약
- Bedrock KB 검색을 감싸는 RAG Client 구현 + 단위 테스트

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `ai/clients/rag.py`: RAGClient 클래스 구현 — search_doj (DOJ Data Source 검색), search_custom (자체 문서 검색, TODO: Data Source 필터링 추가 예정), 검색 실패 시 빈 리스트 반환 (비치명적), JSON 포맷 로깅
- `ai/tests/test_rag_client.py`: mock 기반 단위 테스트 15개 (정상 검색, 빈 결과, API 에러 → 빈 리스트, malformed 항목 스킵, correlation_id 로깅 검증)

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- KB 1개 + Data Source 분리 구조 (KB ID: ~~)
- search_custom은 현재 search_doj와 동일 동작, 추후 Data Source 필터링 추가 예정
- 실제 Bedrock KB 검색 테스트는 추후 CloudShell로 진행 예정