### PR TITLE
[#64][BE] Project 생성 시 Stage별 첫 Required Step 자동 생성

### DIFF
--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -1,3 +1,4 @@
+import uuid
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -10,6 +11,9 @@ from app.core.models.project_required_step_status import (
 )
 from app.core.models.required_step import RequiredStep as RequiredStepModel
 from app.core.models.stage import Stage as StageModel
+from app.core.models.step import Step as StepModel
+from app.core.models.step import StepTree as StepTreeModel
+from app.core.enums import StepStatus
 from app.core.schemas.project import (
     ProjectCreateRequest,
     ProjectListItemResponse,
@@ -63,9 +67,33 @@ def create_project(db: Session, payload: ProjectCreateRequest) -> ProjectRespons
             )
         )
 
+    _create_initial_steps_for_each_stage(db, project.id)
+
     db.commit()
     db.refresh(project)
     return _to_project_response(db, project)
+
+
+def _create_initial_steps_for_each_stage(db: Session, project_id: UUID) -> None:
+    """각 Stage의 첫 번째(sequence=1) Required Step을 루트 Step으로 생성."""
+    first_required_steps = (
+        db.query(RequiredStepModel).filter(RequiredStepModel.sequence == 1).all()
+    )
+    for rs in first_required_steps:
+        step = StepModel(
+            id=uuid.uuid4(),
+            project_id=project_id,
+            stage_id=rs.stage_id,
+            parent_step_id=None,
+            required_step_id=rs.id,
+            belonging_required_step_id=None,
+            name=rs.name,
+            status=StepStatus.READY,
+            sort_order=0,
+        )
+        db.add(step)
+        db.flush()
+        db.add(StepTreeModel(ancestor=step.id, descendant=step.id, depth=0))
 
 
 def list_projects(


### PR DESCRIPTION
## PR 요약
- Project 생성 시 각 Stage의 첫 번째(sequence=1) Required Step을 Step 테이블에 루트 노드로 자동 생성

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `project_service.create_project`에 `_create_initial_steps_for_each_stage` 호출 추가
- `RequiredStep.sequence == 1` 조건으로 Stage별 첫 Required Step 조회 후 Step row 생성
  - `parent_step_id = None` (루트 노드)
  - `required_step_id = <첫 Required Step id>`
  - `status = READY`, `sort_order = 0`
- StepTree 클로저 테이블에 self-row (depth=0) 추가

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 \`alembic revision --autogenerate\` 수행 (스키마 변경 없음)
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영 (변경 없음)

## 참고 사항
- 기존 프로젝트에는 영향 없으며 신규 생성 시점부터 적용됨