### PR TITLE
[#21][BE] 인증 토큰 전달을 HttpOnly Cookie 방식으로 변경

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,7 +12,7 @@ BEDROCK_KB_ID=
 NOTION_TOKEN=
 
 # JWT Config (Lambda A 발급, A/B 모두 검증)
-JWT_SECRET_KEY=f57c4aa2f1cd7003bc123536d2523ebe5122f6b26767eee406d01b346fe572ea
+JWT_SECRET_KEY=
 JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 REFRESH_TOKEN_EXPIRE_DAYS=14
@@ -20,17 +20,10 @@ REFRESH_TOKEN_EXPIRE_DAYS=14
 # Google OAuth
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-# 개발(EC2 IP 사용 시): http://18-232-55-48.nip.io:8080/auth/google/callback
-# 점(.) 대신 하이픈(-) 사용. nip.io가 해당 IP로 자동 DNS 해석.
-# Google Cloud Console > OAuth 2.0 클라이언트 > 승인된 리디렉션 URI에 동일하게 등록 필요.
 GOOGLE_REDIRECT_URI=
 
 # OAuth 콜백 후 프론트엔드로 리다이렉트할 URL
-# 개발(EC2 IP 사용 시): http://18-232-55-48.nip.io:3000 (또는 프론트엔드 포트)
 FRONTEND_REDIRECT_URL=
-
-# CORS — 옵션 A(단일 CloudFront same-origin) 프로덕션에서는 빈 리스트로 두고,
-# 개발 환경에서만 프론트 origin 명시. JSON 배열 형식.
 CORS_ALLOWED_ORIGINS=["*"]
 
 # Cookie 설정 — 개발 HTTP 환경에서는 COOKIE_SECURE=false 필수

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,15 @@ GOOGLE_CLIENT_SECRET=
 # Google Cloud Console > OAuth 2.0 클라이언트 > 승인된 리디렉션 URI에 동일하게 등록 필요.
 GOOGLE_REDIRECT_URI=
 
-# OAuth 콜백 후 프론트엔드로 토큰 전달할 URL (fragment에 토큰 첨부)
+# OAuth 콜백 후 프론트엔드로 리다이렉트할 URL
 # 개발(EC2 IP 사용 시): http://18-232-55-48.nip.io:3000 (또는 프론트엔드 포트)
 FRONTEND_REDIRECT_URL=
+
+# CORS — 옵션 A(단일 CloudFront same-origin) 프로덕션에서는 빈 리스트로 두고,
+# 개발 환경에서만 프론트 origin 명시. JSON 배열 형식.
+CORS_ALLOWED_ORIGINS=["*"]
+
+# Cookie 설정 — 개발 HTTP 환경에서는 COOKIE_SECURE=false 필수
+COOKIE_SECURE=false
+COOKIE_SAMESITE=lax
+# COOKIE_DOMAIN=  # 비워두면 현재 호스트로 자동 설정. 필요시 .poco.com 같은 상위 도메인 명시

--- a/backend/app/ai/main.py
+++ b/backend/app/ai/main.py
@@ -4,13 +4,15 @@ from mangum import Mangum
 
 from app.ai.routers import steps
 from app.core import exception_handlers
+from app.core.auth.csrf import verify_csrf
 from app.core.auth.dependencies import get_current_user_id
+from app.core.config import settings
 
 app = FastAPI(title="Poco AI Orchestrator")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.CORS_ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -18,8 +20,11 @@ app.add_middleware(
 
 exception_handlers.register(app)
 
-# 모든 AI 라우터는 유효한 Bearer Access Token 필수 (DB 조회 없이 토큰만 검증)
-app.include_router(steps.router, tags=["ai"], dependencies=[Depends(get_current_user_id)])
+app.include_router(
+    steps.router,
+    tags=["ai"],
+    dependencies=[Depends(get_current_user_id), Depends(verify_csrf)],
+)
 
 
 @app.get("/health")

--- a/backend/app/business/main.py
+++ b/backend/app/business/main.py
@@ -4,13 +4,15 @@ from mangum import Mangum
 
 from app.business.routers import auth, projects, stages, steps
 from app.core import exception_handlers
+from app.core.auth.csrf import verify_csrf
 from app.core.auth.dependencies import get_current_user
+from app.core.config import settings
 
 app = FastAPI(title="Poco Business API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.CORS_ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -18,14 +20,18 @@ app.add_middleware(
 
 exception_handlers.register(app)
 
-# /auth 는 인증 없이 공개
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 
-# 나머지 라우터는 유효한 Bearer Access Token 필수
-_auth = [Depends(get_current_user)]
-app.include_router(projects.router, prefix="/projects", tags=["projects"], dependencies=_auth)
-app.include_router(stages.router, prefix="/stages", tags=["stages"], dependencies=_auth)
-app.include_router(steps.router, prefix="/steps", tags=["steps"], dependencies=_auth)
+_protected = [Depends(get_current_user), Depends(verify_csrf)]
+app.include_router(
+    projects.router, prefix="/projects", tags=["projects"], dependencies=_protected
+)
+app.include_router(
+    stages.router, prefix="/stages", tags=["stages"], dependencies=_protected
+)
+app.include_router(
+    steps.router, prefix="/steps", tags=["steps"], dependencies=_protected
+)
 
 
 @app.get("/health")

--- a/backend/app/business/routers/auth.py
+++ b/backend/app/business/routers/auth.py
@@ -1,16 +1,19 @@
-from urllib.parse import urlencode
-
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Cookie, Depends, Query, Response
 from fastapi import status as http_status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.business.dependency import get_db
 from app.business.services import auth_service
+from app.core.auth.cookies import (
+    clear_auth_cookies,
+    generate_csrf_token,
+    set_auth_cookies,
+)
 from app.core.auth.dependencies import get_current_user
 from app.core.config import settings
+from app.core.exceptions import InvalidTokenError
 from app.core.models.app_user import AppUser as AppUserModel
-from app.core.schemas.auth import TokenRefreshRequest
 
 router = APIRouter()
 
@@ -33,32 +36,50 @@ def oauth_callback(
     state: str | None = Query(default=None),
     db: Session = Depends(get_db),
 ):
-    """OAuth Provider 콜백 — code를 토큰으로 교환 후 프론트로 리다이렉트.
-    토큰은 URL fragment(#)에 담아 전달 (서버 로그 노출 방지)."""
     tokens = auth_service.handle_oauth_callback(db, provider, code)
-    fragment = urlencode(
-        {
-            "access_token": tokens.access_token,
-            "refresh_token": tokens.refresh_token,
-            "expires_in": tokens.expires_in,
-        }
-    )
-    return RedirectResponse(
-        url=f"{settings.FRONTEND_REDIRECT_URL}#{fragment}",
+    csrf = generate_csrf_token()
+
+    response = RedirectResponse(
+        url=settings.FRONTEND_REDIRECT_URL,
         status_code=http_status.HTTP_302_FOUND,
     )
+    set_auth_cookies(
+        response,
+        access_token=tokens.access_token,
+        refresh_token=tokens.refresh_token,
+        csrf_token=csrf,
+    )
+    return response
 
 
 @router.post("/refresh", status_code=http_status.HTTP_200_OK)
-def refresh_token(payload: TokenRefreshRequest):
-    """Refresh Token으로 Access Token 갱신."""
-    return _ok(auth_service.refresh_access_token(payload.refresh_token).model_dump())
+def refresh_token(
+    response: Response,
+    refresh_token: str | None = Cookie(
+        default=None, alias=settings.REFRESH_COOKIE_NAME
+    ),
+):
+    """Refresh Token 쿠키로 Access Token 갱신. 응답 쿠키도 모두 갱신."""
+    if not refresh_token:
+        raise InvalidTokenError("Refresh Token 쿠키가 없습니다.")
+
+    tokens = auth_service.refresh_access_token(refresh_token)
+    csrf = generate_csrf_token()
+    set_auth_cookies(
+        response,
+        access_token=tokens.access_token,
+        refresh_token=tokens.refresh_token,
+        csrf_token=csrf,
+    )
+    return _ok(None)
 
 
 @router.post("/logout", status_code=http_status.HTTP_200_OK)
-def logout(_: AppUserModel = Depends(get_current_user)):
-    """로그아웃 — Stateless JWT라 클라이언트가 토큰 폐기.
-    추후 token blacklist를 추가하려면 여기에서 처리."""
+def logout(
+    response: Response,
+    _: AppUserModel = Depends(get_current_user),
+):
+    clear_auth_cookies(response)
     return _ok(None)
 
 

--- a/backend/app/business/services/auth_service.py
+++ b/backend/app/business/services/auth_service.py
@@ -26,7 +26,9 @@ def get_authorization_url(provider_name: str, state: str | None = None) -> str:
     return provider.get_authorization_url(state=state)
 
 
-def handle_oauth_callback(db: Session, provider_name: str, code: str) -> AuthTokenResponse:
+def handle_oauth_callback(
+    db: Session, provider_name: str, code: str
+) -> AuthTokenResponse:
     """OAuth 콜백 처리: code → 사용자 조회/생성 → JWT 발급."""
     provider = get_provider(provider_name)
 
@@ -49,9 +51,7 @@ def refresh_access_token(refresh_token: str) -> AuthTokenResponse:
 
 def get_user_profile(db: Session, user: AppUserModel) -> UserProfileResponse:
     oauth = (
-        db.query(OAuthAccountModel)
-        .filter(OAuthAccountModel.user_id == user.id)
-        .first()
+        db.query(OAuthAccountModel).filter(OAuthAccountModel.user_id == user.id).first()
     )
     return UserProfileResponse(
         user_id=user.id,

--- a/backend/app/core/auth/cookies.py
+++ b/backend/app/core/auth/cookies.py
@@ -1,0 +1,64 @@
+"""인증 쿠키 set/clear 헬퍼.
+
+쿠키 3종 구성:
+- access_token : HttpOnly, Path=/             (모든 요청에 자동 첨부)
+- refresh_token: HttpOnly, Path=/auth         (refresh/logout에서만 노출)
+- csrf_token   : NOT HttpOnly, Path=/         (JS가 읽어 X-CSRF-Token 헤더에 실음)
+"""
+
+import secrets
+
+from fastapi import Response
+
+from app.core.config import settings
+
+
+def generate_csrf_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def set_auth_cookies(
+    response: Response,
+    access_token: str,
+    refresh_token: str,
+    csrf_token: str,
+) -> None:
+    common = {
+        "secure": settings.COOKIE_SECURE,
+        "samesite": settings.COOKIE_SAMESITE,
+        "domain": settings.COOKIE_DOMAIN,
+    }
+
+    response.set_cookie(
+        settings.ACCESS_COOKIE_NAME,
+        access_token,
+        httponly=True,
+        path="/",
+        max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        **common,
+    )
+    response.set_cookie(
+        settings.REFRESH_COOKIE_NAME,
+        refresh_token,
+        httponly=True,
+        path="/auth",
+        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400,
+        **common,
+    )
+    response.set_cookie(
+        settings.CSRF_COOKIE_NAME,
+        csrf_token,
+        httponly=False,
+        path="/",
+        max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        **common,
+    )
+
+
+def clear_auth_cookies(response: Response) -> None:
+    for name, path in (
+        (settings.ACCESS_COOKIE_NAME, "/"),
+        (settings.REFRESH_COOKIE_NAME, "/auth"),
+        (settings.CSRF_COOKIE_NAME, "/"),
+    ):
+        response.delete_cookie(name, path=path, domain=settings.COOKIE_DOMAIN)

--- a/backend/app/core/auth/csrf.py
+++ b/backend/app/core/auth/csrf.py
@@ -1,0 +1,31 @@
+"""CSRF Double Submit Cookie 검증 의존성.
+
+원리:
+- 로그인 시 csrf_token을 쿠키(NON-HttpOnly)와 함께 발급
+- 프론트엔드는 mutating 요청 시 쿠키에서 csrf_token을 읽어 X-CSRF-Token 헤더에 첨부
+- 다른 사이트는 우리 도메인 쿠키를 JS로 읽지 못하므로 헤더 위조 불가 → CSRF 차단
+"""
+
+import secrets
+
+from fastapi import Cookie, Header, Request
+
+from app.core.config import settings
+from app.core.exceptions import InvalidTokenError
+
+_MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def verify_csrf(
+    request: Request,
+    csrf_cookie: str | None = Cookie(default=None, alias=settings.CSRF_COOKIE_NAME),
+    csrf_header: str | None = Header(default=None, alias=settings.CSRF_HEADER_NAME),
+) -> None:
+    """state-changing 메서드(POST/PUT/PATCH/DELETE)에서만 검증.
+    GET/HEAD/OPTIONS는 부수효과가 없으므로 검증 생략."""
+    if request.method not in _MUTATING_METHODS:
+        return
+    if not csrf_cookie or not csrf_header:
+        raise InvalidTokenError("CSRF 토큰이 누락되었습니다.")
+    if not secrets.compare_digest(csrf_cookie, csrf_header):
+        raise InvalidTokenError("CSRF 토큰이 일치하지 않습니다.")

--- a/backend/app/core/auth/dependencies.py
+++ b/backend/app/core/auth/dependencies.py
@@ -1,21 +1,23 @@
 from uuid import UUID
 
-from fastapi import Depends, Header
+from fastapi import Cookie, Depends
 from sqlalchemy.orm import Session
 
 from app.core.auth.jwt import ACCESS_TOKEN_TYPE, decode_token
+from app.core.config import settings
 from app.core.database import get_db
 from app.core.exceptions import InvalidTokenError, UserNotFoundError
 from app.core.models.app_user import AppUser as AppUserModel
 
 
-def get_current_user_id(authorization: str | None = Header(default=None)) -> UUID:
-    """Authorization 헤더에서 Bearer 토큰을 검증하고 user_id만 추출.
+def get_current_user_id(
+    access_token: str | None = Cookie(default=None, alias=settings.ACCESS_COOKIE_NAME),
+) -> UUID:
+    """access_token 쿠키를 검증하고 user_id만 추출.
     DB 조회가 필요 없는 경우(AI Lambda 등) 사용."""
-    if not authorization or not authorization.lower().startswith("bearer "):
-        raise InvalidTokenError("Authorization 헤더가 누락되었거나 형식이 올바르지 않습니다.")
-    token = authorization.split(" ", 1)[1].strip()
-    return decode_token(token, expected_type=ACCESS_TOKEN_TYPE)
+    if not access_token:
+        raise InvalidTokenError("Access Token 쿠키가 없습니다.")
+    return decode_token(access_token, expected_type=ACCESS_TOKEN_TYPE)
 
 
 def get_current_user(
@@ -27,7 +29,7 @@ def get_current_user(
         db.query(AppUserModel)
         .filter(
             AppUserModel.id == user_id,
-            AppUserModel.is_deleted == False,
+            AppUserModel.is_deleted == False,  # noqa: E712
         )
         .first()
     )

--- a/backend/app/core/auth/jwt.py
+++ b/backend/app/core/auth/jwt.py
@@ -18,7 +18,9 @@ def _create_token(subject: str, token_type: str, expires_delta: timedelta) -> st
         "iat": int(now.timestamp()),
         "exp": int((now + expires_delta).timestamp()),
     }
-    return jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+    return jwt.encode(
+        payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM
+    )
 
 
 def create_access_token(user_id: UUID) -> str:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,6 +38,18 @@ class Settings(BaseSettings):
     # 프론트엔드 OAuth 콜백 URL
     FRONTEND_REDIRECT_URL: str = "http://localhost/auth/callback"
 
+    # CORS (옵션 A: 프로덕션에서는 same-origin이라 비워두고, 개발에서만 명시)
+    CORS_ALLOWED_ORIGINS: list[str] = []
+
+    # Cookie
+    COOKIE_SECURE: bool = True  # 개발 HTTP 환경에서는 false로 설정
+    COOKIE_SAMESITE: str = "lax"  # same-site 가정
+    COOKIE_DOMAIN: str | None = None  # None이면 현재 호스트 자동 적용
+    ACCESS_COOKIE_NAME: str = "access_token"
+    REFRESH_COOKIE_NAME: str = "refresh_token"
+    CSRF_COOKIE_NAME: str = "csrf_token"
+    CSRF_HEADER_NAME: str = "X-CSRF-Token"
+
     @property
     def DATABASE_URL(self) -> str:
         url = (

--- a/backend/app/core/models/oauth_account.py
+++ b/backend/app/core/models/oauth_account.py
@@ -11,9 +11,7 @@ from app.core.database import Base
 class OAuthAccount(Base):
     __tablename__ = "oauth_account"
     __table_args__ = (
-        UniqueConstraint(
-            "provider", "provider_user_id", name="uq_oauth_provider_user"
-        ),
+        UniqueConstraint("provider", "provider_user_id", name="uq_oauth_provider_user"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -35,4 +33,6 @@ class OAuthAccount(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
-    user: Mapped["AppUser"] = relationship(back_populates="oauth_accounts")  # noqa: F821
+    user: Mapped["AppUser"] = relationship(
+        back_populates="oauth_accounts"
+    )  # noqa: F821

--- a/backend/app/core/schemas/auth.py
+++ b/backend/app/core/schemas/auth.py
@@ -10,10 +10,6 @@ class AuthTokenResponse(BaseModel):
     expires_in: int
 
 
-class TokenRefreshRequest(BaseModel):
-    refresh_token: str
-
-
 class UserProfileResponse(BaseModel):
     user_id: UUID
     email: str

--- a/login_test/index.html
+++ b/login_test/index.html
@@ -7,7 +7,7 @@
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body { font-family: -apple-system, sans-serif; background: #f5f5f5; padding: 40px; }
-        .container { max-width: 500px; margin: 0 auto; }
+        .container { max-width: 560px; margin: 0 auto; }
         h1 { margin-bottom: 24px; color: #333; }
         .card { background: #fff; border-radius: 12px; padding: 24px; margin-bottom: 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
         .card h2 { font-size: 14px; color: #888; margin-bottom: 12px; text-transform: uppercase; }
@@ -19,134 +19,169 @@
         .btn-refresh { background: #3498db; color: #fff; }
         .btn:hover { opacity: 0.9; }
         .hidden { display: none; }
-        .token-box { background: #f8f8f8; border-radius: 8px; padding: 12px; font-family: monospace; font-size: 12px; word-break: break-all; margin-bottom: 8px; max-height: 80px; overflow-y: auto; }
-        .label { font-size: 12px; color: #888; margin-bottom: 4px; }
-        .user-info { margin-bottom: 8px; }
-        .user-info span { font-weight: 600; }
+        .info-row { font-size: 13px; padding: 6px 0; border-bottom: 1px solid #eee; display: flex; justify-content: space-between; }
+        .info-row:last-child { border-bottom: none; }
+        .info-row .k { color: #666; }
+        .info-row .v { font-family: monospace; font-weight: 600; color: #222; max-width: 60%; word-break: break-all; text-align: right; }
+        .badge-ok { color: #155724; }
+        .badge-no { color: #721c24; }
         .status { padding: 8px 12px; border-radius: 8px; font-size: 14px; margin-bottom: 16px; }
         .status-ok { background: #d4edda; color: #155724; }
         .status-err { background: #f8d7da; color: #721c24; }
+        .api-config { font-size: 12px; color: #888; margin-bottom: 16px; }
+        .api-config input { font-family: monospace; padding: 6px 10px; border: 1px solid #ddd; border-radius: 6px; width: 100%; margin-top: 4px; }
+        .note { font-size: 12px; color: #666; background: #fffbe6; border-left: 3px solid #f0c040; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; }
     </style>
 </head>
 <body>
     <div class="container">
         <h1>🐾 Poco 로그인 테스트</h1>
 
+        <div class="card api-config">
+            <label>API Base URL</label>
+            <input id="api-base" value="http://localhost:8000" />
+        </div>
+
         <!-- 로그인 전 -->
         <div id="login-section" class="card">
             <h2>소셜 로그인</h2>
-            <a class="btn btn-google" href="http://localhost:8000/auth/google/login">Google 로그인</a>
-            <a class="btn btn-naver" href="http://localhost:8000/auth/naver/login">Naver 로그인</a>
-            <a class="btn btn-kakao" href="http://localhost:8000/auth/kakao/login">Kakao 로그인</a>
+            <a class="btn btn-google" id="btn-google">Google 로그인</a>
+            <a class="btn btn-naver" id="btn-naver">Naver 로그인</a>
+            <a class="btn btn-kakao" id="btn-kakao">Kakao 로그인</a>
         </div>
 
         <!-- 로그인 후 -->
         <div id="user-section" class="card hidden">
             <h2>로그인 사용자</h2>
             <div id="status"></div>
-            <div class="user-info">이메일: <span id="user-email">-</span></div>
-            <div class="user-info">닉네임: <span id="user-nickname">-</span></div>
-            <div class="user-info">Provider: <span id="user-provider">-</span></div>
-            <div class="user-info">User ID: <span id="user-id">-</span></div>
+            <div class="info-row"><span class="k">이메일</span><span class="v" id="user-email">-</span></div>
+            <div class="info-row"><span class="k">닉네임</span><span class="v" id="user-nickname">-</span></div>
+            <div class="info-row"><span class="k">Provider</span><span class="v" id="user-provider">-</span></div>
+            <div class="info-row"><span class="k">User ID</span><span class="v" id="user-id">-</span></div>
         </div>
 
-        <div id="token-section" class="card hidden">
-            <h2>토큰 정보</h2>
-            <div class="label">Access Token</div>
-            <div class="token-box" id="access-token">-</div>
-            <div class="label">Refresh Token</div>
-            <div class="token-box" id="refresh-token">-</div>
-            <button class="btn btn-refresh" onclick="refreshToken()">토큰 갱신</button>
+        <div id="cookie-section" class="card hidden">
+            <h2>쿠키 상태</h2>
+            <div class="note">access_token / refresh_token 은 HttpOnly 쿠키라 JS에서 읽을 수 없습니다. 브라우저 DevTools → Application → Cookies 에서 직접 확인하세요.</div>
+            <div class="info-row"><span class="k">access_token (HttpOnly)</span><span class="v" id="has-access">-</span></div>
+            <div class="info-row"><span class="k">refresh_token (HttpOnly, Path=/auth)</span><span class="v" id="has-refresh">-</span></div>
+            <div class="info-row"><span class="k">csrf_token (JS 읽기 가능)</span><span class="v" id="csrf-value">-</span></div>
+            <button class="btn btn-refresh" onclick="refreshToken()" style="margin-top: 12px;">토큰 갱신</button>
             <button class="btn btn-logout" onclick="logout()">로그아웃</button>
         </div>
     </div>
 
 <script>
-const API = 'http://localhost:8000';
+// ---------------------------------------------------------------------------
+// 새 인증 흐름:
+// 1. /auth/{provider}/login 으로 이동 → Google/Naver/Kakao 동의 화면
+// 2. 콜백 후 서버가 access_token / refresh_token (HttpOnly) + csrf_token 쿠키 set
+// 3. 프론트는 fetch에 credentials: 'include' 만 붙이면 쿠키 자동 첨부
+// 4. 변경 요청(POST/PUT/PATCH/DELETE)은 csrf_token을 X-CSRF-Token 헤더로 첨부 필요
+// ---------------------------------------------------------------------------
 
-// 페이지 로드 시 URL fragment에서 토큰 추출
-window.addEventListener('load', () => {
-    const hash = window.location.hash.substring(1);
-    if (hash) {
-        const params = new URLSearchParams(hash);
-        const accessToken = params.get('access_token');
-        const refreshToken = params.get('refresh_token');
-
-        if (accessToken) {
-            localStorage.setItem('access_token', accessToken);
-            localStorage.setItem('refresh_token', refreshToken);
-            // URL에서 fragment 제거
-            history.replaceState(null, '', window.location.pathname);
-        }
-    }
-
-    const token = localStorage.getItem('access_token');
-    if (token) {
-        fetchMe(token);
-    }
+const apiInput = document.getElementById('api-base');
+apiInput.value = localStorage.getItem('poco_api_base') || apiInput.value;
+apiInput.addEventListener('change', () => {
+    localStorage.setItem('poco_api_base', apiInput.value);
+    renderProviderLinks();
 });
 
-async function fetchMe(token) {
-    try {
-        const resp = await fetch(`${API}/auth/me`, {
-            headers: { 'Authorization': `Bearer ${token}` }
-        });
-        const body = await resp.json();
+function api() { return apiInput.value.replace(/\/$/, ''); }
 
+function getCookie(name) {
+    return document.cookie
+        .split('; ')
+        .find(c => c.startsWith(name + '='))
+        ?.split('=')[1] || null;
+}
+
+// CSRF 자동 첨부 fetch 래퍼
+async function apiFetch(path, options = {}) {
+    const opts = {
+        credentials: 'include',     // 쿠키 자동 첨부 (Cross-origin/Same-origin 모두 필수)
+        headers: { ...(options.headers || {}) },
+        ...options,
+    };
+    const method = (opts.method || 'GET').toUpperCase();
+    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+        const csrf = getCookie('csrf_token');
+        if (csrf) opts.headers['X-CSRF-Token'] = csrf;
+    }
+    return fetch(api() + path, opts);
+}
+
+function renderProviderLinks() {
+    document.getElementById('btn-google').href = api() + '/auth/google/login';
+    document.getElementById('btn-naver').href = api() + '/auth/naver/login';
+    document.getElementById('btn-kakao').href = api() + '/auth/kakao/login';
+}
+
+window.addEventListener('load', () => {
+    renderProviderLinks();
+    // 콜백 후엔 서버가 이미 쿠키를 set했으므로 즉시 /auth/me 호출
+    fetchMe();
+});
+
+async function fetchMe() {
+    try {
+        const resp = await apiFetch('/auth/me');
+        if (resp.status === 401 || resp.status === 403) {
+            // 비로그인 상태 — 정상
+            return;
+        }
+        const body = await resp.json();
         if (body.status === 'success') {
             showUser(body.data);
         } else {
             showError(body.error?.message || '인증 실패');
         }
     } catch (e) {
-        showError('서버 연결 실패: ' + e.message);
+        // 서버 미연결도 비로그인 상태로 취급
     }
 }
 
 function showUser(data) {
     document.getElementById('login-section').classList.add('hidden');
     document.getElementById('user-section').classList.remove('hidden');
-    document.getElementById('token-section').classList.remove('hidden');
+    document.getElementById('cookie-section').classList.remove('hidden');
 
     document.getElementById('user-email').textContent = data.email;
     document.getElementById('user-nickname').textContent = data.nickname;
     document.getElementById('user-provider').textContent = data.provider;
     document.getElementById('user-id').textContent = data.user_id;
-    document.getElementById('access-token').textContent = localStorage.getItem('access_token');
-    document.getElementById('refresh-token').textContent = localStorage.getItem('refresh_token');
+
+    refreshCookieView();
 
     document.getElementById('status').className = 'status status-ok';
     document.getElementById('status').textContent = '✅ 로그인 성공';
 }
 
+function refreshCookieView() {
+    // HttpOnly 쿠키 존재 여부는 JS로 알 수 없음.
+    // 대신 /auth/me가 200이면 access_token이 유효하다는 간접 확인.
+    document.getElementById('has-access').innerHTML = '<span class="badge-ok">유효 (서버 응답으로 확인)</span>';
+    document.getElementById('has-refresh').innerHTML = '<span class="badge-ok">존재 (DevTools에서 확인)</span>';
+    const csrf = getCookie('csrf_token');
+    document.getElementById('csrf-value').textContent = csrf
+        ? csrf.slice(0, 16) + '…'
+        : '(없음)';
+}
+
 function showError(msg) {
     document.getElementById('login-section').classList.remove('hidden');
     document.getElementById('user-section').classList.remove('hidden');
-    document.getElementById('token-section').classList.add('hidden');
-
+    document.getElementById('cookie-section').classList.add('hidden');
     document.getElementById('status').className = 'status status-err';
     document.getElementById('status').textContent = '❌ ' + msg;
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('refresh_token');
 }
 
 async function refreshToken() {
-    const rt = localStorage.getItem('refresh_token');
-    if (!rt) return alert('Refresh Token이 없습니다.');
-
     try {
-        const resp = await fetch(`${API}/auth/refresh`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ refresh_token: rt })
-        });
+        const resp = await apiFetch('/auth/refresh', { method: 'POST' });
         const body = await resp.json();
-
-        if (body.status === 'success') {
-            localStorage.setItem('access_token', body.data.access_token);
-            localStorage.setItem('refresh_token', body.data.refresh_token);
-            document.getElementById('access-token').textContent = body.data.access_token;
-            document.getElementById('refresh-token').textContent = body.data.refresh_token;
+        if (resp.ok && body.status === 'success') {
+            refreshCookieView();
             document.getElementById('status').className = 'status status-ok';
             document.getElementById('status').textContent = '✅ 토큰 갱신 성공';
         } else {
@@ -157,12 +192,14 @@ async function refreshToken() {
     }
 }
 
-function logout() {
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('refresh_token');
+async function logout() {
+    try {
+        await apiFetch('/auth/logout', { method: 'POST' });
+    } catch (e) { /* 쿠키 삭제만 보장되면 됨 */ }
+
     document.getElementById('login-section').classList.remove('hidden');
     document.getElementById('user-section').classList.add('hidden');
-    document.getElementById('token-section').classList.add('hidden');
+    document.getElementById('cookie-section').classList.add('hidden');
     document.getElementById('status').className = '';
     document.getElementById('status').textContent = '';
 }


### PR DESCRIPTION
## PR 요약
- OAuth 토큰 전달을 URL fragment → HttpOnly Cookie 방식으로 변경하고 CSRF 검증 추가

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- access_token / refresh_token 을 HttpOnly 쿠키로 발급 (URL 노출 차단)
- csrf_token 쿠키 + X-CSRF-Token 헤더 Double Submit Cookie 패턴으로 CSRF 차단
- 비-auth 라우터에 `get_current_user` + `verify_csrf` 의존성 일괄 적용
- CORS `allow_origins=["*"]` 제거, 환경변수로 명시적 origin 관리
- 프론트 로그인 테스트 페이지(`login_test/index.html`)도 새 흐름에 맞춰 갱신

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행 (해당 없음)
- [x] 불필요한 코드 및 주석 제거
- [x] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- 신규 환경변수: `CORS_ALLOWED_ORIGINS`, `COOKIE_SECURE`, `COOKIE_SAMESITE`, `COOKIE_DOMAIN`
- 프론트는 모든 fetch에 `credentials: 'include'` + mutating 요청에 `X-CSRF-Token` 헤더 필수

🤖 Generated with [Claude Code](https://claude.com/claude-code)