### PR TITLE
[#38][BE] Step Rollback API 구현

### DIFF
--- a/backend/app/business/routers/steps.py
+++ b/backend/app/business/routers/steps.py
@@ -26,3 +26,8 @@ def get_required_steps(
 ) -> RequiredStepListResponse:
     """특정 Stage의 Required Step 목록 조회."""
     return step_service.get_required_steps(db, stage_id)
+
+
+@router.post("/{step_id}/rollback", status_code=http_status.HTTP_200_OK)
+def rollback_step(step_id: UUID, db: Session = Depends(get_db)) -> None:
+    return step_service.rollback_step(db, step_id)

--- a/backend/app/business/services/step_service.py
+++ b/backend/app/business/services/step_service.py
@@ -3,8 +3,13 @@ import uuid
 from sqlalchemy.orm import Session
 
 from app.core.enums import StepStatus
+from app.core.exceptions import InvalidRollbackTargetError, StepNotFoundError
+from app.core.models.project_required_step_status import (
+    ProjectRequiredStepStatus as ProjectRequiredStepStatusModel,
+)
 from app.core.models.required_step import RequiredStep as RequiredStepModel
 from app.core.models.step import Step as StepModel
+from app.core.models.step import StepTree as StepTreeModel
 from app.core.schemas.step import (
     RequiredStepItem,
     RequiredStepListResponse,
@@ -28,6 +33,81 @@ def get_step_tree(
     roots = _build_tree(steps)
 
     return StepTreeResponse(current_path=current_path, steps=roots)
+
+
+def rollback_step(db: Session, step_id: uuid.UUID) -> None:
+    step = db.get(StepModel, step_id)
+    if step is None:
+        raise StepNotFoundError()
+
+    # ① children 존재 여부 검사
+    has_child = (
+        db.query(StepModel.id).filter(StepModel.parent_step_id == step_id).first()
+        is not None
+    )
+    if has_child:
+        raise InvalidRollbackTargetError("자식 Step이 있는 Step은 롤백할 수 없습니다.")
+
+    # ② 클로저 테이블로 조상 + 자기 자신을 depth 오름차순으로 조회
+    ancestor_rows = (
+        db.query(StepTreeModel)
+        .filter(StepTreeModel.descendant == step_id)
+        .order_by(StepTreeModel.depth.asc())
+        .all()
+    )
+    ancestor_ids = {row.ancestor for row in ancestor_rows}
+
+    # ③ 프로젝트의 기존 ACCEPTED 흐름을 모두 CANCELED 처리
+    previously_accepted = (
+        db.query(StepModel)
+        .filter(
+            StepModel.project_id == step.project_id,
+            StepModel.status == StepStatus.ACCEPTED,
+        )
+        .all()
+    )
+    for s in previously_accepted:
+        s.status = StepStatus.CANCELED
+
+    # ④ 롤백 대상 + 조상들을 ACCEPTED 처리
+    accepted_targets = db.query(StepModel).filter(StepModel.id.in_(ancestor_ids)).all()
+    for s in accepted_targets:
+        s.status = StepStatus.ACCEPTED
+
+    db.flush()
+
+    # ⑤ 가장 가까운 Required Step 찾아 fulfilled 해제
+    unfulfilled_rs_id = _find_nearest_required_step_id(accepted_targets, ancestor_rows)
+    if unfulfilled_rs_id is not None:
+        record = db.get(
+            ProjectRequiredStepStatusModel,
+            {
+                "project_id": step.project_id,
+                "required_step_id": unfulfilled_rs_id,
+            },
+        )
+        if record is not None:
+            record.is_fulfilled = False
+            record.fulfilled_at = None
+
+    db.commit()
+
+
+def _find_nearest_required_step_id(
+    ancestor_steps: list[StepModel],
+    ancestor_rows: list[StepTreeModel],
+) -> uuid.UUID | None:
+
+    step_by_id = {s.id: s for s in ancestor_steps}
+    for row in ancestor_rows:
+        s = step_by_id.get(row.ancestor)
+        if s is None:
+            continue
+        if s.required_step_id is not None:
+            return s.required_step_id
+        if s.belonging_required_step_id is not None:
+            return s.belonging_required_step_id
+    return None
 
 
 def get_required_steps(db: Session, stage_id: uuid.UUID) -> RequiredStepListResponse:

--- a/backend/app/business/services/step_service.py
+++ b/backend/app/business/services/step_service.py
@@ -81,40 +81,48 @@ def rollback_step(db: Session, step_id: uuid.UUID) -> None:
 
     db.flush()
 
-    # ⑤ 가장 가까운 Required Step 찾아 fulfilled 해제
-    #    검색은 자기 자신 포함(target이 곧 Required Step일 수 있음).
-    search_steps = [step, *accepted_targets]
-    unfulfilled_rs_id = _find_nearest_required_step_id(search_steps, ancestor_rows)
-    if unfulfilled_rs_id is not None:
-        record = db.get(
-            ProjectRequiredStepStatusModel,
-            {
-                "project_id": step.project_id,
-                "required_step_id": unfulfilled_rs_id,
-            },
-        )
-        if record is not None:
-            record.is_fulfilled = False
-            record.fulfilled_at = None
+    # ⑤ Belonging Required Step 이후의 모든 Required Step 상태 fulfilled 해제
+    _unfulfill_required_steps_from(db, step)
 
     db.commit()
 
 
-def _find_nearest_required_step_id(
-    ancestor_steps: list[StepModel],
-    ancestor_rows: list[StepTreeModel],
-) -> uuid.UUID | None:
+def _unfulfill_required_steps_from(db: Session, step: StepModel) -> None:
+    """롤백 대상의 Belonging Required Step부터 같은 Stage의 이후(sequence ≥) 모든
+    Required Step의 ProjectRequiredStepStatus를 is_fulfilled=False로 되돌린다.
 
-    step_by_id = {s.id: s for s in ancestor_steps}
-    for row in ancestor_rows:
-        s = step_by_id.get(row.ancestor)
-        if s is None:
-            continue
-        if s.required_step_id is not None:
-            return s.required_step_id
-        if s.belonging_required_step_id is not None:
-            return s.belonging_required_step_id
-    return None
+    belonging_required_step_id가 없으면 step 자신의 required_step_id를 사용.
+    둘 다 없으면 (필수 Step 영역 밖) 아무 작업도 하지 않는다."""
+    base_rs_id = step.belonging_required_step_id or step.required_step_id
+    if base_rs_id is None:
+        return
+
+    base_rs = db.get(RequiredStepModel, base_rs_id)
+    if base_rs is None:
+        return
+
+    # 같은 Stage에서 sequence가 base 이상인 Required Step의 status 레코드 일괄 해제
+    target_rs_ids_subq = (
+        db.query(RequiredStepModel.id)
+        .filter(
+            RequiredStepModel.stage_id == base_rs.stage_id,
+            RequiredStepModel.sequence >= base_rs.sequence,
+        )
+        .subquery()
+    )
+    records = (
+        db.query(ProjectRequiredStepStatusModel)
+        .filter(
+            ProjectRequiredStepStatusModel.project_id == step.project_id,
+            ProjectRequiredStepStatusModel.required_step_id.in_(
+                db.query(target_rs_ids_subq)
+            ),
+        )
+        .all()
+    )
+    for record in records:
+        record.is_fulfilled = False
+        record.fulfilled_at = None
 
 
 def get_required_steps(db: Session, stage_id: uuid.UUID) -> RequiredStepListResponse:

--- a/backend/app/business/services/step_service.py
+++ b/backend/app/business/services/step_service.py
@@ -49,13 +49,14 @@ def rollback_step(db: Session, step_id: uuid.UUID) -> None:
         raise InvalidRollbackTargetError("자식 Step이 있는 Step은 롤백할 수 없습니다.")
 
     # ② 클로저 테이블로 조상 + 자기 자신을 depth 오름차순으로 조회
+    #    depth=0(자기 자신)은 ACCEPTED 처리에서 제외 — Accept API에서 별도로 처리.
     ancestor_rows = (
         db.query(StepTreeModel)
         .filter(StepTreeModel.descendant == step_id)
         .order_by(StepTreeModel.depth.asc())
         .all()
     )
-    ancestor_ids = {row.ancestor for row in ancestor_rows}
+    ancestor_ids = {row.ancestor for row in ancestor_rows if row.depth > 0}
 
     # ③ 프로젝트의 기존 ACCEPTED 흐름을 모두 CANCELED 처리
     previously_accepted = (
@@ -69,15 +70,21 @@ def rollback_step(db: Session, step_id: uuid.UUID) -> None:
     for s in previously_accepted:
         s.status = StepStatus.CANCELED
 
-    # ④ 롤백 대상 + 조상들을 ACCEPTED 처리
-    accepted_targets = db.query(StepModel).filter(StepModel.id.in_(ancestor_ids)).all()
-    for s in accepted_targets:
-        s.status = StepStatus.ACCEPTED
+    # ④ 조상들만 ACCEPTED 처리 (롤백 대상은 Accept API에서 처리)
+    accepted_targets: list[StepModel] = []
+    if ancestor_ids:
+        accepted_targets = (
+            db.query(StepModel).filter(StepModel.id.in_(ancestor_ids)).all()
+        )
+        for s in accepted_targets:
+            s.status = StepStatus.ACCEPTED
 
     db.flush()
 
     # ⑤ 가장 가까운 Required Step 찾아 fulfilled 해제
-    unfulfilled_rs_id = _find_nearest_required_step_id(accepted_targets, ancestor_rows)
+    #    검색은 자기 자신 포함(target이 곧 Required Step일 수 있음).
+    search_steps = [step, *accepted_targets]
+    unfulfilled_rs_id = _find_nearest_required_step_id(search_steps, ancestor_rows)
     if unfulfilled_rs_id is not None:
         record = db.get(
             ProjectRequiredStepStatusModel,


### PR DESCRIPTION
## PR 요약
- 특정 Step으로 롤백하는 API 구현 (`POST /steps/{step_id}/rollback`)

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `POST /steps/{step_id}/rollback` 엔드포인트 추가
- 동작 규칙
  1. 자식이 없는 Step만 롤백 가능 (있으면 `400 INVALID_ROLLBACK_TARGET`)
  2. 프로젝트의 기존 ACCEPTED Step 흐름을 모두 CANCELED 처리
  3. 롤백 대상 Step과 모든 재귀적 조상을 ACCEPTED 처리 (StepTree 클로저 테이블 활용)
  4. 롤백 대상에서 가장 가까운 Required Step의 `ProjectRequiredStepStatus.is_fulfilled`를 `False`로 되돌림 (`fulfilled_at`도 `None`)

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 \`alembic revision --autogenerate\` 수행 (스키마 변경 없음)
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영 (변경 없음)

## 참고 사항
- 응답은 envelope 형식 `{"status": "success", "data": null}`
- 가장 가까운 Required Step 탐색은 `Step.required_step_id` 우선, 없으면 `belonging_required_step_id`로 fallback