### PR TITLE
[#21][BE] Naver OAuth Provider 추가

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,11 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=
 
+# Naver OAuth — Naver Developers(https://developers.naver.com)에 Callback URL 등록 필요
+NAVER_CLIENT_ID=
+NAVER_CLIENT_SECRET=
+NAVER_REDIRECT_URI=
+
 # OAuth 콜백 후 프론트엔드로 리다이렉트할 URL
 FRONTEND_REDIRECT_URL=
 CORS_ALLOWED_ORIGINS=["*"]

--- a/backend/app/business/auth/providers/__init__.py
+++ b/backend/app/business/auth/providers/__init__.py
@@ -1,10 +1,12 @@
 from app.business.auth.providers.base import OAuthProviderClient
 from app.business.auth.providers.google import GoogleOAuthProvider
+from app.business.auth.providers.naver import NaverOAuthProvider
 from app.core.enums import OAuthProvider
 from app.core.exceptions import UnsupportedOAuthProviderError
 
 _PROVIDERS: dict[OAuthProvider, OAuthProviderClient] = {
     OAuthProvider.GOOGLE: GoogleOAuthProvider(),
+    OAuthProvider.NAVER: NaverOAuthProvider(),
 }
 
 

--- a/backend/app/business/auth/providers/naver.py
+++ b/backend/app/business/auth/providers/naver.py
@@ -1,0 +1,94 @@
+import secrets
+from urllib.parse import urlencode
+
+import httpx
+
+from app.business.auth.providers.base import OAuthProviderClient
+from app.core.config import settings
+from app.core.enums import OAuthProvider
+from app.core.exceptions import OAuthAuthorizationError
+from app.core.schemas.auth import OAuthTokens, OAuthUserInfo
+
+NAVER_AUTH_URL = "https://nid.naver.com/oauth2.0/authorize"
+NAVER_TOKEN_URL = "https://nid.naver.com/oauth2.0/token"
+NAVER_USERINFO_URL = "https://openapi.naver.com/v1/nid/me"
+
+
+class NaverOAuthProvider(OAuthProviderClient):
+    @property
+    def name(self) -> str:
+        return OAuthProvider.NAVER.value
+
+    def get_authorization_url(self, state: str | None = None) -> str:
+        # 네이버는 state 파라미터가 필수. 호출자가 안 넘기면 안전한 랜덤값으로 자동 생성.
+        params = {
+            "response_type": "code",
+            "client_id": settings.NAVER_CLIENT_ID,
+            "redirect_uri": settings.NAVER_REDIRECT_URI,
+            "state": state or secrets.token_urlsafe(16),
+        }
+        return f"{NAVER_AUTH_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str) -> OAuthTokens:
+        try:
+            with httpx.Client(timeout=10.0) as client:
+                resp = client.post(
+                    NAVER_TOKEN_URL,
+                    data={
+                        "grant_type": "authorization_code",
+                        "client_id": settings.NAVER_CLIENT_ID,
+                        "client_secret": settings.NAVER_CLIENT_SECRET,
+                        "code": code,
+                        # 네이버는 토큰 교환 시에도 state를 요구하지만, 별도 검증을 하지 않으므로
+                        # 자리 채움용 임의값을 보내도 무방하다.
+                        "state": "exchange",
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPError as e:
+            raise OAuthAuthorizationError(f"Naver 토큰 교환 실패: {e}")
+
+        # 네이버 에러 응답은 200으로 오면서 본문에 error 필드를 담아 반환하기도 함.
+        if "error" in data:
+            raise OAuthAuthorizationError(
+                f"Naver 토큰 교환 실패: {data.get('error_description') or data['error']}"
+            )
+
+        expires_in = data.get("expires_in")
+        return OAuthTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token"),
+            expires_in=int(expires_in) if expires_in is not None else None,
+        )
+
+    def get_user_info(self, access_token: str) -> OAuthUserInfo:
+        try:
+            with httpx.Client(timeout=10.0) as client:
+                resp = client.get(
+                    NAVER_USERINFO_URL,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPError as e:
+            raise OAuthAuthorizationError(f"Naver 사용자 정보 조회 실패: {e}")
+
+        # 네이버 응답 형식: {"resultcode": "00", "message": "success", "response": {...}}
+        if data.get("resultcode") != "00":
+            raise OAuthAuthorizationError(
+                f"Naver 사용자 정보 조회 실패: {data.get('message')}"
+            )
+
+        profile = data.get("response") or {}
+        email = profile.get("email", "")
+        nickname = (
+            profile.get("nickname")
+            or profile.get("name")
+            or (email.split("@")[0] if email else "")
+        )
+        return OAuthUserInfo(
+            provider_user_id=str(profile["id"]),
+            email=email,
+            nickname=nickname,
+        )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -35,6 +35,11 @@ class Settings(BaseSettings):
     GOOGLE_CLIENT_SECRET: str = ""
     GOOGLE_REDIRECT_URI: str = ""
 
+    # Naver OAuth
+    NAVER_CLIENT_ID: str = ""
+    NAVER_CLIENT_SECRET: str = ""
+    NAVER_REDIRECT_URI: str = ""
+
     # 프론트엔드 OAuth 콜백 URL
     FRONTEND_REDIRECT_URL: str = "http://localhost/auth/callback"
 


### PR DESCRIPTION
## PR 요약
- Google에 이어 Naver OAuth 로그인 지원 추가

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `NaverOAuthProvider` 신규 구현 (state 자동 생성, response 응답 구조 처리)
- Provider 레지스트리에 NAVER 등록
- `.env`/`.env.example`에 `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET`, `NAVER_REDIRECT_URI` 추가

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행 (해당 없음)
- [x] 불필요한 코드 및 주석 제거
- [x] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- Naver Developers에 애플리케이션 등록 후 Callback URL을 `NAVER_REDIRECT_URI`와 동일하게 설정 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)