### PR TITLE
[#57][AI] optional 테스트 + side_panel 2탭 구조 + Haiku 4.5 전환

### DIFF
--- a/ai/config.py
+++ b/ai/config.py
@@ -16,7 +16,7 @@ class AISettings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     AWS_REGION: str = "us-east-1"
-    MODEL_ID: str = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+    MODEL_ID: str = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
     KB_ID: str = ""
     MAX_TOKENS: int = 4096
     TEMPERATURE: float = 0.7

--- a/ai/prompts/side_panel.txt
+++ b/ai/prompts/side_panel.txt
@@ -2,7 +2,7 @@
 
 당신은 미국 법무부 소프트웨어 개발 생명주기 가이드(DOJ SDLC)를 기반으로 소프트웨어 프로젝트를 안내하는 AI 멘토다. 사용자는 소프트웨어 개발 경험이 많지 않은 대학생 또는 사이드 프로젝트 개발자다.
 
-이번 호출의 목적은 사용자가 클릭한 **일반 Step의 사이드패널 콘텐츠**를 생성하는 것이다. 사이드패널은 Step을 클릭했을 때 화면 우측에 열리는 가이드 패널이며, 사용자가 그 Step을 어떻게 진행할지 즉시 이해하도록 돕는다.
+이번 호출의 목적은 사용자가 클릭한 **일반 Step의 사이드패널 콘텐츠**를 생성하는 것이다. 사이드패널은 Step을 클릭했을 때 화면 우측에 열리는 가이드 패널이며, **멘토링 탭**과 **용어 사전 탭** 2개로 구성된다.
 
 > 필수 Step의 사이드패널은 DB에 사전 제작되어 있어 AI가 생성하지 않는다. 이 호출은 일반 Step 전용이다.
 
@@ -18,44 +18,61 @@
 **오직 다음 JSON 한 덩어리만** 반환한다. 설명·서론·마무리·코드 펜스(```) 없이 순수 JSON만 출력한다.
 
 {{
-  "description": "...",
-  "recommended_methods": [
-    {{ "title": "...", "content": "..." }},
-    {{ "title": "...", "content": "..." }}
-  ],
-  "common_mistakes": [
-    {{ "mistake": "...", "bad_example": "...", "good_example": "..." }},
-    {{ "mistake": "...", "bad_example": "...", "good_example": "..." }}
-  ],
-  "one_line_tip": "..."
+  "mentoring": {{
+    "description": "...",
+    "recommended_methods": [
+      {{ "title": "...", "content": "..." }},
+      {{ "title": "...", "content": "..." }}
+    ],
+    "common_mistakes": [
+      {{ "mistake": "...", "bad_example": "...", "good_example": "..." }},
+      {{ "mistake": "...", "bad_example": "...", "good_example": "..." }}
+    ],
+    "one_line_tip": "..."
+  }},
+  "dictionary": [
+    {{ "term": "...", "definition": "..." }},
+    {{ "term": "...", "definition": "..." }}
+  ]
 }}
 
 규칙:
-- 위 4개 키만 사용한다. 추가 키 금지.
+- 최상위 키는 정확히 `mentoring`과 `dictionary` 두 개. 추가 키 금지.
+- `mentoring` 객체 내부 키는 정확히 `description`, `recommended_methods`, `common_mistakes`, `one_line_tip` 네 개.
+- `dictionary` 배열의 각 항목은 정확히 `term`, `definition` 두 키만 갖는다.
 - 모든 값은 한국어 문자열.
 
-# 각 필드 작성 가이드
+# `mentoring` 탭 — 각 필드 작성 가이드
 
-## 📖 `description`
+## 📖 `mentoring.description`
 - **3~5문장**.
 - 이 Step에서 무엇을 하는지 + 왜 중요한지가 자연스럽게 이어지도록.
 - 사용자가 "아, 이걸 왜 해야 하는지" 한 번에 이해되어야 한다.
 
-## 🔥 `recommended_methods` (배열, 2~4개)
+## 🔥 `mentoring.recommended_methods` (배열, 2~4개)
 각 항목은 정확히 두 키 `title`, `content`로만 구성한다.
 - `title`: 방법의 이름. **10~15자** 한국어. (예: "경쟁 서비스 찾아보기", "사용자 리뷰 모으기")
 - `content`: 구체적인 실행 방법을 **2~3문장**으로. "어떻게 하는가"가 분명히 드러나야 하며, 가능하면 도구·산출물·진행 단계가 등장하도록 한다.
 - 초보자가 **당장 시도해볼 수 있는 실용 기법**만 담는다. 고급·이론적 기법은 피한다.
 
-## ⚠️ `common_mistakes` (배열, 2~3개)
+## ⚠️ `mentoring.common_mistakes` (배열, 2~3개)
 각 항목은 정확히 세 키 `mistake`, `bad_example`, `good_example`로만 구성한다.
 - `mistake`: 자주 하는 실수를 한 줄로.
 - `bad_example`: ❌ 그 실수가 실제로 어떻게 나타나는지 짧고 구체적인 예. 한 문장이면 가장 좋다.
 - `good_example`: ✅ **같은 상황**을 올바르게 처리한 예. 비교가 되도록 bad_example과 같은 주제·맥락을 다룬다.
 
-## 💡 `one_line_tip`
+## 💡 `mentoring.one_line_tip`
 - 이 Step의 본질을 압축한 **한 문장**의 핵심 조언.
 - "꼭 기억해야 할 단 하나"를 담는다.
+
+# `dictionary` 탭 — 용어 사전 작성 가이드
+
+## 📚 `dictionary` (배열, 2~4개)
+- 이 Step을 수행하는 데 **필요한 핵심 용어 2~4개**를 골라 `term` + `definition`으로 생성한다.
+- 초보자가 모를 수 있는 **소프트웨어 공학 용어 위주**로 선정한다 (예: 페르소나, MVP, 와이어프레임, 사용자 스토리, 기능 명세, 기술 부채 등).
+- `term`: 용어 그 자체. 한국어 또는 한국어(영문) 표기. (예: "페르소나", "MVP(Minimum Viable Product)")
+- `definition`: **1~2문장**의 초보자용 정의. 학술적 정의가 아니라 "이 Step에서 왜 이 단어가 등장하는지"가 드러나는 실용 설명. 또 다른 어려운 용어로 정의하지 않는다.
+- 사이드패널의 다른 부분에서 쓰인 용어 중 풀이가 필요한 것을 우선 포함한다.
 
 # 콘텐츠 생성 원칙
 
@@ -64,6 +81,7 @@
 3. **프로젝트 맥락 반영** — 기간(`{duration_months}`개월), 인원(`{member_count}`명), 제약사항을 고려해 **실제로 실행 가능한 범위**만 추천한다. 짧은 일정에 몇 달 걸릴 활동을 제안하지 않는다.
 4. **현재 필수 Step과의 정합성** — 진행 중인 필수 Step이 있으면, 이 Step이 그 필수 Step의 충족(`fulfillment_criteria`)에 어떻게 기여하는지가 자연스럽게 드러나도록 작성한다.
 5. **히스토리 활용** — 의사결정 히스토리에 이미 Accept된 Step에서 다룬 내용은 중복 설명하지 말고, 그 위에서 한 걸음 나아가는 식으로 연결한다.
+6. **두 탭의 정합성** — `dictionary`에 담는 용어는 `mentoring` 탭의 description/recommended_methods/common_mistakes에서 등장한 용어 중 풀이가 필요한 것을 우선으로 한다.
 
 ---
 

--- a/ai/schemas/__init__.py
+++ b/ai/schemas/__init__.py
@@ -4,7 +4,9 @@ from ai.schemas.accept import AcceptInput, AcceptOutput
 from ai.schemas.common import (
     CommonMistake,
     DecisionHistoryItem,
+    DictionaryItem,
     GeneratedStep,
+    MentoringContent,
     ProjectInfo,
     RecommendedMethod,
     RequiredStepInfo,
@@ -28,6 +30,8 @@ __all__ = [
     "RecommendedMethod",
     "CommonMistake",
     "RetrievedChunk",
+    "MentoringContent",
+    "DictionaryItem",
     # generate
     "GenerateInput",
     "GenerateOutput",

--- a/ai/schemas/common.py
+++ b/ai/schemas/common.py
@@ -91,3 +91,19 @@ class RetrievedChunk(BaseModel):
 
     text: str
     relevance_score: float
+
+
+class MentoringContent(BaseModel):
+    """사이드패널 멘토링 탭 콘텐츠."""
+
+    description: str
+    recommended_methods: list[RecommendedMethod]
+    common_mistakes: list[CommonMistake]
+    one_line_tip: str
+
+
+class DictionaryItem(BaseModel):
+    """사이드패널 용어 사전 항목."""
+
+    term: str
+    definition: str

--- a/ai/schemas/side_panel.py
+++ b/ai/schemas/side_panel.py
@@ -1,7 +1,8 @@
 """side_panel 시나리오 입출력 스키마 — AI Dataset Spec v3.1 기반.
 
 일반 Step 사이드패널 콘텐츠 동적 생성:
-description + recommended_methods + common_mistakes + one_line_tip.
+mentoring 탭(description + recommended_methods + common_mistakes + one_line_tip)
++ dictionary 탭(term + definition 항목 목록).
 """
 
 from typing import Any, Optional
@@ -9,10 +10,10 @@ from typing import Any, Optional
 from pydantic import BaseModel
 
 from ai.schemas.common import (
-    CommonMistake,
     DecisionHistoryItem,
+    DictionaryItem,
+    MentoringContent,
     ProjectInfo,
-    RecommendedMethod,
     RequiredStepInfo,
     StageInfo,
     StepInfo,
@@ -31,9 +32,7 @@ class SidePanelInput(BaseModel):
 
 
 class SidePanelOutput(BaseModel):
-    """side_panel 시나리오 출력 — 일반 Step용."""
+    """side_panel 시나리오 출력 — 일반 Step용 (mentoring + dictionary 2탭 구조)."""
 
-    description: str
-    recommended_methods: list[RecommendedMethod]
-    common_mistakes: list[CommonMistake]
-    one_line_tip: str
+    mentoring: MentoringContent
+    dictionary: list[DictionaryItem]

--- a/ai/tests/test_config.py
+++ b/ai/tests/test_config.py
@@ -11,7 +11,7 @@ class TestAISettings:
     def test_default_values(self):
         settings = AISettings(_env_file=None)
         assert settings.AWS_REGION == "us-east-1"
-        assert settings.MODEL_ID == "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        assert settings.MODEL_ID == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
         assert settings.KB_ID == ""
         assert settings.MAX_TOKENS == 4096
         assert settings.TEMPERATURE == 0.7

--- a/ai/tests/test_llm_client_property.py
+++ b/ai/tests/test_llm_client_property.py
@@ -1,0 +1,109 @@
+"""hypothesis 기반 LLMClient property 테스트."""
+
+import io
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ai.clients.llm import LLMClient
+from ai.exceptions import AIGenerationFailedError
+from ai.schemas.accept import AcceptOutput
+from ai.schemas.common import (
+    CommonMistake,
+    DictionaryItem,
+    GeneratedStep,
+    MentoringContent,
+    RecommendedMethod,
+)
+from ai.schemas.generate import GenerateOutput
+from ai.schemas.side_panel import SidePanelOutput
+
+_nonempty = st.text(min_size=1)
+
+_generated_step_st = st.builds(GeneratedStep, name=_nonempty, description=_nonempty)
+_recommended_method_st = st.builds(RecommendedMethod, title=_nonempty, content=_nonempty)
+_common_mistake_st = st.builds(
+    CommonMistake, mistake=_nonempty, bad_example=_nonempty, good_example=_nonempty
+)
+
+_generate_output_st = st.builds(
+    GenerateOutput,
+    generated_steps=st.lists(_generated_step_st, min_size=3, max_size=3),
+)
+_accept_output_st = st.builds(AcceptOutput, is_current_required_step_completed=st.booleans())
+_dictionary_item_st = st.builds(DictionaryItem, term=_nonempty, definition=_nonempty)
+_mentoring_content_st = st.builds(
+    MentoringContent,
+    description=_nonempty,
+    recommended_methods=st.lists(_recommended_method_st, min_size=0, max_size=5),
+    common_mistakes=st.lists(_common_mistake_st, min_size=0, max_size=5),
+    one_line_tip=_nonempty,
+)
+_side_panel_output_st = st.builds(
+    SidePanelOutput,
+    mentoring=_mentoring_content_st,
+    dictionary=st.lists(_dictionary_item_st, min_size=0, max_size=5),
+)
+
+
+# ---------------------------------------------------------------------------
+# Property 1: 직렬화 → 파싱 라운드트립
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(output=_generate_output_st)
+def test_generate_output_roundtrip(output: GenerateOutput):
+    payload = json.loads(output.model_dump_json())
+    restored = GenerateOutput.model_validate(payload)
+    assert restored == output
+
+
+@settings(max_examples=100)
+@given(output=_accept_output_st)
+def test_accept_output_roundtrip(output: AcceptOutput):
+    payload = json.loads(output.model_dump_json())
+    restored = AcceptOutput.model_validate(payload)
+    assert restored == output
+
+
+@settings(max_examples=100)
+@given(output=_side_panel_output_st)
+def test_side_panel_output_roundtrip(output: SidePanelOutput):
+    payload = json.loads(output.model_dump_json())
+    restored = SidePanelOutput.model_validate(payload)
+    assert restored == output
+
+
+# ---------------------------------------------------------------------------
+# Property 2: 스키마 불일치 시 재시도 일관성
+# ---------------------------------------------------------------------------
+
+
+def _schema_mismatch_bedrock_mock() -> MagicMock:
+    """invoke_model이 항상 빈 dict {}를 content[0].text로 반환하는 mock."""
+
+    def _response(**_):
+        envelope = {"content": [{"type": "text", "text": json.dumps({})}]}
+        return {"body": io.BytesIO(json.dumps(envelope).encode())}
+
+    mock = MagicMock()
+    mock.invoke_model.side_effect = _response
+    return mock
+
+
+@settings(max_examples=100)
+@given(st.data())
+def test_schema_mismatch_retry_count_and_failure(data):
+    bedrock_mock = _schema_mismatch_bedrock_mock()
+    client = LLMClient(bedrock_client=bedrock_mock, model_id="test-model")
+
+    import asyncio
+
+    with pytest.raises(AIGenerationFailedError):
+        asyncio.run(client.invoke("{}", GenerateOutput, max_retries=2))
+
+    assert bedrock_mock.invoke_model.call_count == 3

--- a/ai/tests/test_logging_property.py
+++ b/ai/tests/test_logging_property.py
@@ -1,0 +1,91 @@
+"""hypothesis 기반 LLMClient 로깅 property 테스트.
+
+Property 8: 요청별 correlation_id 일관성
+"""
+
+import asyncio
+import io
+import json
+import logging
+from unittest.mock import MagicMock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ai.clients.llm import LLMClient
+from ai.schemas.accept import AcceptOutput
+
+
+def _make_bedrock_mock(payload: dict) -> MagicMock:
+    """주어진 payload를 Bedrock 응답 형식으로 반환하는 mock (호출마다 새 BytesIO)."""
+    envelope = {"content": [{"type": "text", "text": json.dumps(payload)}]}
+    raw = json.dumps(envelope).encode()
+
+    mock = MagicMock()
+    mock.invoke_model.side_effect = lambda **_: {"body": io.BytesIO(raw)}
+    return mock
+
+
+def _capture_logs(client: LLMClient) -> tuple[list[dict], list[dict]]:
+    """두 번 invoke를 실행하고 각 호출에서 캡처된 로그 레코드 목록을 반환."""
+    log_records_1: list[str] = []
+    log_records_2: list[str] = []
+
+    class _Collector(logging.Handler):
+        def __init__(self, target: list[str]) -> None:
+            super().__init__()
+            self._target = target
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self._target.append(record.getMessage())
+
+    llm_logger = logging.getLogger("ai.clients.llm")
+    llm_logger.setLevel(logging.DEBUG)
+
+    handler1 = _Collector(log_records_1)
+    llm_logger.addHandler(handler1)
+    asyncio.run(client.invoke("{}", AcceptOutput))
+    llm_logger.removeHandler(handler1)
+
+    handler2 = _Collector(log_records_2)
+    llm_logger.addHandler(handler2)
+    asyncio.run(client.invoke("{}", AcceptOutput))
+    llm_logger.removeHandler(handler2)
+
+    def _parse(records: list[str]) -> list[dict]:
+        result = []
+        for msg in records:
+            try:
+                result.append(json.loads(msg))
+            except json.JSONDecodeError:
+                pass
+        return result
+
+    return _parse(log_records_1), _parse(log_records_2)
+
+
+# Property 8: 요청별 correlation_id 일관성
+@settings(max_examples=100)
+@given(st.data())
+def test_correlation_id_consistency(_data):
+    valid_payload = {"is_current_required_step_completed": True}
+    bedrock_mock = _make_bedrock_mock(valid_payload)
+    client = LLMClient(bedrock_client=bedrock_mock, model_id="test-model")
+
+    logs1, logs2 = _capture_logs(client)
+
+    # 각 호출에 로그가 존재해야 함
+    assert len(logs1) >= 2  # at least llm_invoke_start + llm_invoke_success
+    assert len(logs2) >= 2
+
+    # 단일 요청 내 모든 로그 엔트리에 동일한 correlation_id가 있어야 함
+    ids1 = {entry["correlation_id"] for entry in logs1 if "correlation_id" in entry}
+    ids2 = {entry["correlation_id"] for entry in logs2 if "correlation_id" in entry}
+
+    assert len(ids1) == 1, f"1회 invoke에서 correlation_id가 여러 개: {ids1}"
+    assert len(ids2) == 1, f"2회 invoke에서 correlation_id가 여러 개: {ids2}"
+
+    # 서로 다른 호출의 correlation_id는 달라야 함
+    cid1 = ids1.pop()
+    cid2 = ids2.pop()
+    assert cid1 != cid2, "서로 다른 invoke 호출이 동일한 correlation_id를 공유함"

--- a/ai/tests/test_prompt_template_property.py
+++ b/ai/tests/test_prompt_template_property.py
@@ -1,0 +1,41 @@
+"""hypothesis 기반 PromptTemplate property 테스트."""
+
+import re
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ai.prompts.template import PromptTemplate
+
+# 유효한 Python 식별자 전략 (format_map 키로 사용 가능)
+_identifier = st.from_regex(r"[a-z][a-z0-9_]{0,9}", fullmatch=True)
+_value = st.text(min_size=1, max_size=30).filter(lambda s: "{" not in s and "}" not in s)
+
+
+@settings(max_examples=100)
+@given(
+    prefix=st.text(max_size=20).filter(lambda s: "{" not in s and "}" not in s),
+    suffix=st.text(max_size=20).filter(lambda s: "{" not in s and "}" not in s),
+    var_items=st.lists(
+        st.tuples(_identifier, _value),
+        min_size=1,
+        max_size=5,
+    ),
+)
+def test_prompt_template_render_substitution_completeness(prefix, suffix, var_items):
+    # 중복 키 제거 (마지막 값 우선)
+    variables = dict(var_items)
+
+    # {var_name} 플레이스홀더를 포함한 템플릿 구성
+    placeholders = "".join(f"{{{name}}}" for name in variables)
+    template = prefix + placeholders + suffix
+
+    result = PromptTemplate.render(template, **variables)
+
+    # 미치환 플레이스홀더가 남아있지 않아야 한다
+    remaining = re.findall(r"\{[a-z][a-z0-9_]*\}", result)
+    assert remaining == [], f"미치환 플레이스홀더 발견: {remaining}"
+
+    # 모든 변수 값이 결과에 포함되어야 한다
+    for value in variables.values():
+        assert value in result, f"변수 값 '{value}'이 결과에 없음"

--- a/ai/tests/test_required_step_judge_property.py
+++ b/ai/tests/test_required_step_judge_property.py
@@ -1,0 +1,115 @@
+"""hypothesis 기반 RequiredStepJudge property 테스트."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ai.schemas.accept import AcceptInput, AcceptOutput
+from ai.schemas.common import (
+    ProjectInfo,
+    RequiredStepInfo,
+    RequiredStepStatus,
+    StageInfo,
+    StepInfo,
+)
+from ai.services.required_step_judge import RequiredStepJudge
+
+_safe_text = st.text(
+    alphabet=st.characters(
+        blacklist_categories=("C",),
+        blacklist_characters='"\\{}',
+    ),
+    min_size=1,
+    max_size=40,
+)
+
+_step_id = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz0123456789",
+    min_size=1,
+    max_size=8,
+)
+
+_project_st = st.builds(
+    ProjectInfo,
+    project_id=_step_id,
+    duration_months=st.integers(min_value=1, max_value=24),
+    member_count=st.integers(min_value=1, max_value=10),
+    initial_prompt=_safe_text,
+    name=st.just(None),
+    description=st.just(None),
+    constraints=st.just(None),
+)
+
+_stage_st = st.builds(
+    StageInfo,
+    stage_id=_step_id,
+    stage_number=st.integers(min_value=1, max_value=6),
+    name=_safe_text,
+)
+
+_required_step_st = st.builds(
+    RequiredStepInfo,
+    step_id=_step_id,
+    name=_safe_text,
+    is_completed=st.booleans(),
+    goal=_safe_text,
+    entry_criteria=_safe_text,
+    fulfillment_criteria=st.lists(_safe_text, min_size=1, max_size=5),
+    minimum_fulfillment_count=st.integers(min_value=1, max_value=3),
+)
+
+_step_info_st = st.builds(StepInfo, step_id=_step_id, name=_safe_text)
+
+_required_step_status_st = st.builds(
+    RequiredStepStatus,
+    name=_safe_text,
+    order=st.integers(min_value=1, max_value=4),
+    is_completed=st.booleans(),
+)
+
+_accept_input_st = st.builds(
+    AcceptInput,
+    project_info=_project_st,
+    current_stage=_stage_st,
+    required_steps_status=st.lists(_required_step_status_st, min_size=0, max_size=4),
+    current_required_step=_required_step_st,
+    accepted_steps_in_required=st.lists(_step_info_st, min_size=1, max_size=5),
+    accepted_step=_step_info_st,
+    rag_context=st.just(None),
+)
+
+
+def _make_service(result: bool) -> tuple[RequiredStepJudge, MagicMock]:
+    llm = MagicMock()
+    llm.invoke = AsyncMock(return_value=AcceptOutput(is_current_required_step_completed=result))
+    return RequiredStepJudge(llm=llm), llm
+
+
+@settings(max_examples=100)
+@given(input_data=_accept_input_st, llm_result=st.booleans())
+def test_accept_prompt_completeness_and_output_type(
+    input_data: AcceptInput, llm_result: bool
+):
+    service, llm = _make_service(llm_result)
+
+    result = asyncio.run(service.judge_required_step(input_data))
+
+    # 반환값이 AcceptOutput boolean 타입인지 확인
+    assert isinstance(result, AcceptOutput)
+    assert isinstance(result.is_current_required_step_completed, bool)
+
+    prompt: str = llm.invoke.await_args.args[0]
+
+    # 1) fulfillment_criteria 각 항목이 프롬프트에 포함되는지
+    for aspect in input_data.current_required_step.fulfillment_criteria:
+        assert aspect in prompt, f"aspect 누락: {aspect!r}"
+
+    # 2) minimum_fulfillment_count 값이 프롬프트에 포함되는지
+    threshold = input_data.current_required_step.minimum_fulfillment_count
+    assert str(threshold) in prompt, f"threshold {threshold} 누락"
+
+    # 3) accepted_steps_in_required의 모든 Step name이 포함되는지
+    for step in input_data.accepted_steps_in_required:
+        assert step.name in prompt, f"step name 누락: {step.name!r}"

--- a/ai/tests/test_schemas.py
+++ b/ai/tests/test_schemas.py
@@ -1,0 +1,466 @@
+"""ai/schemas/ 단위 테스트."""
+
+import pytest
+from pydantic import ValidationError
+
+from ai.schemas.accept import AcceptInput, AcceptOutput
+from ai.schemas.common import (
+    CommonMistake,
+    DecisionHistoryItem,
+    DictionaryItem,
+    GeneratedStep,
+    MentoringContent,
+    ProjectInfo,
+    RecommendedMethod,
+    RequiredStepInfo,
+    RequiredStepStatus,
+    RetrievedChunk,
+    StageInfo,
+    StepInfo,
+)
+from ai.schemas.generate import GenerateInput, GenerateOutput
+from ai.schemas.side_panel import SidePanelInput, SidePanelOutput
+
+# ---------------------------------------------------------------------------
+# Fixtures — 재사용 가능한 최소 유효 데이터
+# ---------------------------------------------------------------------------
+
+PROJECT_INFO = {
+    "project_id": "proj-1",
+    "duration_months": 6,
+    "member_count": 4,
+    "initial_prompt": "쇼핑몰 개발",
+}
+
+STAGE_INFO = {
+    "stage_id": "stage-1",
+    "stage_number": 1,
+    "name": "요구사항 분석",
+}
+
+STEP_INFO = {"step_id": "step-1", "name": "요구사항 수집"}
+
+REQUIRED_STEP_INFO = {
+    "step_id": "rs-1",
+    "name": "기능 명세 작성",
+    "is_completed": False,
+    "goal": "기능 명세 완성",
+    "entry_criteria": "프로젝트 킥오프 완료",
+    "fulfillment_criteria": ["측면A", "측면B", "측면C"],
+    "minimum_fulfillment_count": 2,
+}
+
+GENERATED_STEP = {"name": "설계 단계", "description": "시스템 설계를 수행한다"}
+
+
+# ---------------------------------------------------------------------------
+# common.py
+# ---------------------------------------------------------------------------
+
+
+class TestProjectInfo:
+    def test_valid(self):
+        m = ProjectInfo(**PROJECT_INFO)
+        assert m.project_id == "proj-1"
+        assert m.name is None
+
+    def test_optional_fields_accepted(self):
+        m = ProjectInfo(**PROJECT_INFO, name="Poco", description="설명", constraints="제약")
+        assert m.name == "Poco"
+
+    @pytest.mark.parametrize("missing", ["project_id", "duration_months", "member_count", "initial_prompt"])
+    def test_missing_required_field(self, missing):
+        data = {k: v for k, v in PROJECT_INFO.items() if k != missing}
+        with pytest.raises(ValidationError):
+            ProjectInfo(**data)
+
+
+class TestStageInfo:
+    def test_valid(self):
+        m = StageInfo(**STAGE_INFO)
+        assert m.stage_number == 1
+
+    @pytest.mark.parametrize("missing", ["stage_id", "stage_number", "name"])
+    def test_missing_required_field(self, missing):
+        data = {k: v for k, v in STAGE_INFO.items() if k != missing}
+        with pytest.raises(ValidationError):
+            StageInfo(**data)
+
+
+class TestStepInfo:
+    def test_valid(self):
+        m = StepInfo(**STEP_INFO)
+        assert m.step_id == "step-1"
+
+    @pytest.mark.parametrize("missing", ["step_id", "name"])
+    def test_missing_required_field(self, missing):
+        data = {k: v for k, v in STEP_INFO.items() if k != missing}
+        with pytest.raises(ValidationError):
+            StepInfo(**data)
+
+
+class TestDecisionHistoryItem:
+    def test_valid(self):
+        m = DecisionHistoryItem(step_id="s1", name="분석", status="accepted")
+        assert m.stage_number is None
+
+    def test_missing_status(self):
+        with pytest.raises(ValidationError):
+            DecisionHistoryItem(step_id="s1", name="분석")
+
+
+class TestRequiredStepInfo:
+    def test_valid(self):
+        m = RequiredStepInfo(**REQUIRED_STEP_INFO)
+        assert len(m.fulfillment_criteria) == 3
+        assert m.minimum_fulfillment_count == 2
+
+    @pytest.mark.parametrize(
+        "missing",
+        ["step_id", "name", "is_completed", "goal", "entry_criteria", "fulfillment_criteria", "minimum_fulfillment_count"],
+    )
+    def test_missing_required_field(self, missing):
+        data = {k: v for k, v in REQUIRED_STEP_INFO.items() if k != missing}
+        with pytest.raises(ValidationError):
+            RequiredStepInfo(**data)
+
+
+class TestRequiredStepStatus:
+    def test_valid(self):
+        m = RequiredStepStatus(name="기능 명세", order=1, is_completed=False)
+        assert m.order == 1
+
+    def test_missing_order(self):
+        with pytest.raises(ValidationError):
+            RequiredStepStatus(name="기능 명세", is_completed=True)
+
+
+class TestGeneratedStep:
+    def test_valid(self):
+        m = GeneratedStep(**GENERATED_STEP)
+        assert m.name == "설계 단계"
+
+    @pytest.mark.parametrize("missing", ["name", "description"])
+    def test_missing_required_field(self, missing):
+        data = {k: v for k, v in GENERATED_STEP.items() if k != missing}
+        with pytest.raises(ValidationError):
+            GeneratedStep(**data)
+
+
+class TestRecommendedMethod:
+    def test_valid(self):
+        m = RecommendedMethod(title="방법1", content="내용1")
+        assert m.title == "방법1"
+
+    def test_missing_content(self):
+        with pytest.raises(ValidationError):
+            RecommendedMethod(title="방법1")
+
+
+class TestCommonMistake:
+    def test_valid(self):
+        m = CommonMistake(mistake="실수", bad_example="나쁜 예", good_example="좋은 예")
+        assert m.good_example == "좋은 예"
+
+    @pytest.mark.parametrize("missing", ["mistake", "bad_example", "good_example"])
+    def test_missing_required_field(self, missing):
+        data = {"mistake": "실수", "bad_example": "나쁜 예", "good_example": "좋은 예"}
+        data.pop(missing)
+        with pytest.raises(ValidationError):
+            CommonMistake(**data)
+
+
+class TestRetrievedChunk:
+    def test_valid(self):
+        m = RetrievedChunk(text="청크 내용", relevance_score=0.95)
+        assert m.relevance_score == pytest.approx(0.95)
+
+    def test_missing_relevance_score(self):
+        with pytest.raises(ValidationError):
+            RetrievedChunk(text="청크 내용")
+
+
+# ---------------------------------------------------------------------------
+# generate.py
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateInput:
+    def _base(self, **kwargs):
+        return {
+            "project_info": PROJECT_INFO,
+            "current_stage": STAGE_INFO,
+            "decision_history": [],
+            "current_step": STEP_INFO,
+            **kwargs,
+        }
+
+    def test_valid_minimal(self):
+        m = GenerateInput(**self._base())
+        assert m.current_required_step is None
+        assert m.rag_context is None
+
+    def test_valid_full(self):
+        m = GenerateInput(
+            **self._base(
+                current_required_step=REQUIRED_STEP_INFO,
+                rag_context={"chunks": []},
+            )
+        )
+        assert m.current_required_step is not None
+
+    @pytest.mark.parametrize("missing", ["project_info", "current_stage", "decision_history", "current_step"])
+    def test_missing_required_field(self, missing):
+        data = {k: v for k, v in self._base().items() if k != missing}
+        with pytest.raises(ValidationError):
+            GenerateInput(**data)
+
+
+class TestGenerateOutput:
+    def _three_steps(self):
+        return [GENERATED_STEP] * 3
+
+    def test_valid_exactly_three(self):
+        m = GenerateOutput(generated_steps=self._three_steps())
+        assert len(m.generated_steps) == 3
+
+    def test_zero_steps_raises(self):
+        with pytest.raises(ValidationError, match="exactly 3"):
+            GenerateOutput(generated_steps=[])
+
+    def test_two_steps_raises(self):
+        with pytest.raises(ValidationError, match="exactly 3"):
+            GenerateOutput(generated_steps=[GENERATED_STEP, GENERATED_STEP])
+
+    def test_four_steps_raises(self):
+        with pytest.raises(ValidationError, match="exactly 3"):
+            GenerateOutput(generated_steps=[GENERATED_STEP] * 4)
+
+    def test_missing_generated_steps(self):
+        with pytest.raises(ValidationError):
+            GenerateOutput()
+
+    def test_steps_are_generated_step_instances(self):
+        m = GenerateOutput(generated_steps=self._three_steps())
+        assert all(isinstance(s, GeneratedStep) for s in m.generated_steps)
+
+
+# ---------------------------------------------------------------------------
+# accept.py
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptInput:
+    def _base(self, **kwargs):
+        return {
+            "project_info": PROJECT_INFO,
+            "current_stage": STAGE_INFO,
+            "required_steps_status": [],
+            "accepted_steps_in_required": [],
+            "accepted_step": STEP_INFO,
+            **kwargs,
+        }
+
+    def test_valid_minimal(self):
+        m = AcceptInput(**self._base())
+        assert m.current_required_step is None
+
+    def test_valid_full(self):
+        m = AcceptInput(
+            **self._base(
+                current_required_step=REQUIRED_STEP_INFO,
+                rag_context={"docs": []},
+            )
+        )
+        assert m.current_required_step.step_id == "rs-1"
+
+    @pytest.mark.parametrize(
+        "missing",
+        ["project_info", "current_stage", "required_steps_status", "accepted_steps_in_required", "accepted_step"],
+    )
+    def test_missing_required_field(self, missing):
+        data = {k: v for k, v in self._base().items() if k != missing}
+        with pytest.raises(ValidationError):
+            AcceptInput(**data)
+
+
+class TestAcceptOutput:
+    def test_true(self):
+        m = AcceptOutput(is_current_required_step_completed=True)
+        assert m.is_current_required_step_completed is True
+
+    def test_false(self):
+        m = AcceptOutput(is_current_required_step_completed=False)
+        assert m.is_current_required_step_completed is False
+
+    def test_missing_field(self):
+        with pytest.raises(ValidationError):
+            AcceptOutput()
+
+    @pytest.mark.parametrize("truthy_str", ["true", "1", "yes"])
+    def test_coercion_from_truthy_string(self, truthy_str):
+        # Pydantic v2는 "true"/"1" 등을 bool로 강제 변환한다
+        m = AcceptOutput(is_current_required_step_completed=truthy_str)
+        assert m.is_current_required_step_completed is True
+
+    @pytest.mark.parametrize("falsy_str", ["false", "0", "no"])
+    def test_coercion_from_falsy_string(self, falsy_str):
+        m = AcceptOutput(is_current_required_step_completed=falsy_str)
+        assert m.is_current_required_step_completed is False
+
+    def test_non_coercible_string_raises(self):
+        with pytest.raises(ValidationError):
+            AcceptOutput(is_current_required_step_completed="maybe")
+
+    def test_none_raises(self):
+        with pytest.raises(ValidationError):
+            AcceptOutput(is_current_required_step_completed=None)
+
+    def test_integer_one_coerced_to_true(self):
+        m = AcceptOutput(is_current_required_step_completed=1)
+        assert m.is_current_required_step_completed is True
+
+    def test_integer_zero_coerced_to_false(self):
+        m = AcceptOutput(is_current_required_step_completed=0)
+        assert m.is_current_required_step_completed is False
+
+
+# ---------------------------------------------------------------------------
+# side_panel.py
+# ---------------------------------------------------------------------------
+
+
+class TestSidePanelInput:
+    def _base(self, **kwargs):
+        return {
+            "project_info": PROJECT_INFO,
+            "current_stage": STAGE_INFO,
+            "target_step": STEP_INFO,
+            "decision_history": [],
+            **kwargs,
+        }
+
+    def test_valid_minimal(self):
+        m = SidePanelInput(**self._base())
+        assert m.current_required_step is None
+        assert m.rag_context is None
+
+    def test_valid_full(self):
+        m = SidePanelInput(
+            **self._base(
+                current_required_step=REQUIRED_STEP_INFO,
+                rag_context={"key": "val"},
+            )
+        )
+        assert m.rag_context == {"key": "val"}
+
+    @pytest.mark.parametrize(
+        "missing", ["project_info", "current_stage", "target_step", "decision_history"]
+    )
+    def test_missing_required_field(self, missing):
+        data = {k: v for k, v in self._base().items() if k != missing}
+        with pytest.raises(ValidationError):
+            SidePanelInput(**data)
+
+
+class TestSidePanelOutput:
+    def _valid_mentoring(self):
+        return {
+            "description": "단계 설명",
+            "recommended_methods": [{"title": "방법1", "content": "내용1"}],
+            "common_mistakes": [
+                {"mistake": "실수1", "bad_example": "나쁜 예", "good_example": "좋은 예"}
+            ],
+            "one_line_tip": "팁입니다",
+        }
+
+    def _valid_dictionary(self):
+        return [
+            {"term": "페르소나", "definition": "타겟 사용자를 대표하는 가상의 인물 모델"},
+            {"term": "MVP", "definition": "최소 기능만 갖춘 초기 제품"},
+        ]
+
+    def _valid(self):
+        return {
+            "mentoring": self._valid_mentoring(),
+            "dictionary": self._valid_dictionary(),
+        }
+
+    def test_valid(self):
+        m = SidePanelOutput(**self._valid())
+        assert m.mentoring.one_line_tip == "팁입니다"
+        assert len(m.mentoring.recommended_methods) == 1
+        assert len(m.mentoring.common_mistakes) == 1
+        assert len(m.dictionary) == 2
+        assert m.dictionary[0].term == "페르소나"
+
+    def test_empty_lists_accepted(self):
+        data = self._valid()
+        data["mentoring"]["recommended_methods"] = []
+        data["mentoring"]["common_mistakes"] = []
+        data["dictionary"] = []
+        m = SidePanelOutput(**data)
+        assert m.mentoring.recommended_methods == []
+        assert m.dictionary == []
+
+    @pytest.mark.parametrize("missing", ["mentoring", "dictionary"])
+    def test_missing_top_level_field(self, missing):
+        data = {k: v for k, v in self._valid().items() if k != missing}
+        with pytest.raises(ValidationError):
+            SidePanelOutput(**data)
+
+    @pytest.mark.parametrize(
+        "missing", ["description", "recommended_methods", "common_mistakes", "one_line_tip"]
+    )
+    def test_missing_mentoring_field(self, missing):
+        data = self._valid()
+        data["mentoring"] = {k: v for k, v in data["mentoring"].items() if k != missing}
+        with pytest.raises(ValidationError):
+            SidePanelOutput(**data)
+
+    @pytest.mark.parametrize("missing", ["term", "definition"])
+    def test_missing_dictionary_item_field(self, missing):
+        data = self._valid()
+        data["dictionary"] = [
+            {k: v for k, v in data["dictionary"][0].items() if k != missing}
+        ]
+        with pytest.raises(ValidationError):
+            SidePanelOutput(**data)
+
+
+class TestMentoringContent:
+    def _valid(self):
+        return {
+            "description": "설명",
+            "recommended_methods": [{"title": "T", "content": "C"}],
+            "common_mistakes": [
+                {"mistake": "m", "bad_example": "b", "good_example": "g"}
+            ],
+            "one_line_tip": "팁",
+        }
+
+    def test_valid(self):
+        m = MentoringContent(**self._valid())
+        assert m.one_line_tip == "팁"
+
+    @pytest.mark.parametrize(
+        "missing", ["description", "recommended_methods", "common_mistakes", "one_line_tip"]
+    )
+    def test_missing_required_field(self, missing):
+        data = {k: v for k, v in self._valid().items() if k != missing}
+        with pytest.raises(ValidationError):
+            MentoringContent(**data)
+
+
+class TestDictionaryItem:
+    def test_valid(self):
+        item = DictionaryItem(term="페르소나", definition="타겟 사용자 모델")
+        assert item.term == "페르소나"
+        assert item.definition == "타겟 사용자 모델"
+
+    @pytest.mark.parametrize("missing", ["term", "definition"])
+    def test_missing_required_field(self, missing):
+        data = {"term": "T", "definition": "D"}
+        del data[missing]
+        with pytest.raises(ValidationError):
+            DictionaryItem(**data)

--- a/ai/tests/test_schemas_property.py
+++ b/ai/tests/test_schemas_property.py
@@ -1,0 +1,95 @@
+"""hypothesis 기반 property 테스트."""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ai.schemas.common import (
+    CommonMistake,
+    DictionaryItem,
+    GeneratedStep,
+    MentoringContent,
+    RecommendedMethod,
+)
+from ai.schemas.generate import GenerateOutput
+from ai.schemas.side_panel import SidePanelOutput
+
+_nonempty_text = st.text(min_size=1)
+
+_generated_step_st = st.builds(
+    GeneratedStep,
+    name=_nonempty_text,
+    description=_nonempty_text,
+)
+
+_recommended_method_st = st.builds(
+    RecommendedMethod,
+    title=_nonempty_text,
+    content=_nonempty_text,
+)
+
+_common_mistake_st = st.builds(
+    CommonMistake,
+    mistake=_nonempty_text,
+    bad_example=_nonempty_text,
+    good_example=_nonempty_text,
+)
+
+
+# Property 4: generate 출력 구조 불변성
+@settings(max_examples=100)
+@given(
+    steps=st.lists(_generated_step_st, min_size=3, max_size=3),
+)
+def test_generate_output_invariants(steps):
+    output = GenerateOutput(generated_steps=steps)
+
+    assert len(output.generated_steps) == 3
+    for step in output.generated_steps:
+        assert isinstance(step.name, str) and step.name
+        assert isinstance(step.description, str) and step.description
+
+
+_dictionary_item_st = st.builds(
+    DictionaryItem,
+    term=_nonempty_text,
+    definition=_nonempty_text,
+)
+
+
+# Property 7: side_panel 출력 구조 완전성 (mentoring + dictionary 2탭 구조)
+@settings(max_examples=100)
+@given(
+    description=_nonempty_text,
+    recommended_methods=st.lists(_recommended_method_st, min_size=0, max_size=5),
+    common_mistakes=st.lists(_common_mistake_st, min_size=0, max_size=5),
+    one_line_tip=_nonempty_text,
+    dictionary=st.lists(_dictionary_item_st, min_size=0, max_size=5),
+)
+def test_side_panel_output_completeness(
+    description, recommended_methods, common_mistakes, one_line_tip, dictionary
+):
+    output = SidePanelOutput(
+        mentoring=MentoringContent(
+            description=description,
+            recommended_methods=recommended_methods,
+            common_mistakes=common_mistakes,
+            one_line_tip=one_line_tip,
+        ),
+        dictionary=dictionary,
+    )
+
+    assert output.mentoring.description
+    assert output.mentoring.one_line_tip
+
+    for method in output.mentoring.recommended_methods:
+        assert method.title
+        assert method.content
+
+    for mistake in output.mentoring.common_mistakes:
+        assert mistake.mistake
+        assert mistake.bad_example
+        assert mistake.good_example
+
+    for item in output.dictionary:
+        assert item.term
+        assert item.definition

--- a/ai/tests/test_side_panel_generator.py
+++ b/ai/tests/test_side_panel_generator.py
@@ -10,6 +10,8 @@ from ai.exceptions import AIGenerationFailedError
 from ai.schemas.common import (
     CommonMistake,
     DecisionHistoryItem,
+    DictionaryItem,
+    MentoringContent,
     ProjectInfo,
     RecommendedMethod,
     RequiredStepInfo,
@@ -87,19 +89,25 @@ def _input_minimal() -> SidePanelInput:
 
 def _valid_output() -> SidePanelOutput:
     return SidePanelOutput(
-        description="이 Step에서는 ...",
-        recommended_methods=[
-            RecommendedMethod(title="경쟁 서비스 찾기", content="3~5개 후보를 모은다."),
-            RecommendedMethod(title="사용자 리뷰 모으기", content="앱스토어 리뷰를 모은다."),
+        mentoring=MentoringContent(
+            description="이 Step에서는 ...",
+            recommended_methods=[
+                RecommendedMethod(title="경쟁 서비스 찾기", content="3~5개 후보를 모은다."),
+                RecommendedMethod(title="사용자 리뷰 모으기", content="앱스토어 리뷰를 모은다."),
+            ],
+            common_mistakes=[
+                CommonMistake(
+                    mistake="이름만 모으고 끝내기",
+                    bad_example="A사, B사가 있다",
+                    good_example="A사는 ~를 잘하지만 ~가 부족하다",
+                ),
+            ],
+            one_line_tip="기존 대안이 놓친 틈을 찾자.",
+        ),
+        dictionary=[
+            DictionaryItem(term="페르소나", definition="타겟 사용자를 대표하는 가상 인물"),
+            DictionaryItem(term="MVP", definition="최소 기능만 갖춘 초기 제품"),
         ],
-        common_mistakes=[
-            CommonMistake(
-                mistake="이름만 모으고 끝내기",
-                bad_example="A사, B사가 있다",
-                good_example="A사는 ~를 잘하지만 ~가 부족하다",
-            ),
-        ],
-        one_line_tip="기존 대안이 놓친 틈을 찾자.",
     )
 
 
@@ -154,9 +162,10 @@ class TestHappyPath:
         result = await service.generate_side_panel(_input_full())
 
         assert isinstance(result, SidePanelOutput)
-        assert len(result.recommended_methods) == 2
-        assert len(result.common_mistakes) == 1
-        assert result.one_line_tip == "기존 대안이 놓친 틈을 찾자."
+        assert len(result.mentoring.recommended_methods) == 2
+        assert len(result.mentoring.common_mistakes) == 1
+        assert result.mentoring.one_line_tip == "기존 대안이 놓친 틈을 찾자."
+        assert len(result.dictionary) == 2
 
     @pytest.mark.asyncio
     async def test_passes_side_panel_output_schema_to_llm(self):
@@ -390,3 +399,61 @@ class TestPromptAssembly:
         prompt = llm.invoke.await_args.args[0]
         # name, description, constraints 모두 None → "없음" 라벨
         assert "이름: 없음" in prompt
+
+
+# ---------------------------------------------------------------------------
+# 통합 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    @pytest.mark.asyncio
+    async def test_happy_path_doj_and_custom_chunks(self):
+        service, _, _ = _make_service(
+            llm_return=_valid_output(),
+            doj_return=[
+                RetrievedChunk(text="DOJ 청크 A", relevance_score=0.92),
+                RetrievedChunk(text="DOJ 청크 B", relevance_score=0.85),
+            ],
+            custom_return=[
+                RetrievedChunk(text="Custom 청크 A", relevance_score=0.88),
+            ],
+        )
+
+        result = await service.generate_side_panel(_input_full())
+
+        assert isinstance(result, SidePanelOutput)
+
+    @pytest.mark.asyncio
+    async def test_custom_empty_no_custom_label_in_prompt(self):
+        service, llm, _ = _make_service(
+            doj_return=[RetrievedChunk(text="DOJ 청크만", relevance_score=0.9)],
+            custom_return=[],
+        )
+
+        await service.generate_side_panel(_input_full())
+
+        prompt = llm.invoke.await_args.args[0]
+        assert "[자체 문서]" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_custom_failure_returns_side_panel_output(self):
+        service, _, _ = _make_service(
+            doj_return=[RetrievedChunk(text="DOJ 청크", relevance_score=0.9)],
+            custom_return=[],
+        )
+
+        result = await service.generate_side_panel(_input_full())
+
+        assert isinstance(result, SidePanelOutput)
+
+    @pytest.mark.asyncio
+    async def test_llm_schema_mismatch_propagates(self):
+        err = AIGenerationFailedError(
+            message="재시도 초과",
+            details={"last_error": {"type": "schema_validation_error", "attempt": 2}},
+        )
+        service, _, _ = _make_service(llm_side_effect=err)
+
+        with pytest.raises(AIGenerationFailedError):
+            await service.generate_side_panel(_input_full())

--- a/ai/tests/test_step_generator_property.py
+++ b/ai/tests/test_step_generator_property.py
@@ -1,0 +1,114 @@
+"""hypothesis 기반 StepGenerator property 테스트."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ai.schemas.common import (
+    DecisionHistoryItem,
+    ProjectInfo,
+    RequiredStepInfo,
+    StageInfo,
+    StepInfo,
+)
+from ai.schemas.generate import GenerateInput, GenerateOutput, GeneratedStep
+from ai.services.step_generator import StepGenerator
+
+_nonempty = st.text(
+    # 제어 문자(C), 큰따옴표, 역슬래시, 중괄호 제외
+    # — json.dumps 이스케이프 시 원본과 달라지는 문자들을 막아 프롬프트 포함성 검증을 단순화
+    alphabet=st.characters(
+        blacklist_categories=("C",),
+        blacklist_characters='"\\{}',
+    ),
+    min_size=1,
+    max_size=40,
+)
+_step_id = st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=8)
+
+_project_st = st.builds(
+    ProjectInfo,
+    project_id=_step_id,
+    duration_months=st.integers(min_value=1, max_value=24),
+    member_count=st.integers(min_value=1, max_value=10),
+    initial_prompt=_nonempty,
+    name=st.just(None),
+    description=st.just(None),
+    constraints=st.just(None),
+)
+
+_stage_st = st.builds(
+    StageInfo,
+    stage_id=_step_id,
+    stage_number=st.integers(min_value=1, max_value=6),
+    name=_nonempty,
+)
+
+_history_item_st = st.builds(
+    DecisionHistoryItem,
+    step_id=_step_id,
+    name=_nonempty,
+    status=st.just("ACCEPTED"),
+)
+
+_required_step_st = st.builds(
+    RequiredStepInfo,
+    step_id=_step_id,
+    name=_nonempty,
+    is_completed=st.booleans(),
+    goal=_nonempty,
+    entry_criteria=_nonempty,
+    fulfillment_criteria=st.lists(_nonempty, min_size=1, max_size=5),
+    minimum_fulfillment_count=st.integers(min_value=1, max_value=3),
+)
+
+_current_step_st = st.builds(StepInfo, step_id=_step_id, name=_nonempty)
+
+_generate_input_st = st.builds(
+    GenerateInput,
+    project_info=_project_st,
+    current_stage=_stage_st,
+    decision_history=st.lists(_history_item_st, min_size=1, max_size=5),
+    current_step=_current_step_st,
+    current_required_step=_required_step_st,
+    rag_context=st.just(None),
+)
+
+_dummy_output = GenerateOutput(
+    generated_steps=[
+        GeneratedStep(name="Step A", description="A 활동"),
+        GeneratedStep(name="Step B", description="B 활동"),
+        GeneratedStep(name="Step C", description="C 활동"),
+    ]
+)
+
+
+def _make_service() -> tuple[StepGenerator, MagicMock, MagicMock]:
+    llm = MagicMock()
+    llm.invoke = AsyncMock(return_value=_dummy_output)
+
+    rag = MagicMock()
+    rag.search_doj = AsyncMock(return_value=[])
+
+    return StepGenerator(llm=llm, rag=rag), llm, rag
+
+
+@settings(max_examples=100)
+@given(input_data=_generate_input_st)
+def test_generate_prompt_contains_all_context(input_data: GenerateInput):
+    import asyncio
+
+    service, llm, _ = _make_service()
+    asyncio.run(service.generate_steps(input_data))
+
+    prompt: str = llm.invoke.await_args.args[0]
+
+    assert input_data.project_info.initial_prompt in prompt
+
+    for item in input_data.decision_history:
+        assert item.name in prompt
+
+    for aspect in input_data.current_required_step.fulfillment_criteria:
+        assert aspect in prompt


### PR DESCRIPTION
## PR 요약
- side_panel 스키마 2탭 구조 변경 + Haiku 4.5 모델 전환 + optional 테스트 일괄 추가

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `ai/schemas/common.py`: MentoringContent, DictionaryItem 모델 추가
- `ai/schemas/side_panel.py`: SidePanelOutput을 mentoring + dictionary 2탭 구조로 변경
- `ai/prompts/side_panel.txt`: 새 JSON 스키마 예시 + dictionary 생성 지시 추가
- `ai/config.py`: MODEL_ID를 Haiku 4.5로 전환 (AWS 측 지시)
- `ai/tests/test_schemas.py`: 스키마 단위 테스트 80개
- `ai/tests/test_*_property.py`: Property 테스트 7개 파일 (hypothesis 100회 반복)
- `ai/tests/test_logging_property.py`: correlation_id 일관성 Property 테스트

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- 206개 전체 테스트 통과 확인
- Haiku 4.5: AWS 측에서 먼저 사용하라고 지시, 품질 부족 시 Sonnet 전환 예정
- Sonnet 4 호출 정보 백업: `us.anthropic.claude-sonnet-4-20250514-v1:0` (검증 완료)