### PR TITLE
[#74][AI] stage_number → stage_sequence 리네이밍

### DIFF
--- a/ai/cli_simulator.py
+++ b/ai/cli_simulator.py
@@ -35,7 +35,7 @@ from ai.services.required_step_judge import RequiredStepJudge
 from ai.services.side_panel_generator import SidePanelGenerator
 from ai.services.step_generator import StepGenerator
 
-_STAGE = StageInfo(stage_id="stage-1", stage_number=1, name="아이디어 구체화")
+_STAGE = StageInfo(stage_id="stage-1", stage_sequence=1, name="아이디어 구체화")
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +259,7 @@ async def _run(
             step_id=current_required.step_id,
             name=current_required.name,
             status="ACCEPTED",
-            stage_number=_STAGE.stage_number,
+            stage_sequence=_STAGE.stage_sequence,
         )
     )
     current_step = StepInfo(step_id=current_required.step_id, name=current_required.name)
@@ -296,7 +296,7 @@ async def _run(
                 step_id=picked_step_info.step_id,
                 name=picked_step_info.name,
                 status="ACCEPTED",
-                stage_number=_STAGE.stage_number,
+                stage_sequence=_STAGE.stage_sequence,
             )
         )
         accepted_steps_in_required.append(picked_step_info)
@@ -356,7 +356,7 @@ async def _run(
                     step_id=current_required.step_id,
                     name=current_required.name,
                     status="ACCEPTED",
-                    stage_number=_STAGE.stage_number,
+                    stage_sequence=_STAGE.stage_sequence,
                 )
             )
             current_step = StepInfo(

--- a/ai/prompts/generate.txt
+++ b/ai/prompts/generate.txt
@@ -83,7 +83,7 @@
 - 초기 아이디어: {initial_prompt}
 
 ## 현재 Stage
-- Stage {stage_number}: {stage_name}
+- Stage {stage_sequence}: {stage_name}
 
 ## 의사결정 히스토리 (이미 Accept된 Step 목록, JSON)
 {decision_history}

--- a/ai/prompts/side_panel.txt
+++ b/ai/prompts/side_panel.txt
@@ -96,7 +96,7 @@
 - 초기 아이디어: {initial_prompt}
 
 ## 현재 Stage
-- Stage {stage_number}: {stage_name}
+- Stage {stage_sequence}: {stage_name}
 
 ## 클릭된 Step (사이드패널 생성 대상)
 - {target_step_name}

--- a/ai/schemas/common.py
+++ b/ai/schemas/common.py
@@ -24,7 +24,7 @@ class StageInfo(BaseModel):
     """현재 Stage 정보."""
 
     stage_id: str
-    stage_number: int
+    stage_sequence: int
     name: str
 
 
@@ -41,7 +41,7 @@ class DecisionHistoryItem(BaseModel):
     step_id: str
     name: str
     status: str
-    stage_number: Optional[int] = None
+    stage_sequence: Optional[int] = None
 
 
 class RequiredStepInfo(BaseModel):

--- a/ai/services/side_panel_generator.py
+++ b/ai/services/side_panel_generator.py
@@ -71,7 +71,7 @@ class SidePanelGenerator:
         project = input_data.project_info
         target = input_data.target_step
 
-        doj_query = f"Stage {stage.stage_number} {stage.name} {target.name}"
+        doj_query = f"Stage {stage.stage_sequence} {stage.name} {target.name}"
         custom_query = target.name
 
         doj_chunks, custom_chunks = await asyncio.gather(
@@ -102,7 +102,7 @@ class SidePanelGenerator:
             description=_coerce(project.description),
             constraints=_coerce(project.constraints),
             initial_prompt=project.initial_prompt,
-            stage_number=str(stage.stage_number),
+            stage_sequence=str(stage.stage_sequence),
             stage_name=stage.name,
             target_step_name=target.name,
             decision_history=decision_history_json,
@@ -115,7 +115,7 @@ class SidePanelGenerator:
                 {
                     "event": "side_panel_generator_invoke",
                     "project_id": project.project_id,
-                    "stage_number": stage.stage_number,
+                    "stage_sequence": stage.stage_sequence,
                     "target_step_name": target.name,
                     "doj_chunks": len(doj_chunks),
                     "custom_chunks": len(custom_chunks),

--- a/ai/services/step_generator.py
+++ b/ai/services/step_generator.py
@@ -54,7 +54,7 @@ class StepGenerator:
         stage = input_data.current_stage
         project = input_data.project_info
 
-        rag_query = f"Stage {stage.stage_number} {stage.name} activities"
+        rag_query = f"Stage {stage.stage_sequence} {stage.name} activities"
         chunks = await self.rag.search_doj(rag_query)
 
         decision_history_json = json.dumps(
@@ -80,7 +80,7 @@ class StepGenerator:
             description=_coerce(project.description, _NONE_LABEL),
             constraints=_coerce(project.constraints, _NONE_LABEL),
             initial_prompt=project.initial_prompt,
-            stage_number=str(stage.stage_number),
+            stage_sequence=str(stage.stage_sequence),
             stage_name=stage.name,
             decision_history=decision_history_json,
             current_step_name=input_data.current_step.name,
@@ -93,7 +93,7 @@ class StepGenerator:
                 {
                     "event": "step_generator_invoke",
                     "project_id": project.project_id,
-                    "stage_number": stage.stage_number,
+                    "stage_sequence": stage.stage_sequence,
                     "rag_chunks": len(chunks),
                     "has_required_step": input_data.current_required_step is not None,
                     "prompt_len": len(prompt),

--- a/ai/tests/test_orchestrator.py
+++ b/ai/tests/test_orchestrator.py
@@ -53,7 +53,7 @@ def _project() -> ProjectInfo:
 
 
 def _stage() -> StageInfo:
-    return StageInfo(stage_id="stage-1", stage_number=1, name="아이디어 구체화")
+    return StageInfo(stage_id="stage-1", stage_sequence=1, name="아이디어 구체화")
 
 
 def _required_step() -> RequiredStepInfo:

--- a/ai/tests/test_required_step_judge.py
+++ b/ai/tests/test_required_step_judge.py
@@ -36,7 +36,7 @@ def _project() -> ProjectInfo:
 
 
 def _stage() -> StageInfo:
-    return StageInfo(stage_id="stage-1", stage_number=1, name="아이디어 구체화")
+    return StageInfo(stage_id="stage-1", stage_sequence=1, name="아이디어 구체화")
 
 
 def _required_step() -> RequiredStepInfo:

--- a/ai/tests/test_required_step_judge_property.py
+++ b/ai/tests/test_required_step_judge_property.py
@@ -45,7 +45,7 @@ _project_st = st.builds(
 _stage_st = st.builds(
     StageInfo,
     stage_id=_step_id,
-    stage_number=st.integers(min_value=1, max_value=6),
+    stage_sequence=st.integers(min_value=1, max_value=6),
     name=_safe_text,
 )
 

--- a/ai/tests/test_schemas.py
+++ b/ai/tests/test_schemas.py
@@ -34,7 +34,7 @@ PROJECT_INFO = {
 
 STAGE_INFO = {
     "stage_id": "stage-1",
-    "stage_number": 1,
+    "stage_sequence": 1,
     "name": "요구사항 분석",
 }
 
@@ -78,9 +78,9 @@ class TestProjectInfo:
 class TestStageInfo:
     def test_valid(self):
         m = StageInfo(**STAGE_INFO)
-        assert m.stage_number == 1
+        assert m.stage_sequence == 1
 
-    @pytest.mark.parametrize("missing", ["stage_id", "stage_number", "name"])
+    @pytest.mark.parametrize("missing", ["stage_id", "stage_sequence", "name"])
     def test_missing_required_field(self, missing):
         data = {k: v for k, v in STAGE_INFO.items() if k != missing}
         with pytest.raises(ValidationError):
@@ -102,7 +102,7 @@ class TestStepInfo:
 class TestDecisionHistoryItem:
     def test_valid(self):
         m = DecisionHistoryItem(step_id="s1", name="분석", status="accepted")
-        assert m.stage_number is None
+        assert m.stage_sequence is None
 
     def test_missing_status(self):
         with pytest.raises(ValidationError):

--- a/ai/tests/test_side_panel_generator.py
+++ b/ai/tests/test_side_panel_generator.py
@@ -50,7 +50,7 @@ def _project_minimal() -> ProjectInfo:
 
 
 def _stage() -> StageInfo:
-    return StageInfo(stage_id="stage-1", stage_number=1, name="아이디어 구체화")
+    return StageInfo(stage_id="stage-1", stage_sequence=1, name="아이디어 구체화")
 
 
 def _required_step() -> RequiredStepInfo:
@@ -381,7 +381,7 @@ class TestPromptAssembly:
             "{description}",
             "{constraints}",
             "{initial_prompt}",
-            "{stage_number}",
+            "{stage_sequence}",
             "{stage_name}",
             "{target_step_name}",
             "{decision_history}",

--- a/ai/tests/test_step_generator.py
+++ b/ai/tests/test_step_generator.py
@@ -48,7 +48,7 @@ def _project_minimal() -> ProjectInfo:
 
 
 def _stage() -> StageInfo:
-    return StageInfo(stage_id="stage-1", stage_number=1, name="아이디어 구체화")
+    return StageInfo(stage_id="stage-1", stage_sequence=1, name="아이디어 구체화")
 
 
 def _required_step() -> RequiredStepInfo:
@@ -142,7 +142,7 @@ class TestGenerateStepsHappyPath:
         assert len(result.generated_steps) == 3
 
     @pytest.mark.asyncio
-    async def test_rag_query_uses_stage_number_and_name(self):
+    async def test_rag_query_uses_stage_sequence_and_name(self):
         service, _, rag = _make_service()
 
         await service.generate_steps(_input_with_required())

--- a/ai/tests/test_step_generator_property.py
+++ b/ai/tests/test_step_generator_property.py
@@ -42,7 +42,7 @@ _project_st = st.builds(
 _stage_st = st.builds(
     StageInfo,
     stage_id=_step_id,
-    stage_number=st.integers(min_value=1, max_value=6),
+    stage_sequence=st.integers(min_value=1, max_value=6),
     name=_nonempty,
 )
 


### PR DESCRIPTION
## PR 요약
- 백엔드 DB 컬럼명 정합을 위한 stage_number → stage_sequence 리네이밍

## 변경 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `ai/schemas/common.py`: StageInfo.stage_number → stage_sequence, DecisionHistoryItem.stage_number → stage_sequence
- `ai/prompts/generate.txt`, `ai/prompts/side_panel.txt`: 플레이스홀더 변경
- `ai/services/`, `ai/cli_simulator.py`: 필드 참조 변경
- `ai/tests/` 7개 파일: mock 데이터 + assertion 변경

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- 242개 전체 테스트 통과
- 백엔드 DB의 stage 테이블 컬럼명 `stage_sequence`와 정합