### PR TITLE
[#44][FE] OAuth 콜백 처리 및 토큰 저장 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import LandingPage from './pages/LandingPage'
 import LoginPage from './pages/LoginPage'
 import ProjectListPage from './pages/ProjectListPage'
 import CreateProjectPage from './pages/CreateProjectPage'
+import AuthCallbackPage from './pages/AuthCallbackPage'
 
 export default function App() {
   return (
@@ -12,6 +13,7 @@ export default function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/projects" element={<ProjectListPage />} />
         <Route path="/projects/create" element={<CreateProjectPage />} />
+        <Route path="/auth/callback" element={<AuthCallbackPage />} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/api/projects.js
+++ b/frontend/src/api/projects.js
@@ -1,15 +1,28 @@
 import axios from 'axios'
 
+// csrf_token 쿠키에서 읽기
+function getCsrfToken() {
+  return document.cookie
+    .split('; ')
+    .find(row => row.startsWith('csrf_token='))
+    ?.split('=')[1]
+}
+
 const api = axios.create({
   baseURL: '/api',
+  withCredentials: true, // 쿠키 자동 전송 (fetch의 credentials: 'include'와 동일)
 })
 
 api.interceptors.request.use((config) => {
-  const token = localStorage.getItem('access_token')
-  if (token) {  // 토큰 있을 때만 헤더 추가
-    config.headers.Authorization = `Bearer ${token}`
+  // POST/PUT/PATCH/DELETE 요청에만 CSRF 토큰 헤더 추가
+  const mutatingMethods = ['post', 'put', 'patch', 'delete']
+  if (mutatingMethods.includes(config.method)) {
+    const csrfToken = getCsrfToken()
+    if (csrfToken) {
+      config.headers['X-CSRF-Token'] = csrfToken
+    }
   }
-  return config  // 토큰 없으면 그냥 그대로 요청
+  return config
 })
 
 api.interceptors.response.use(

--- a/frontend/src/pages/AuthCallbackPage.jsx
+++ b/frontend/src/pages/AuthCallbackPage.jsx
@@ -5,19 +5,7 @@ export default function AuthCallbackPage() {
   const navigate = useNavigate()
 
   useEffect(() => {
-    const hash = window.location.hash.substring(1)
-    const params = new URLSearchParams(hash)
-
-    const accessToken = params.get('access_token')
-    const refreshToken = params.get('refresh_token')
-
-    if (accessToken) {
-      localStorage.setItem('access_token', accessToken)
-      if (refreshToken) localStorage.setItem('refresh_token', refreshToken)
-      navigate('/projects', { replace: true })
-    } else {
-      navigate('/login', { replace: true })
-    }
+    navigate('/projects', { replace: true })
   }, [])
 
   return (

--- a/frontend/src/pages/AuthCallbackPage.jsx
+++ b/frontend/src/pages/AuthCallbackPage.jsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export default function AuthCallbackPage() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const hash = window.location.hash.substring(1)
+    const params = new URLSearchParams(hash)
+
+    const accessToken = params.get('access_token')
+    const refreshToken = params.get('refresh_token')
+
+    if (accessToken) {
+      localStorage.setItem('access_token', accessToken)
+      if (refreshToken) localStorage.setItem('refresh_token', refreshToken)
+      navigate('/projects', { replace: true })
+    } else {
+      navigate('/login', { replace: true })
+    }
+  }, [])
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
+      <p style={{ color: '#6B6D90', fontFamily: 'Pretendard, sans-serif' }}>로그인 처리 중...</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## PR 요약
- OAuth 로그인 후 토큰을 받아 localStorage에 저장하는 AuthCallbackPage 구현
- /auth/callback 라우트 추가
- projects.js — withCredentials + CSRF 토큰 헤더 추가

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- AuthCallbackPage
  - 백엔드가 쿠키로 토큰을 직접 설정하므로 URL 파싱/localStorage 저장 불필요
  - 콜백 진입 시 /projects로 자동 이동
- App.jsx
  - /auth/callback 라우트 추가
 
## 체크리스트
- [x] 로컬에서 화면 정상 렌더링 확인
- [x] 라우팅 정상 동작 확인
- [ ] EC2에서 OAuth 로그인 후 토큰 저장 확인

## 참고 사항

