### PR TITLE
[#62][FE] canvas flow 전반 정리

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import ProjectListPage from './pages/ProjectListPage'
 import CreateProjectPage from './pages/CreateProjectPage'
 import AuthCallbackPage from './pages/AuthCallbackPage'
 import CanvasPage from './pages/CanvasPage'
+import PrivateRoute from './components/PrivateRoute'
 
 export default function App() {
   return (
@@ -12,10 +13,10 @@ export default function App() {
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/projects" element={<ProjectListPage />} />
-        <Route path="/projects/create" element={<CreateProjectPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
-        <Route path="/canvas/:projectId" element={<CanvasPage />} />
+        <Route path="/projects" element={<PrivateRoute><ProjectListPage /></PrivateRoute>} />
+        <Route path="/projects/create" element={<PrivateRoute><CreateProjectPage /></PrivateRoute>} />
+        <Route path="/canvas/:projectId" element={<PrivateRoute><CanvasPage /></PrivateRoute>} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,29 @@
+import axios from 'axios'
+
+function getCsrfToken() {
+  return document.cookie
+    .split('; ')
+    .find(row => row.startsWith('csrf_token='))
+    ?.split('=')[1]
+}
+
+const api = axios.create({
+  baseURL: '/api',
+  withCredentials: true,
+})
+
+api.interceptors.request.use((config) => {
+  const mutatingMethods = ['post', 'put', 'patch', 'delete']
+  if (mutatingMethods.includes(config.method)) {
+    const csrfToken = getCsrfToken()
+    if (csrfToken) config.headers['X-CSRF-Token'] = csrfToken
+  }
+  return config
+})
+
+api.interceptors.response.use(
+  (res) => res.data.data,
+  (err) => Promise.reject(err.response?.data?.error ?? err)
+)
+
+export const getMe = () => api.get('/auth/me')

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -1,8 +1,5 @@
 import axios from 'axios'
 
-export const getStep = (stepId) =>
-  aiApi.get(`/steps/${stepId}`)
-
 function getCsrfToken() {
   return document.cookie
     .split('; ')
@@ -10,13 +7,11 @@ function getCsrfToken() {
     ?.split('=')[1]
 }
 
-// Business API
 const api = axios.create({
   baseURL: '/api',
   withCredentials: true,
 })
 
-// AI API
 const aiApi = axios.create({
   baseURL: '/ai',
   withCredentials: true,
@@ -40,11 +35,9 @@ const addCsrfInterceptor = (instance) => {
 addCsrfInterceptor(api)
 addCsrfInterceptor(aiApi)
 
-// Business
 export const getStepTree = (projectId, stageId) =>
   api.get('/steps/tree', { params: { project_id: projectId, stage_id: stageId } })
 
-// AI
 export const generateSteps = (stepId) =>
   aiApi.post(`/steps/${stepId}/generate`)
 
@@ -53,3 +46,6 @@ export const acceptStep = (stepId) =>
 
 export const createNotionTemplate = (stepId) =>
   aiApi.post(`/steps/${stepId}/notion-template`)
+
+export const getStepDetail = (stepId) =>
+  aiApi.get(`/steps/${stepId}`)

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import { getMe } from '../api/auth'
+
+const DEV_BYPASS = import.meta.env.DEV  // 로컬 개발 환경에서만 true
+
+export default function PrivateRoute({ children }) {
+  const [status, setStatus] = useState(DEV_BYPASS ? 'ok' : 'loading')
+
+  useEffect(() => {
+    if (DEV_BYPASS) return
+    getMe()
+      .then(() => setStatus('ok'))
+      .catch(() => setStatus('unauth'))
+  }, [])
+
+  if (status === 'loading') return null
+  if (status === 'unauth') return <Navigate to="/login" replace />
+  return children
+}

--- a/frontend/src/components/canvas/StageNavigator.jsx
+++ b/frontend/src/components/canvas/StageNavigator.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { BsChevronLeft, BsChevronRight, BsCheckLg } from 'react-icons/bs'
+import { BsChevronLeft, BsChevronRight } from 'react-icons/bs'
 import styles from './StageNavigator.module.css'
 
 export default function StageNavigator({

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import {
   ReactFlow, Background, Controls,
@@ -14,9 +14,9 @@ import StepNode from '../components/canvas/StepNode'
 import RequiredStepNode from '../components/canvas/RequiredStepNode'
 
 import { getStages } from '../api/stage'
-import { getStepTree, acceptStep, generateSteps } from '../api/step'
+import { getStepTree, getStepDetail, acceptStep, generateSteps } from '../api/step'
 
-import { X_GAP, Y_GAP, STAGE_ENGLISH, makeEdge, flattenTree } from '../utils/canvasUtils'
+import { STAGE_ENGLISH, flattenTree } from '../utils/canvasUtils'
 
 import styles from './CanvasPage.module.css'
 import { HiOutlineUser } from 'react-icons/hi'
@@ -42,12 +42,15 @@ export default function CanvasPage() {
   const [toast, setToast] = useState(null)
   const [toastVisible, setToastVisible] = useState(false)
 
+  const shownToasts = useRef(new Set())
+  const timerRef = useRef(null)
+  const currentRequiredStepName = useRef(null)
+
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
 
   const onConnect = (params) => setEdges((eds) => addEdge(params, eds))
 
-  // Stage 목록 조회
   useEffect(() => {
     if (!projectId) return
     getStages(projectId).then((data) => {
@@ -61,21 +64,29 @@ export default function CanvasPage() {
     })
   }, [projectId])
 
-  // Step 트리 조회
+  function openToastOnce(key, message) {
+    if (shownToasts.current.has(key)) return
+    shownToasts.current.add(key)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setToast(message)
+    setToastVisible(true)
+    timerRef.current = setTimeout(() => setToastVisible(false), 3000)
+  }
+
+  async function fetchAndRenderTree(stageId) {
+    const treeData = await getStepTree(projectId, stageId)
+    const stage = stages.find((s) => s.stage_id === stageId)
+    const { nodes: n, edges: e } = flattenTree(treeData.steps ?? [], stage?.stage_sequence)
+    setNodes(n)
+    setEdges(e)
+  }
+
   useEffect(() => {
     if (!selectedStageId || !projectId) return
-    const stage = stages.find(s => s.stage_id === selectedStageId)
-    getStepTree(projectId, selectedStageId).then((data) => {
-      const { nodes: n, edges: e } = flattenTree(
-        data.steps ?? [],
-        stage?.stage_sequence
-      )
-      setNodes(n)
-      setEdges(e)
-    })
-  }, [selectedStageId])
+    fetchAndRenderTree(selectedStageId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedStageId, projectId])
 
-  // Stage UI 포맷 변환
   const uiStages = stages.map(s => ({
     id: s.stage_id,
     sequence: s.stage_sequence,
@@ -91,8 +102,12 @@ export default function CanvasPage() {
   async function handleNodeClick(event, node) {
     setSelectedStep(node)
     setStepDetail(null)
-    // const detail = await getStep(node.id)
-    // setStepDetail(detail)
+    try {
+      const detail = await getStepDetail(node.id)
+      setStepDetail(detail)
+    } catch {
+      // 상세 정보 로드 실패해도 노드 선택은 유지
+    }
   }
 
   async function handleAccept() {
@@ -106,33 +121,41 @@ export default function CanvasPage() {
       return
     }
 
-    // 필수 Step Accept 시 "시작" 토스트
     if (selectedStep.type === 'requiredStepNode') {
-      setToast(`📌 ${selectedStep.data.label}이(가) 시작됐어요!`)
-      setToastVisible(true)
-      setTimeout(() => setToastVisible(false), 3000)
-    }
-
-    // 필수 Step 완료 시 "종료" 토스트
-    if (acceptResult?.is_current_required_step_completed) {
-      setToast(`✅ ${selectedStep.data.label}이(가) 종료됐어요!`)
-      setToastVisible(true)
-      setTimeout(() => setToastVisible(false), 3000)
-    }
-
-    setNodes((nds) =>
-      nds.map((n) =>
-        n.id === selectedStep.id
-          ? { ...n, data: { ...n.data, status: 'ACCEPTED' } }
-          : n
+      currentRequiredStepName.current = selectedStep.data.label
+      openToastOnce(
+        `required-start-${selectedStep.id}`,
+        `📌 ${selectedStep.data.label}이(가) 시작됐어요!`
       )
-    )
+    }
 
-    let data
+    if (acceptResult?.is_current_required_step_completed) {
+      const name = currentRequiredStepName.current ?? selectedStep.data.label
+      const isStageComplete = acceptResult?.is_current_stage_completed
+
+      const message = isStageComplete
+        ? `✅ ${name}이(가) 종료됐어요. 이제 다음 스테이지로 이동할 수 있어요.`
+        : `✅ ${name}이(가) 종료됐어요!`
+
+      if (timerRef.current) clearTimeout(timerRef.current)
+      setToast(message)
+      setToastVisible(true)
+      timerRef.current = setTimeout(() => setToastVisible(false), 3000)
+
+      if (isStageComplete) {
+        getStages(projectId).then((data) => {
+          const list = data.stages ?? []
+          setStages(list)
+          const active = list.find(s => s.is_active)
+          if (active) setCurrentStageSequence(active.stage_sequence)
+        })
+      }
+    }
+
     let retryCount = 0
     while (retryCount < 3) {
       try {
-        data = await generateSteps(selectedStep.id)
+        await generateSteps(selectedStep.id)
         break
       } catch {
         retryCount++
@@ -143,24 +166,7 @@ export default function CanvasPage() {
       }
     }
 
-    const stage = stages.find(s => s.stage_id === selectedStageId)
-    const newNodes = (data.generated_steps ?? []).map((s, i) => ({
-      id: s.step_id,
-      type: s.is_required ? 'requiredStepNode' : 'stepNode',
-      position: {
-        x: selectedStep.position.x + X_GAP,
-        y: selectedStep.position.y + (i - 1) * Y_GAP,
-      },
-      data: {
-        label: s.name,
-        status: s.status,
-        is_required: s.is_required,
-        stageNumber: stage?.stage_sequence,
-      },
-    }))
-    const newEdges = (data.generated_steps ?? []).map(s => makeEdge(selectedStep.id, s.step_id))
-    setNodes(prev => [...prev, ...newNodes])
-    setEdges(prev => [...prev, ...newEdges])
+    await fetchAndRenderTree(selectedStageId)
     setSelectedStep(null)
     setStepDetail(null)
   }
@@ -217,7 +223,13 @@ export default function CanvasPage() {
             onToggle={() => {
               const next = !toastVisible
               setToastVisible(next)
-              if (next) setTimeout(() => setToastVisible(false), 3000)
+              if (next) {
+                if (currentRequiredStepName.current) {
+                  setToast(`📌 ${currentRequiredStepName.current} 진행 중이에요`)
+                }
+                if (timerRef.current) clearTimeout(timerRef.current)
+                timerRef.current = setTimeout(() => setToastVisible(false), 3000)
+              }
             }}
           />
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,6 +1,5 @@
 import styles from './LoginPage.module.css'
 import { SiGoogle, SiNaver } from 'react-icons/si'
-import { RiKakaoTalkFill } from 'react-icons/ri'
 
 
 export default function LoginPage() {
@@ -22,10 +21,6 @@ export default function LoginPage() {
         <h1 className={styles.title}>로그인</h1>
 
         <div className={styles.btnGroup}>
-          
-          <button className={`${styles.socialBtn} ${styles.kakao}`} onClick={() => handleLogin('kakao')}>
-            <RiKakaoTalkFill size={35} /> Kakao로 시작하기
-          </button>
           <button className={`${styles.socialBtn} ${styles.google}`} onClick={() => handleLogin('google')}>
             <img src="/google-logo.svg" width={27} height={27} /> Google로 시작하기
           </button>

--- a/frontend/src/pages/LoginPage.module.css
+++ b/frontend/src/pages/LoginPage.module.css
@@ -29,7 +29,7 @@
   justify-content: center;
   flex: 1;
   gap: 30px;
-  padding-bottom: 120px;
+  padding-bottom: 200px;
 }
 
 .title {
@@ -41,8 +41,9 @@
 .btnGroup {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 40px;
   width: 360px;
+  padding-top: 20px;
 }
 
 .socialBtn {
@@ -56,16 +57,6 @@
   align-items: center;
   justify-content: center;
   box-shadow: 2px 4px 10px 0 rgba(0, 0, 0, 0.15);
-}
-
-.kakao {
-  background-color: #FEE500;
-  gap: 20px;
-  color: #3C1E1E;
-}
-
-.kakao:hover {
-  background-color: #F5DC00;
 }
 
 .google {

--- a/frontend/src/pages/ProjectListPage.jsx
+++ b/frontend/src/pages/ProjectListPage.jsx
@@ -69,7 +69,7 @@ export default function ProjectListPage() {
     setEditData({
       name: project.name ?? '',
       member_count: project.member_count ?? '',
-      duration_months: project.duration_months ?? '',
+      duration_month: project.duration_month ?? '',
       description: project.description ?? '',
       constraint: project.constraint ?? '',
     })
@@ -272,7 +272,7 @@ export default function ProjectListPage() {
               {[
                 { label: '프로젝트 이름', key: 'name', type: 'input' },
                 { label: '프로젝트 인원', key: 'member_count', type: 'input', inputType: 'number', suffix: '명' },
-                { label: '프로젝트 기간', key: 'duration_months', type: 'input', inputType: 'number', suffix: '개월' },
+                { label: '프로젝트 기간', key: 'duration_month', type: 'input', inputType: 'number', suffix: '개월' },
                 { label: '프로젝트 설명', key: 'description', type: 'textarea' },
                 { label: '프로젝트 제약 사항', key: 'constraint', type: 'textarea' },
               ].map(({ label, key, type, inputType, suffix }) => (

--- a/frontend/src/utils/canvasUtils.js
+++ b/frontend/src/utils/canvasUtils.js
@@ -1,5 +1,5 @@
-export const X_GAP = 300
-export const Y_GAP = 120
+export const X_GAP = 350
+export const Y_GAP = 90
 
 export const STAGE_ENGLISH = {
   1: 'Ideation', 2: 'Planning', 3: 'Requirement',
@@ -7,22 +7,33 @@ export const STAGE_ENGLISH = {
 }
 
 export const EDGE_STYLE = {
-  type: 'straight',
-  style: { stroke: '#291C80', strokeWidth: 1.5, strokeDasharray: '5,5' },
+  type: '',
+  style: { stroke: '#291C80', strokeWidth: 1, strokeDasharray: '8,8' },
 }
 
-export function makeEdge(sourceId, targetId) {
+export function makeEdge(sourceId, targetId, solid = false) {
   return {
     id: `e-${sourceId}-${targetId}`,
     source: sourceId,
     target: targetId,
-    ...EDGE_STYLE,
+    type: 'default',
+    style: {
+      stroke: '#291C80',
+      strokeWidth: solid ?  1.5: 1.5,
+      strokeDasharray: solid ? undefined : '5,5',
+    },
   }
 }
 
 export function flattenTree(steps, stageSequence) {
   const nodes = []
   const edges = []
+
+  function getSubtreeSize(node) {
+    const children = node.children ?? []
+    if (children.length === 0) return 1
+    return children.reduce((sum, child) => sum + getSubtreeSize(child), 0)
+  }
 
   function build(node, depth, centerY) {
     nodes.push({
@@ -38,13 +49,24 @@ export function flattenTree(steps, stageSequence) {
       },
     })
 
-    if (node.parent_step_id) edges.push(makeEdge(node.parent_step_id, node.step_id))
+    if (node.parent_step_id) {
+      edges.push(makeEdge(node.parent_step_id, node.step_id, node.status === 'ACCEPTED'))
+    }
 
     const children = node.children ?? []
     if (children.length === 0) return
-    const totalHeight = (children.length - 1) * Y_GAP
-    const startY = centerY - totalHeight / 2
-    children.forEach((child, index) => build(child, depth + 1, startY + index * Y_GAP))
+
+    const sorted = [...children].sort((a, b) => (a.is_required ? 1 : 0) - (b.is_required ? 1 : 0))
+    const sizes = sorted.map(child => getSubtreeSize(child))
+    const totalLeaves = sizes.reduce((sum, s) => sum + s, 0)
+    const totalHeight = (totalLeaves - 1) * Y_GAP
+
+    let currentY = centerY - totalHeight / 2
+    sorted.forEach((child, index) => {
+      const childCenterY = currentY + (sizes[index] - 1) * Y_GAP / 2
+      build(child, depth + 1, childCenterY)
+      currentY += sizes[index] * Y_GAP
+    })
   }
 
   const rootGap = 260


### PR DESCRIPTION
## PR 요약
- PrivateRoute 추가로 인증되지 않은 접근 차단
- Canvas 토스트 알림 개선 (중복 방지, stage 완료 복합 메시지, 토글 시 "진행 중이에요")
- 노드 클릭 시 getStepDetail 실제 호출로 사이드패널 데이터 로드
- 캔버스 트리 레이아웃 개선 (서브트리 기반 비례 간격, 필수 Step 노드 마지막 정렬)
- ACCEPTED 경로 실선 / 나머지 점선 엣지 스타일 적용
- 로그인 페이지 카카오 제거
- 프로젝트 기간 필드명 불일치 수정 (duration_months → duration_month)

## 변경 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링

## 변경 사항
- `PrivateRoute.jsx` 추가, `App.jsx`에 보호 라우트 적용 (/project 로 접근 불가)
- `auth.js` 추가 (getMe API)
- `CanvasPage.jsx` 토스트 개선, fetchAndRenderTree 분리, getStepDetail 호출
- `canvasUtils.js` 트리 레이아웃 및 엣지 스타일 개선
- `step.js` getStepDetail 추가 및 코드 정리
- `StageNavigator.jsx` 불필요 import 제거
- `LoginPage.jsx` 카카오 로그인 제거
- `ProjectListPage.jsx` duration_months → duration_month 수정

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영