### PR TITLE
[#16][BE] Lambda B AI Orchestrator 엔드포인트 구현 (generate / accept / 사이드패널)

### DIFF
--- a/backend/app/ai/routers/steps.py
+++ b/backend/app/ai/routers/steps.py
@@ -18,14 +18,17 @@ def _ok(data):
 def generate_steps(step_id: UUID, db: Session = Depends(get_db)) -> dict:
     """현재 Step 기반으로 다음 후보 Step 3개를 AI로 생성."""
     response = step_service.generate_steps(db, step_id)
-    return _ok(response.model_dump())
+    return _ok(response)
 
 @router.post("/steps/{step_id}/accept", status_code=http_status.HTTP_200_OK)
 def accept_step(step_id: UUID, db: Session = Depends(get_db)) -> dict:
     response = step_service.accept_step(db, step_id)
     return _ok(response)
 
-    
+@router.get("/steps/{step_id}", status_code=http_status.HTTP_200_OK)
+def get_step_detail(step_id: UUID, db: Session = Depends(get_db)) -> dict:
+    response = step_service.get_step_detail(db, step_id)
+    return _ok(response)
 
 
 @router.post(

--- a/backend/app/ai/routers/steps.py
+++ b/backend/app/ai/routers/steps.py
@@ -20,17 +20,12 @@ def generate_steps(step_id: UUID, db: Session = Depends(get_db)) -> dict:
     response = step_service.generate_steps(db, step_id)
     return _ok(response.model_dump())
 
-
 @router.post("/steps/{step_id}/accept", status_code=http_status.HTTP_200_OK)
-def accept_step(step_id: UUID) -> dict:
-    """Step Accept (상태 판정) — TODO: AI 충족 판단 구현."""
-    return _ok(
-        {
-            "step_id": str(step_id),
-            "status": "ACCEPTED",
-            "is_current_required_step_completed": False,
-        }
-    )
+def accept_step(step_id: UUID, db: Session = Depends(get_db)) -> dict:
+    response = step_service.accept_step(db, step_id)
+    return _ok(response)
+
+    
 
 
 @router.post(

--- a/backend/app/ai/services/orchestrator.py
+++ b/backend/app/ai/services/orchestrator.py
@@ -1,22 +1,18 @@
 import json
-from uuid import UUID
 
-from app.ai.services.rag import retrieve
 from app.core.aws.bedrock import bedrock_runtime
 from app.core.config import settings
+from app.core.schemas.bedrock import AcceptPayload
 
-STEP_GENERATION_PROMPT = """\
-당신은 소프트웨어 개발 방법론 전문가입니다. 아래 프로젝트 컨텍스트를 바탕으로,
-사용자가 다음에 수행할 수 있는 Step 후보 3개를 제안하세요.
 
-프로젝트 컨텍스트:
-{context}
+ACCEPT_PROMPT = """\
+당신은 소프트웨어 개발 방법론 전문가입니다.
+아래 데이터를 바탕으로 현재 필수 Step의 목표 달성 여부를 판단하세요.
 
-관련 자료:
-{references}
-
-JSON 배열 형식으로만 답하세요. 각 원소는 {{"name": str, "guide": str}} 형태입니다.
+반드시 아래 JSON 형식만 출력하세요:
+{"is_current_required_step_completed": true 또는 false}
 """
+
 
 
 def _invoke_claude(prompt: str) -> str:
@@ -35,27 +31,7 @@ def _invoke_claude(prompt: str) -> str:
     return payload["content"][0]["text"]
 
 
-def generate_next_steps(payload: dict) -> dict:
-    context = payload.get("context", "")
-    refs = retrieve(context) if context else []
-    ref_text = "\n".join(r.get("content", {}).get("text", "") for r in refs)
-
-    prompt = STEP_GENERATION_PROMPT.format(context=context, references=ref_text)
-    # TODO: remove stub guard once Bedrock is wired
-    try:
-        raw = _invoke_claude(prompt)
-    except Exception as e:  # noqa: BLE001
-        return {"error": str(e), "steps": []}
-
-    return {"raw": raw}
-
-
-def generate_step_details(step_id: UUID, payload: dict) -> dict:
-    # TODO: implement guide/dictionary/mentoring/template 생성
-    return {
-        "step_id": str(step_id),
-        "todo": [],
-        "dictionary": [],
-        "recommendations": [],
-        "references": [],
-    }
+def call_accept(payload: AcceptPayload) -> dict:
+    message = ACCEPT_PROMPT + "\n\n" + json.dumps(payload.model_dump(), ensure_ascii=False)
+    raw = _invoke_claude(message)
+    return json.loads(raw)

--- a/backend/app/ai/services/orchestrator.py
+++ b/backend/app/ai/services/orchestrator.py
@@ -2,16 +2,7 @@ import json
 
 from app.core.aws.bedrock import bedrock_runtime
 from app.core.config import settings
-from app.core.schemas.bedrock import AcceptPayload
-
-
-ACCEPT_PROMPT = """\
-당신은 소프트웨어 개발 방법론 전문가입니다.
-아래 데이터를 바탕으로 현재 필수 Step의 목표 달성 여부를 판단하세요.
-
-반드시 아래 JSON 형식만 출력하세요:
-{"is_current_required_step_completed": true 또는 false}
-"""
+from app.core.schemas.bedrock import AcceptPayload, GeneratePayload
 
 
 
@@ -31,7 +22,31 @@ def _invoke_claude(prompt: str) -> str:
     return payload["content"][0]["text"]
 
 
+ACCEPT_PROMPT = """\
+당신은 소프트웨어 개발 방법론 전문가입니다.
+아래 데이터를 바탕으로 현재 필수 Step의 목표 달성 여부를 판단하세요.
+
+반드시 아래 JSON 형식만 출력하세요:
+{"is_current_required_step_completed": true 또는 false}
+"""
+
 def call_accept(payload: AcceptPayload) -> dict:
     message = ACCEPT_PROMPT + "\n\n" + json.dumps(payload.model_dump(), ensure_ascii=False)
+    raw = _invoke_claude(message)
+    return json.loads(raw)
+
+
+GENERATE_PROMPT = """\
+당신은 소프트웨어 개발 방법론 전문가입니다.
+아래 데이터를 바탕으로 현재 프로젝트 상황에 적합한 다음 액션 Step 3개를 제안하세요.
+Step 이름은 구체적이고 실행 가능한 동사형으로 작성하세요.
+
+반드시 아래 JSON 형식만 출력하세요:
+{"generated_steps": [{"name": "Step 이름1"}, {"name": "Step 이름2"}, {"name": "Step 이름3"}]}
+"""
+
+
+def call_generate(payload: GeneratePayload) -> dict:
+    message = GENERATE_PROMPT + "\n\n" + json.dumps(payload.model_dump(), ensure_ascii=False)
     raw = _invoke_claude(message)
     return json.loads(raw)

--- a/backend/app/ai/services/orchestrator.py
+++ b/backend/app/ai/services/orchestrator.py
@@ -2,7 +2,7 @@ import json
 
 from app.core.aws.bedrock import bedrock_runtime
 from app.core.config import settings
-from app.core.schemas.bedrock import AcceptPayload, GeneratePayload
+from app.core.schemas.bedrock import AcceptPayload, GeneratePayload, SidePanelPayload
 
 
 
@@ -48,5 +48,30 @@ Step 이름은 구체적이고 실행 가능한 동사형으로 작성하세요.
 
 def call_generate(payload: GeneratePayload) -> dict:
     message = GENERATE_PROMPT + "\n\n" + json.dumps(payload.model_dump(), ensure_ascii=False)
+    raw = _invoke_claude(message)
+    return json.loads(raw)
+
+SIDE_PANEL_PROMPT = """\
+당신은 소프트웨어 개발 방법론 전문가입니다.
+아래 데이터를 바탕으로 사용자가 클릭한 Step에 대한 멘토링과 용어 사전을 생성하세요.
+이미 진행된 decision_history를 참고해 중복되지 않는 가이드를 제공하세요.
+
+반드시 아래 JSON 형식만 출력하세요:
+{
+  "mentoring": {
+    "description": "이 Step이 왜 필요한지, 무엇을 해야 하는지",
+    "recommended_methods": [{ "title": "...", "content": "..." }],
+    "common_mistakes": [{ "mistake": "...", "bad_example": "...", "good_example": "..." }],
+    "one_line_tip": "..."
+  },
+  "dictionary": [
+    { "term": "...", "definition": "..." }
+  ]
+}
+"""
+
+
+def call_side_panel(payload: SidePanelPayload) -> dict:
+    message = SIDE_PANEL_PROMPT + "\n\n" + json.dumps(payload.model_dump(), ensure_ascii=False)
     raw = _invoke_claude(message)
     return json.loads(raw)

--- a/backend/app/ai/services/step_service.py
+++ b/backend/app/ai/services/step_service.py
@@ -1,4 +1,3 @@
-import random
 import uuid
 
 from sqlalchemy.orm import Session
@@ -15,6 +14,8 @@ from app.core.schemas.bedrock import (
     CurrentStage,
     ProjectInfo,
     RequiredStepStatusItem,
+    DecisionHistoryItem,
+    GeneratePayload,
 )
 from datetime import datetime, timezone
 from app.ai.services import orchestrator
@@ -23,19 +24,6 @@ from app.core.models.project_required_step_status import ProjectRequiredStepStat
 from app.core.models.required_step import RequiredStep as RequiredStepModel
 from app.ai.services.rag import retrieve
 
-
-_EXAMPLE_STEP_NAMES = [
-    "사용자 인터뷰 진행",
-    "경쟁사 분석",
-    "페르소나 정의",
-    "핵심 문제 도출",
-    "솔루션 브레인스토밍",
-    "유사 서비스 벤치마킹",
-    "사용자 여정 맵 작성",
-    "문제-솔루션 핏 검증",
-    "핵심 가치 제안 정의",
-    "초기 아이디어 스케치",
-]
 
 
 def _insert_closure_rows(
@@ -53,67 +41,6 @@ def _insert_closure_rows(
                 ancestor=row.ancestor, descendant=step_id, depth=row.depth + 1
             )
         )
-
-
-def generate_steps(db: Session, parent_step_id: uuid.UUID) -> StepGenerateResponse:
-    parent_step = db.get(StepModel, parent_step_id)
-    if parent_step is None:
-        raise StepNotFoundError(f"Parent Step을 찾을 수 없습니다: {parent_step_id}")
-
-    # TODO(AI): Bedrock Claude + RAG 기반 Step 후보 생성
-    # context = {
-    #     "project_id": parent_step.project_id,
-    #     "stage_id": parent_step.stage_id,
-    #     "parent_step_name": parent_step.name,
-    #     "step_history": <closure table 기반 현재 경로>,
-    # }
-    # candidates = bedrock_client.invoke(model_id=settings.BEDROCK_MODEL_ID, context=context)
-    # → Claude가 3개의 regular step + optional 1 required step 후보를 JSON으로 반환
-
-    chosen_names = random.sample(_EXAMPLE_STEP_NAMES, 3)  # 임시
-
-    # 부모가 필수 Step 영역에 속하면 자식도 같은 영역에 속함
-    belonging_rs_id = (
-        parent_step.belonging_required_step_id or parent_step.required_step_id
-    )
-
-    steps: list[StepModel] = []
-    for i, name in enumerate(chosen_names):
-        step = StepModel(
-            id=uuid.uuid4(),
-            project_id=parent_step.project_id,
-            stage_id=parent_step.stage_id,
-            parent_step_id=parent_step_id,
-            required_step_id=None,
-            belonging_required_step_id=belonging_rs_id,
-            name=name,
-            status=StepStatus.READY,
-            sort_order=i + 1,
-        )
-        db.add(step)
-        db.flush()
-        _insert_closure_rows(db, step.id, parent_step_id)
-        steps.append(step)
-
-    db.commit()
-    for step in steps:
-        db.refresh(step)
-
-    return StepGenerateResponse(
-        generated_steps=[
-            GeneratedStep(
-                step_id=s.id,
-                name=s.name,
-                status=s.status,
-                is_required=s.required_step_id is not None,
-                parent_step_id=s.parent_step_id,
-            )
-            for s in steps
-        ]
-    )
-
-
-
 
 
 def accept_step(db: Session, step_id: uuid.UUID) -> dict:
@@ -270,3 +197,189 @@ def _upsert_required_step_status(
         db.add(record)
     record.is_fulfilled = True
     record.fulfilled_at = datetime.now(timezone.utc)
+
+
+def generate_steps(db: Session, parent_step_id: uuid.UUID) -> StepGenerateResponse:
+    parent_step = db.get(StepModel, parent_step_id)
+    if parent_step is None:
+        raise StepNotFoundError(f"Parent Step을 찾을 수 없습니다: {parent_step_id}")
+
+    # ① Bedrock으로 일반 Step 이름 3개 생성
+    payload = _build_generate_payload(db, parent_step)
+
+    result = orchestrator.call_generate(payload)
+    generated: list[dict] = result.get("generated_steps", [])
+
+    # ② 부모가 필수 Step 영역에 속하면 자식도 같은 영역에 속함
+    belonging_rs_id = (
+        parent_step.belonging_required_step_id or parent_step.required_step_id
+    )
+
+    steps: list[StepModel] = []
+    sort_order = 1
+
+    # ③ 필수 Step 노드 포함 여부 판단
+    next_rs_id = _get_next_unfulfilled_required_step_id(db, parent_step)
+    already_inside = (
+        parent_step.belonging_required_step_id == next_rs_id
+        or parent_step.required_step_id == next_rs_id
+    )
+    if next_rs_id is not None and not already_inside:
+        # 기존 READY 필수 Step 노드 재사용 여부 확인
+        existing_pending = (
+            db.query(StepModel)
+            .filter(
+                StepModel.project_id == parent_step.project_id,
+                StepModel.stage_id == parent_step.stage_id,
+                StepModel.required_step_id == next_rs_id,
+                StepModel.status == StepStatus.READY,
+            )
+            .first()
+        )
+
+        if existing_pending:
+            existing_pending.parent_step_id = parent_step_id
+            existing_pending.sort_order = 0
+            db.query(StepTreeModel).filter(
+                StepTreeModel.descendant == existing_pending.id
+            ).delete()
+            db.flush()
+            _insert_closure_rows(db, existing_pending.id, parent_step_id)
+            db.flush()
+            steps.append(existing_pending)
+        else:
+            next_rs = db.get(RequiredStepModel, next_rs_id)
+            req_step = StepModel(
+                id=uuid.uuid4(),
+                project_id=parent_step.project_id,
+                stage_id=parent_step.stage_id,
+                parent_step_id=parent_step_id,
+                required_step_id=next_rs_id,
+                belonging_required_step_id=None,
+                name=next_rs.name,
+                status=StepStatus.READY,
+                sort_order=0,
+            )
+            db.add(req_step)
+            db.flush()
+            _insert_closure_rows(db, req_step.id, parent_step_id)
+            steps.append(req_step)
+
+    # ④ 일반 Step 생성
+    for item in generated:
+        step = StepModel(
+            id=uuid.uuid4(),
+            project_id=parent_step.project_id,
+            stage_id=parent_step.stage_id,
+            parent_step_id=parent_step_id,
+            required_step_id=None,
+            belonging_required_step_id=belonging_rs_id,
+            name=item["name"],
+            status=StepStatus.READY,
+            sort_order=sort_order,
+        )
+        db.add(step)
+        db.flush()
+        _insert_closure_rows(db, step.id, parent_step_id)
+        steps.append(step)
+        sort_order += 1
+
+    db.commit()
+    for step in steps:
+        db.refresh(step)
+
+    return StepGenerateResponse(
+        generated_steps=[
+            GeneratedStep(
+                step_id=s.id,
+                name=s.name,
+                status=s.status,
+                is_required=s.required_step_id is not None,
+                parent_step_id=s.parent_step_id,
+            )
+            for s in steps
+        ]
+    )
+def _build_generate_payload(db: Session, parent_step: StepModel) -> GeneratePayload:
+    project = parent_step.project
+    stage = parent_step.stage
+
+    # 현재 stage에서 ACCEPTED된 step 전체 (decision_history)
+    accepted_steps = (
+        db.query(StepModel)
+        .filter(
+            StepModel.project_id == project.id,
+            StepModel.stage_id == stage.id,
+            StepModel.status == StepStatus.ACCEPTED,
+        )
+        .all()
+    )
+
+    all_required = (
+        db.query(RequiredStepModel)
+        .filter(RequiredStepModel.stage_id == stage.id)
+        .order_by(RequiredStepModel.sequence)
+        .all()
+    )
+    fulfilled_ids = {
+        row.required_step_id
+        for row in db.query(ProjectRequiredStepStatus).filter_by(
+            project_id=project.id, is_fulfilled=True
+        )
+    }
+
+    current_rs = next((rs for rs in all_required if rs.id not in fulfilled_ids), None)
+    current_required_step = None
+    if current_rs:
+        current_required_step = CurrentRequiredStep(
+            step_id=current_rs.id,
+            name=current_rs.name,
+            is_completed=False,
+            goal=current_rs.goal,
+            entry_criteria=current_rs.entry_criteria,
+            fulfillment_aspects=current_rs.fulfillment_aspects,
+            fulfillment_threshold=current_rs.fulfillment_threshold,
+        )
+
+    rag_results = retrieve(f"{stage.name} {parent_step.name}")
+
+    return GeneratePayload(
+        project_info=ProjectInfo(
+            project_id=project.id,
+            name=project.name,
+            duration_months=project.duration_month,
+            member_count=project.member_count,
+            description=project.description,
+            constraints=project.constraint_text,
+            initial_prompt=project.prompt,
+        ),
+        current_stage=CurrentStage(
+            stage_id=stage.id,
+            stage_number=stage.sequence,
+            name=stage.name,
+        ),
+        current_required_step=current_required_step,
+        decision_history=[
+            DecisionHistoryItem(step_id=s.id, name=s.name, status=s.status)
+            for s in accepted_steps
+        ],
+        current_step=AcceptedStepItem(step_id=parent_step.id, name=parent_step.name),
+        rag_context={"results": rag_results},
+    )
+def _get_next_unfulfilled_required_step_id(
+    db: Session, step: StepModel
+) -> uuid.UUID | None:
+    fulfilled_ids = {
+        row.required_step_id
+        for row in db.query(ProjectRequiredStepStatus).filter_by(
+            project_id=step.project_id, is_fulfilled=True
+        )
+    }
+    query = (
+        db.query(RequiredStepModel)
+        .filter(RequiredStepModel.stage_id == step.stage_id)
+    )
+    if fulfilled_ids:
+        query = query.filter(RequiredStepModel.id.not_in(fulfilled_ids))
+    next_rs = query.order_by(RequiredStepModel.sequence).first()
+    return next_rs.id if next_rs else None

--- a/backend/app/ai/services/step_service.py
+++ b/backend/app/ai/services/step_service.py
@@ -1,4 +1,5 @@
 import uuid
+import json
 
 from sqlalchemy.orm import Session
 
@@ -16,6 +17,9 @@ from app.core.schemas.bedrock import (
     RequiredStepStatusItem,
     DecisionHistoryItem,
     GeneratePayload,
+    SidePanelPayload,
+    SidePanelDecisionHistoryItem,
+    TargetStep,
 )
 from datetime import datetime, timezone
 from app.ai.services import orchestrator
@@ -23,6 +27,7 @@ from app.core.exceptions import StepAlreadyAcceptedError
 from app.core.models.project_required_step_status import ProjectRequiredStepStatus
 from app.core.models.required_step import RequiredStep as RequiredStepModel
 from app.ai.services.rag import retrieve
+from app.core.models.step import StepContent as StepContentModel
 
 
 
@@ -199,7 +204,7 @@ def _upsert_required_step_status(
     record.fulfilled_at = datetime.now(timezone.utc)
 
 
-def generate_steps(db: Session, parent_step_id: uuid.UUID) -> StepGenerateResponse:
+def generate_steps(db: Session, parent_step_id: uuid.UUID) -> dict:
     parent_step = db.get(StepModel, parent_step_id)
     if parent_step is None:
         raise StepNotFoundError(f"Parent Step을 찾을 수 없습니다: {parent_step_id}")
@@ -299,7 +304,8 @@ def generate_steps(db: Session, parent_step_id: uuid.UUID) -> StepGenerateRespon
             )
             for s in steps
         ]
-    )
+    ).model_dump()
+
 def _build_generate_payload(db: Session, parent_step: StepModel) -> GeneratePayload:
     project = parent_step.project
     stage = parent_step.stage
@@ -383,3 +389,126 @@ def _get_next_unfulfilled_required_step_id(
         query = query.filter(RequiredStepModel.id.not_in(fulfilled_ids))
     next_rs = query.order_by(RequiredStepModel.sequence).first()
     return next_rs.id if next_rs else None
+
+
+# 사이드 패널
+def get_step_detail(db: Session, step_id: uuid.UUID) -> dict:
+    step = db.get(StepModel, step_id)
+    if step is None:
+        raise StepNotFoundError()
+
+    # 필수 Step → DB에서 반환
+    if step.required_step_id is not None:
+        content = step.content
+        return {
+            "is_required": True,
+            "step_id": step.id,
+            "name": step.name,
+            "mentoring": json.loads(content.mentoring) if content.mentoring else None,
+            "dictionary": json.loads(content.dictionary) if content.dictionary else None,
+            "template_url": content.template_url if content else None, 
+        }
+
+    # 일반 Step → DB 캐시 확인 후 없으면 AI 호출
+    content = step.content
+    if content and content.mentoring:
+        return {
+            "is_required": False,
+            "step_id": step.id,
+            "name": step.name,
+            "mentoring": json.loads(content.mentoring) if content.mentoring else None,
+            "dictionary": json.loads(content.dictionary) if content.dictionary else None,
+        }
+
+    # AI 호출
+    payload = _build_side_panel_payload(db, step)
+    result = orchestrator.call_side_panel(payload)
+
+    # StepContent에 저장
+    if content is None:
+        content = StepContentModel(step_id=step.id)
+        db.add(content)
+
+    content.mentoring = json.dumps(result.get("mentoring"), ensure_ascii=False)  
+    content.dictionary = json.dumps(result.get("dictionary"), ensure_ascii=False)
+    db.commit()
+
+    return {
+        "is_required": False,
+        "step_id": step.id,
+        "name": step.name,
+        "mentoring": result.get("mentoring"),
+        "dictionary": result.get("dictionary"),
+    }
+
+
+def _build_side_panel_payload(db: Session, step: StepModel) -> SidePanelPayload:
+    project = step.project
+    stage = step.stage
+
+    accepted_steps = (
+        db.query(StepModel)
+        .filter(
+            StepModel.project_id == project.id,
+            StepModel.stage_id == stage.id,
+            StepModel.status == StepStatus.ACCEPTED,
+        )
+        .all()
+    )
+
+    all_required = (
+        db.query(RequiredStepModel)
+        .filter(RequiredStepModel.stage_id == stage.id)
+        .order_by(RequiredStepModel.sequence)
+        .all()
+    )
+    fulfilled_ids = {
+        row.required_step_id
+        for row in db.query(ProjectRequiredStepStatus).filter_by(
+            project_id=project.id, is_fulfilled=True
+        )
+    }
+
+    current_rs = next((rs for rs in all_required if rs.id not in fulfilled_ids), None)
+    current_required_step = None
+    if current_rs:
+        current_required_step = CurrentRequiredStep(
+            step_id=current_rs.id,
+            name=current_rs.name,
+            is_completed=False,
+            goal=current_rs.goal,
+            entry_criteria=current_rs.entry_criteria,
+            fulfillment_aspects=current_rs.fulfillment_aspects,
+            fulfillment_threshold=current_rs.fulfillment_threshold,
+        )
+
+    rag_results = retrieve(f"{stage.name} {step.name}")
+
+    return SidePanelPayload(
+        project_info=ProjectInfo(
+            project_id=project.id,
+            name=project.name,
+            duration_months=project.duration_month,
+            member_count=project.member_count,
+            description=project.description,
+            constraints=project.constraint_text,
+            initial_prompt=project.prompt,
+        ),
+        current_stage=CurrentStage(
+            stage_id=stage.id,
+            stage_number=stage.sequence,
+            name=stage.name,
+        ),
+        target_step=TargetStep(step_id=step.id, name=step.name),
+        decision_history=[
+            SidePanelDecisionHistoryItem(
+                step_id=s.id,
+                name=s.name,
+                status=s.status,
+                stage_number=stage.sequence,
+            )
+            for s in accepted_steps
+        ],
+        current_required_step=current_required_step,
+        rag_context={"results": rag_results},
+    )

--- a/backend/app/ai/services/step_service.py
+++ b/backend/app/ai/services/step_service.py
@@ -8,6 +8,21 @@ from app.core.exceptions import StepNotFoundError
 from app.core.models.step import Step as StepModel
 from app.core.models.step import StepTree as StepTreeModel
 from app.core.schemas.step import StepGenerateResponse, GeneratedStep
+from app.core.schemas.bedrock import (
+    AcceptPayload,
+    AcceptedStepItem,
+    CurrentRequiredStep,
+    CurrentStage,
+    ProjectInfo,
+    RequiredStepStatusItem,
+)
+from datetime import datetime, timezone
+from app.ai.services import orchestrator
+from app.core.exceptions import StepAlreadyAcceptedError
+from app.core.models.project_required_step_status import ProjectRequiredStepStatus
+from app.core.models.required_step import RequiredStep as RequiredStepModel
+from app.ai.services.rag import retrieve
+
 
 _EXAMPLE_STEP_NAMES = [
     "사용자 인터뷰 진행",
@@ -96,3 +111,162 @@ def generate_steps(db: Session, parent_step_id: uuid.UUID) -> StepGenerateRespon
             for s in steps
         ]
     )
+
+
+
+
+
+def accept_step(db: Session, step_id: uuid.UUID) -> dict:
+    # ① 조회 및 검증
+    step = db.get(StepModel, step_id)
+    if step is None:
+        raise StepNotFoundError()
+    if step.status == StepStatus.ACCEPTED:
+        raise StepAlreadyAcceptedError()
+
+    # ② ACCEPTED 처리
+    step.status = StepStatus.ACCEPTED
+
+    # ③ 형제 Step CANCELED
+    if step.parent_step_id is not None:
+        siblings = (
+            db.query(StepModel)
+            .filter(
+                StepModel.parent_step_id == step.parent_step_id,
+                StepModel.id != step_id,
+                StepModel.status == StepStatus.READY,
+            )
+            .all()
+        )
+        for sibling in siblings:
+            sibling.status = StepStatus.CANCELED
+
+    db.flush()
+
+    # ④ Bedrock 호출 (필수 Step 영역 안에 있을 때만)
+    is_completed = False
+    if step.belonging_required_step_id is not None:
+        
+        # DB에 이미 완료된 상태면 Bedrock 호출 스킵
+        existing = db.get(
+            ProjectRequiredStepStatus,
+            {"project_id": step.project_id, "required_step_id": step.belonging_required_step_id},
+        )
+        if existing and existing.is_fulfilled:
+            is_completed = True  # 이미 완료 → Bedrock 호출 안 함
+        else:
+            payload = _build_accept_payload(db, step)
+            result = orchestrator.call_accept(payload)
+            is_completed = result.get("is_current_required_step_completed", False)
+            if is_completed:
+                _upsert_required_step_status(
+                    db,
+                    project_id=step.project_id,
+                    required_step_id=step.belonging_required_step_id,
+                )
+
+    db.commit()
+
+    return {
+        "step_id": step_id,
+        "status": StepStatus.ACCEPTED,
+        "is_current_required_step_completed": is_completed,
+    }
+
+
+def _build_accept_payload(db: Session, step: StepModel) -> AcceptPayload:
+    project = step.project
+    stage = step.stage
+
+    all_required = (
+        db.query(RequiredStepModel)
+        .filter(RequiredStepModel.stage_id == stage.id)
+        .order_by(RequiredStepModel.sequence)
+        .all()
+    )
+    fulfilled_ids = {
+        row.required_step_id
+        for row in db.query(ProjectRequiredStepStatus).filter_by(
+            project_id=project.id, is_fulfilled=True
+        )
+    }
+
+    current_rs = db.get(RequiredStepModel, step.belonging_required_step_id)
+    current_required_step = None
+    if current_rs and current_rs.id not in fulfilled_ids:
+        current_required_step = CurrentRequiredStep(
+            step_id=current_rs.id,
+            name=current_rs.name,
+            is_completed=False,
+            goal=current_rs.goal,
+            entry_criteria=current_rs.entry_criteria,
+            fulfillment_aspects=current_rs.fulfillment_aspects,
+            fulfillment_threshold=current_rs.fulfillment_threshold,
+        )
+
+    accepted_in_required = (
+        db.query(StepModel)
+        .filter(
+            StepModel.project_id == project.id,
+            StepModel.belonging_required_step_id == step.belonging_required_step_id,
+            StepModel.status == StepStatus.ACCEPTED,
+        )
+        .all()
+    )
+    # rag_context: 현재 Stage + Step 이름으로 KB 검색
+    rag_results = retrieve(f"{stage.name} {step.name}")
+
+
+    return AcceptPayload(
+        project_info=ProjectInfo(
+            project_id=project.id,
+            name=project.name,
+            duration_months=project.duration_month,
+            member_count=project.member_count,
+            description=project.description,
+            constraints=project.constraint_text,
+            initial_prompt=project.prompt,
+        ),
+        current_stage=CurrentStage(
+            stage_id=stage.id,
+            stage_number=stage.sequence,
+            name=stage.name,
+        ),
+        required_steps_status=[
+            RequiredStepStatusItem(
+                name=rs.name,
+                order=rs.sequence,
+                is_completed=rs.id in fulfilled_ids,
+            )
+            for rs in all_required
+        ],
+        current_required_step=current_required_step,
+        accepted_steps_in_required=[
+            AcceptedStepItem(step_id=s.id, name=s.name)
+            for s in accepted_in_required
+        ],
+        accepted_step=AcceptedStepItem(
+            step_id=step.id,
+            name=step.name,
+        ),
+        rag_context={"results": rag_results},
+    )
+
+
+def _upsert_required_step_status(
+    db: Session,
+    project_id: uuid.UUID,
+    required_step_id: uuid.UUID,
+) -> None:
+    record = db.get(
+        ProjectRequiredStepStatus,
+        {"project_id": project_id, "required_step_id": required_step_id},
+    )
+    if record is None:
+        record = ProjectRequiredStepStatus(
+            project_id=project_id,
+            required_step_id=required_step_id,
+        )
+        db.add(record)
+    record.is_fulfilled = True
+    record.fulfilled_at = datetime.now(timezone.utc)

--- a/backend/app/core/schemas/bedrock.py
+++ b/backend/app/core/schemas/bedrock.py
@@ -1,0 +1,49 @@
+from uuid import UUID
+from pydantic import BaseModel
+
+
+class ProjectInfo(BaseModel):
+    project_id: UUID
+    name: str
+    duration_months: int | None
+    member_count: int | None
+    description: str | None
+    constraints: str | None
+    initial_prompt: str
+
+
+class CurrentStage(BaseModel):
+    stage_id: UUID
+    stage_number: int
+    name: str
+
+
+class RequiredStepStatusItem(BaseModel):
+    name: str
+    order: int
+    is_completed: bool
+
+
+class CurrentRequiredStep(BaseModel):
+    step_id: UUID
+    name: str
+    is_completed: bool
+    goal: str
+    entry_criteria: str
+    fulfillment_aspects: list[str]
+    fulfillment_threshold: int
+
+
+class AcceptedStepItem(BaseModel):
+    step_id: UUID
+    name: str
+
+
+class AcceptPayload(BaseModel):
+    project_info: ProjectInfo
+    current_stage: CurrentStage
+    required_steps_status: list[RequiredStepStatusItem]
+    current_required_step: CurrentRequiredStep | None
+    accepted_steps_in_required: list[AcceptedStepItem]
+    accepted_step: AcceptedStepItem
+    rag_context: dict = {}

--- a/backend/app/core/schemas/bedrock.py
+++ b/backend/app/core/schemas/bedrock.py
@@ -47,3 +47,17 @@ class AcceptPayload(BaseModel):
     accepted_steps_in_required: list[AcceptedStepItem]
     accepted_step: AcceptedStepItem
     rag_context: dict = {}
+
+class DecisionHistoryItem(BaseModel):
+    step_id: UUID
+    name: str
+    status: str 
+
+
+class GeneratePayload(BaseModel):
+    project_info: ProjectInfo
+    current_stage: CurrentStage
+    current_required_step: CurrentRequiredStep | None
+    decision_history: list[DecisionHistoryItem]
+    current_step: AcceptedStepItem               # 방금 accept된 부모 step
+    rag_context: dict = {}

--- a/backend/app/core/schemas/bedrock.py
+++ b/backend/app/core/schemas/bedrock.py
@@ -61,3 +61,23 @@ class GeneratePayload(BaseModel):
     decision_history: list[DecisionHistoryItem]
     current_step: AcceptedStepItem               # 방금 accept된 부모 step
     rag_context: dict = {}
+
+class TargetStep(BaseModel):
+    step_id: UUID
+    name: str
+
+
+class SidePanelDecisionHistoryItem(BaseModel):
+    step_id: UUID
+    name: str
+    status: str
+    stage_number: int
+
+
+class SidePanelPayload(BaseModel):
+    project_info: ProjectInfo
+    current_stage: CurrentStage
+    target_step: TargetStep
+    decision_history: list[SidePanelDecisionHistoryItem]
+    current_required_step: CurrentRequiredStep | None
+    rag_context: dict = {}


### PR DESCRIPTION
## 구현 내용

### POST /steps/{step_id}/accept
- Bedrock Claude 호출로 필수 Step 완료 여부 판단
- 필수 Step 영역 밖이면 Bedrock 호출 스킵
- 이미 완료된 필수 Step은 DB 확인 후 스킵
- 완료 시 ProjectRequiredStepStatus 업데이트

### POST /steps/{step_id}/generate
- Bedrock Claude 호출로 일반 Step 이름 3개 생성
- 다음 미완료 필수 Step 노드 자동 포함 (재사용 또는 신규 생성)
- 필수 Step 영역 안에 있을 때는 필수 노드 추가 안 함
- 클로저 테이블 재구성 로직 포함

### GET /steps/{step_id}
- 필수 Step: StepContent DB에서 바로 반환
- 일반 Step: StepContent 캐시 확인 후 없으면 Bedrock AI 호출
- AI 생성 결과 StepContent에 저장

## 추가된 파일
- `app/core/schemas/bedrock.py` — AI 페이로드 Pydantic 스키마

## Known Issues
- 브랜치 분기 시 동일 Stage에서 필수 Step 중복 판단 문제 (추후 롤백 API 설계 후 수정 예정)