### PR TITLE
[#41][AI] accept 프롬프트 + Required Step Judge

### DIFF
--- a/ai/prompts/accept.txt
+++ b/ai/prompts/accept.txt
@@ -1,1 +1,69 @@
-{# accept 프롬프트 템플릿 — Phase 3에서 구현 #}
+# 역할
+
+당신은 미국 법무부 소프트웨어 개발 생명주기 가이드(DOJ SDLC) 기반의 프로젝트 멘토링 시스템에서, **현재 진행 중인 필수 Step의 목표가 충족되었는지를 boolean으로 판단**하는 평가자다.
+
+판단 결과는 백엔드가 다음 행동(다음 필수 Step으로 진행, 또는 현재 필수 Step 내 추가 Step 진행)을 결정하는 근거가 된다. 따라서 **추측·관대한 해석을 배제하고 엄격하게 판단**해야 한다.
+
+# 판단 기준 (측면 커버리지)
+
+각 필수 Step에는 충족 기준 측면(`fulfillment_aspects`) 4~5개가 정의되어 있다. 다음 절차로 판단하라:
+
+1. **측면별 커버리지 평가** — `fulfillment_aspects` 각 항목에 대해, 그 측면의 핵심 활동이 `accepted_steps_in_required`(이 필수 Step 하위에서 Accept된 Step 목록)에 속한 어떤 Step의 `name` + `description`에서 **명확히 드러나는지**를 확인한다.
+   - **명확히 드러난다 = 커버됨(1)**: 해당 측면이 가리키는 활동을 그 Step이 실제로 수행한 것이 자연스럽게 읽힌다.
+   - **모호하다·간접적이다 = 미커버(0)**: 단어가 일부 겹쳐도 측면의 핵심 활동을 다루지 않으면 커버로 인정하지 않는다.
+   - **여러 Step이 같은 측면을 다뤄도 1로 카운트** (커버리지는 측면 단위지 Step 단위가 아니다).
+
+2. **카운트** — 커버된 측면의 개수를 센다.
+
+3. **임계값 비교** — 커버된 측면 수가 `fulfillment_threshold` **이상**이면 `true`, **미만**이면 `false`.
+
+## description의 위상
+
+`accepted_steps_in_required` 각 Step의 `description`은 프론트엔드에 노출되지 않는 **AI 내부 판단용** 필드다. 이 필드에는 그 Step이 어떤 측면·활동을 다루는지가 직접적으로 기술되어 있다. **측면 커버리지 판단의 핵심 근거**로 사용하라. `name`은 사용자 친화적 라벨이라 정보가 약할 수 있으므로, 가능한 한 `description`을 우선 참고한다.
+
+## 엄격성 가이드
+
+- **금지**: "비슷한 단어가 있으니 커버로 친다", "관련은 있어 보인다" 식의 관대한 판단.
+- **권장**: 측면이 요구하는 활동의 **결과물·산출물·행위**가 Step에 명시적으로 등장할 때에만 커버로 인정.
+- 의심스러우면 **미커버(0)** 로 분류한다.
+
+# 출력 형식 (엄격)
+
+**오직 다음 JSON 한 덩어리만** 반환한다. 설명·서론·마무리·코드 펜스(```) 없이 순수 JSON만 출력한다.
+
+{{ "is_current_required_step_completed": true }}
+
+또는
+
+{{ "is_current_required_step_completed": false }}
+
+규칙:
+- 키는 정확히 `is_current_required_step_completed` 하나.
+- 값은 boolean (`true` 또는 `false`). 문자열·숫자·null 금지.
+- 위 스키마 외 키를 추가하지 않는다.
+
+---
+
+# 입력 데이터
+
+## 현재 진행 중인 필수 Step
+- 이름: {required_step_name}
+- 목표: {required_step_goal}
+
+## 충족 기준 측면 (JSON 배열)
+{fulfillment_aspects}
+
+## 충족 임계값
+{fulfillment_threshold}개 이상의 측면이 커버되면 충족으로 판단한다.
+
+## 이 필수 Step 하위에서 Accept된 Step 목록 (JSON, 각 항목에 name + description 포함)
+{accepted_steps_in_required}
+
+## 방금 Accept된 Step
+{accepted_step_name}
+
+---
+
+# 출력
+
+위 절차를 따라 측면별 커버리지를 평가하고 임계값과 비교한 뒤, 위에서 명세한 JSON 한 덩어리만 출력하라.

--- a/ai/services/required_step_judge.py
+++ b/ai/services/required_step_judge.py
@@ -1,0 +1,85 @@
+"""필수 Step 충족 판단 서비스 (accept 시나리오).
+
+LLMClient만 사용하여 (RAG 없음), 현재 진행 중인 필수 Step의 목표가
+충족되었는지 boolean으로 판단한다. current_required_step이 null이면
+Claude를 호출하지 않고 즉시 False를 반환한다.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from ai.clients.llm import LLMClient
+from ai.prompts.template import PromptTemplate
+from ai.schemas.accept import AcceptInput, AcceptOutput
+
+logger = logging.getLogger(__name__)
+
+_SCENARIO = "accept"
+
+
+class RequiredStepJudge:
+    """accept 시나리오 — 필수 Step 충족 여부 boolean 판단."""
+
+    def __init__(self, llm: LLMClient) -> None:
+        self.llm = llm
+
+    async def judge_required_step(self, input_data: AcceptInput) -> AcceptOutput:
+        """필수 Step 충족 여부를 판단한다.
+
+        흐름:
+            1) current_required_step이 None → False 즉시 반환 (LLM 호출 없음)
+            2) 그 외 → 프롬프트 조립 후 LLM 호출
+        """
+        required_step = input_data.current_required_step
+
+        if required_step is None:
+            logger.info(
+                json.dumps(
+                    {
+                        "event": "required_step_judge_skip",
+                        "project_id": input_data.project_info.project_id,
+                        "reason": "no_current_required_step",
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            return AcceptOutput(is_current_required_step_completed=False)
+
+        accepted_steps_json = json.dumps(
+            [step.model_dump() for step in input_data.accepted_steps_in_required],
+            ensure_ascii=False,
+        )
+        fulfillment_aspects_json = json.dumps(
+            required_step.fulfillment_aspects,
+            ensure_ascii=False,
+        )
+
+        prompt = PromptTemplate.load_and_render(
+            _SCENARIO,
+            required_step_name=required_step.name,
+            required_step_goal=required_step.goal,
+            fulfillment_aspects=fulfillment_aspects_json,
+            fulfillment_threshold=str(required_step.fulfillment_threshold),
+            accepted_steps_in_required=accepted_steps_json,
+            accepted_step_name=input_data.accepted_step.name,
+        )
+
+        logger.info(
+            json.dumps(
+                {
+                    "event": "required_step_judge_invoke",
+                    "project_id": input_data.project_info.project_id,
+                    "required_step_id": required_step.step_id,
+                    "required_step_name": required_step.name,
+                    "num_accepted_steps": len(input_data.accepted_steps_in_required),
+                    "num_aspects": len(required_step.fulfillment_aspects),
+                    "threshold": required_step.fulfillment_threshold,
+                    "prompt_len": len(prompt),
+                },
+                ensure_ascii=False,
+            )
+        )
+
+        return await self.llm.invoke(prompt, AcceptOutput)

--- a/ai/tests/test_required_step_judge.py
+++ b/ai/tests/test_required_step_judge.py
@@ -1,0 +1,312 @@
+"""ai/services/required_step_judge.py 단위 테스트."""
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.exceptions import AIGenerationFailedError
+from ai.schemas.accept import AcceptInput, AcceptOutput
+from ai.schemas.common import (
+    ProjectInfo,
+    RequiredStepInfo,
+    RequiredStepStatus,
+    StageInfo,
+    StepInfo,
+)
+from ai.services.required_step_judge import RequiredStepJudge
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _project() -> ProjectInfo:
+    return ProjectInfo(
+        project_id="proj-1",
+        name="스터디 매칭 앱",
+        duration_months=3,
+        member_count=4,
+        description="대학생용 스터디 매칭",
+        constraints="React + FastAPI",
+        initial_prompt="스터디 메이트 매칭 서비스를 만들고 싶음",
+    )
+
+
+def _stage() -> StageInfo:
+    return StageInfo(stage_id="stage-1", stage_number=1, name="아이디어 구체화")
+
+
+def _required_step() -> RequiredStepInfo:
+    return RequiredStepInfo(
+        step_id="rs-1",
+        name="대상 사용자 파악",
+        is_completed=False,
+        goal="정의된 문제로 불편을 겪는 구체적 사용자군을 식별하고 특성을 그린다.",
+        entry_criteria="문제/기회에 관한 맥락이 존재한다.",
+        fulfillment_aspects=[
+            "1차 타겟 사용자군의 특성 정의 (연령·상황·역할 등)",
+            "사용자의 현재 행동·습관·맥락 파악",
+            "사용자 페르소나 또는 시나리오 정리",
+            "사용자 검증 활동 (인터뷰·관찰·설문 등)",
+        ],
+        fulfillment_threshold=2,
+    )
+
+
+def _required_steps_status() -> list[RequiredStepStatus]:
+    return [
+        RequiredStepStatus(name="문제/기회 정의", order=1, is_completed=True),
+        RequiredStepStatus(name="대상 사용자 파악", order=2, is_completed=False),
+        RequiredStepStatus(name="핵심 컨셉 정의", order=3, is_completed=False),
+        RequiredStepStatus(name="실현 가능성 검토", order=4, is_completed=False),
+    ]
+
+
+def _input_with_required(
+    accepted_steps: list[StepInfo] | None = None,
+    accepted_step: StepInfo | None = None,
+) -> AcceptInput:
+    return AcceptInput(
+        project_info=_project(),
+        current_stage=_stage(),
+        required_steps_status=_required_steps_status(),
+        current_required_step=_required_step(),
+        accepted_steps_in_required=accepted_steps
+        if accepted_steps is not None
+        else [
+            StepInfo(step_id="s1", name="타겟 사용자 정의"),
+            StepInfo(step_id="s2", name="사용자 인터뷰 계획"),
+        ],
+        accepted_step=accepted_step
+        if accepted_step is not None
+        else StepInfo(step_id="s2", name="사용자 인터뷰 계획"),
+    )
+
+
+def _input_without_required() -> AcceptInput:
+    return AcceptInput(
+        project_info=_project(),
+        current_stage=_stage(),
+        required_steps_status=_required_steps_status(),
+        current_required_step=None,
+        accepted_steps_in_required=[],
+        accepted_step=StepInfo(step_id="s0", name="아무거나"),
+    )
+
+
+def _make_service(
+    llm_return: Any = None,
+    llm_side_effect: Any = None,
+) -> tuple[RequiredStepJudge, MagicMock]:
+    llm = MagicMock()
+    llm.invoke = AsyncMock()
+    if llm_side_effect is not None:
+        llm.invoke.side_effect = llm_side_effect
+    else:
+        llm.invoke.return_value = (
+            llm_return
+            if llm_return is not None
+            else AcceptOutput(is_current_required_step_completed=True)
+        )
+    return RequiredStepJudge(llm=llm), llm
+
+
+# ---------------------------------------------------------------------------
+# 조기 반환 (LLM 호출 없음)
+# ---------------------------------------------------------------------------
+
+
+class TestSkipWhenNoRequiredStep:
+    @pytest.mark.asyncio
+    async def test_returns_false_when_current_required_step_is_none(self):
+        service, llm = _make_service()
+
+        result = await service.judge_required_step(_input_without_required())
+
+        assert isinstance(result, AcceptOutput)
+        assert result.is_current_required_step_completed is False
+
+    @pytest.mark.asyncio
+    async def test_llm_not_called_when_current_required_step_is_none(self):
+        service, llm = _make_service()
+
+        await service.judge_required_step(_input_without_required())
+
+        llm.invoke.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 정상 판단 흐름
+# ---------------------------------------------------------------------------
+
+
+class TestJudgeHappyPath:
+    @pytest.mark.asyncio
+    async def test_llm_returns_true_propagated(self):
+        service, llm = _make_service(
+            llm_return=AcceptOutput(is_current_required_step_completed=True)
+        )
+
+        result = await service.judge_required_step(_input_with_required())
+
+        assert isinstance(result, AcceptOutput)
+        assert result.is_current_required_step_completed is True
+        llm.invoke.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_llm_returns_false_propagated(self):
+        service, llm = _make_service(
+            llm_return=AcceptOutput(is_current_required_step_completed=False)
+        )
+
+        result = await service.judge_required_step(_input_with_required())
+
+        assert isinstance(result, AcceptOutput)
+        assert result.is_current_required_step_completed is False
+        llm.invoke.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_passes_accept_output_schema_to_llm(self):
+        service, llm = _make_service()
+
+        await service.judge_required_step(_input_with_required())
+
+        schema_arg = llm.invoke.await_args.args[1]
+        assert schema_arg is AcceptOutput
+
+
+# ---------------------------------------------------------------------------
+# LLM 실패 전파
+# ---------------------------------------------------------------------------
+
+
+class TestLLMFailurePropagates:
+    @pytest.mark.asyncio
+    async def test_validation_failure_propagates(self):
+        err = AIGenerationFailedError(
+            message="재시도 초과",
+            details={"last_error": {"type": "schema_validation_error", "attempt": 2}},
+        )
+        service, _ = _make_service(llm_side_effect=err)
+
+        with pytest.raises(AIGenerationFailedError):
+            await service.judge_required_step(_input_with_required())
+
+
+# ---------------------------------------------------------------------------
+# 프롬프트 조립 검증
+# ---------------------------------------------------------------------------
+
+
+class TestPromptAssembly:
+    @pytest.mark.asyncio
+    async def test_prompt_contains_required_step_name_and_goal(self):
+        service, llm = _make_service()
+
+        await service.judge_required_step(_input_with_required())
+
+        prompt = llm.invoke.await_args.args[0]
+        assert "대상 사용자 파악" in prompt
+        assert "정의된 문제로 불편을 겪는" in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_all_fulfillment_aspects(self):
+        service, llm = _make_service()
+
+        await service.judge_required_step(_input_with_required())
+
+        prompt = llm.invoke.await_args.args[0]
+        for aspect in _required_step().fulfillment_aspects:
+            assert aspect in prompt, f"측면이 누락됨: {aspect}"
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_threshold(self):
+        service, llm = _make_service()
+
+        await service.judge_required_step(_input_with_required())
+
+        prompt = llm.invoke.await_args.args[0]
+        # threshold=2 → "2개 이상의 측면" 표현이 템플릿에 들어있고
+        # placeholder가 정상 치환되어야 함
+        assert "2개 이상의 측면" in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_accepted_steps_in_required(self):
+        service, llm = _make_service()
+
+        await service.judge_required_step(_input_with_required())
+
+        prompt = llm.invoke.await_args.args[0]
+        assert "타겟 사용자 정의" in prompt
+        assert "사용자 인터뷰 계획" in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_accepted_step_name(self):
+        service, llm = _make_service(
+            llm_return=AcceptOutput(is_current_required_step_completed=False)
+        )
+        inp = _input_with_required(
+            accepted_step=StepInfo(step_id="s99", name="설문 조사 진행")
+        )
+
+        await service.judge_required_step(inp)
+
+        prompt = llm.invoke.await_args.args[0]
+        assert "설문 조사 진행" in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_serializes_aspects_as_json_array(self):
+        service, llm = _make_service()
+
+        await service.judge_required_step(_input_with_required())
+
+        prompt = llm.invoke.await_args.args[0]
+        # JSON 배열 직렬화 결과가 그대로 prompt에 들어가야 함
+        expected = json.dumps(
+            _required_step().fulfillment_aspects, ensure_ascii=False
+        )
+        assert expected in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_serializes_accepted_steps_as_json_with_names(self):
+        service, llm = _make_service()
+
+        await service.judge_required_step(_input_with_required())
+
+        prompt = llm.invoke.await_args.args[0]
+        # 각 Step의 step_id + name이 JSON 직렬화로 들어가야 함
+        assert '"step_id"' in prompt
+        assert '"name"' in prompt
+        assert '"s1"' in prompt or "s1" in prompt
+        assert '"s2"' in prompt or "s2" in prompt
+
+    @pytest.mark.asyncio
+    async def test_empty_accepted_steps_renders_empty_array(self):
+        service, llm = _make_service()
+        inp = _input_with_required(accepted_steps=[])
+
+        await service.judge_required_step(inp)
+
+        prompt = llm.invoke.await_args.args[0]
+        assert "[]" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_unresolved_placeholders_in_prompt(self):
+        service, llm = _make_service()
+
+        await service.judge_required_step(_input_with_required())
+
+        prompt = llm.invoke.await_args.args[0]
+        # 미치환 placeholder 패턴이 없어야 한다
+        for placeholder in [
+            "{required_step_name}",
+            "{required_step_goal}",
+            "{fulfillment_aspects}",
+            "{fulfillment_threshold}",
+            "{accepted_steps_in_required}",
+            "{accepted_step_name}",
+        ]:
+            assert placeholder not in prompt, f"미치환: {placeholder}"


### PR DESCRIPTION
## PR 요약
- accept 프롬프트 템플릿 작성 + Required Step Judge 구현

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `ai/prompts/accept.txt`: 필수 Step 충족 판단 프롬프트 템플릿 (측면 커버리지 3단계 판단 절차, 엄격성 가이드, description 우선 참고 명시)
- `ai/services/required_step_judge.py`: RequiredStepJudge 클래스 (current_required_step=None → False 즉시 반환, non-null → 프롬프트 조립 → Claude 호출 → boolean 반환)
- `ai/tests/test_required_step_judge.py`: mock 기반 단위 테스트 15개 (조기 반환, 정상 판단, LLM 실패 전파, 프롬프트 조립 검증)

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- RAG 호출 없음 — 순수 accepted_steps vs fulfillment_aspects 비교
- current_required_step=None 시 Claude 호출 없이 즉시 False 반환 (비용 절감)
- 170개 전체 테스트 통과 확인