### PR TITLE
[#69][BE] 프로젝트 소유권 검증 및 user_id 연동

### DIFF
--- a/backend/app/business/dependencies.py
+++ b/backend/app/business/dependencies.py
@@ -1,0 +1,59 @@
+from uuid import UUID
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from app.core.auth.dependencies import get_current_user
+from app.core.database import get_db
+from app.core.exceptions import ProjectForbiddenError, ProjectNotFoundError, StepNotFoundError
+from app.core.models.app_user import AppUser as AppUserModel
+from app.core.models.project import Project as ProjectModel
+from app.core.models.step import Step as StepModel
+
+
+def get_owned_project(
+    project_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: AppUserModel = Depends(get_current_user),
+) -> ProjectModel:
+    """project_id가 경로/쿼리 파라미터로 전달되는 엔드포인트에서
+    프로젝트 존재 여부 + 소유권을 한 번에 검증한다."""
+    project = (
+        db.query(ProjectModel)
+        .filter(
+            ProjectModel.id == project_id,
+            ProjectModel.is_deleted.is_(False),
+        )
+        .first()
+    )
+    if not project:
+        raise ProjectNotFoundError()
+    if project.user_id != current_user.id:
+        raise ProjectForbiddenError()
+    return project
+
+
+def get_owned_step(
+    step_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: AppUserModel = Depends(get_current_user),
+) -> StepModel:
+    """step_id만 경로 파라미터로 전달되는 엔드포인트에서
+    step → project 소유권을 한 번에 검증한다."""
+    step = db.get(StepModel, step_id)
+    if not step:
+        raise StepNotFoundError()
+
+    project = (
+        db.query(ProjectModel)
+        .filter(
+            ProjectModel.id == step.project_id,
+            ProjectModel.is_deleted.is_(False),
+        )
+        .first()
+    )
+    if not project:
+        raise ProjectNotFoundError()
+    if project.user_id != current_user.id:
+        raise ProjectForbiddenError()
+    return step

--- a/backend/app/business/routers/projects.py
+++ b/backend/app/business/routers/projects.py
@@ -6,9 +6,11 @@ from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.business.services import project_service
+from app.business.dependencies import get_owned_project
 from app.core.api.route import EnvelopeRouter
 from app.core.auth.dependencies import get_current_user
 from app.core.models.app_user import AppUser as AppUserModel
+from app.core.models.project import Project as ProjectModel
 from app.core.schemas.project import (
     ProjectCreateRequest,
     ProjectListResponse,
@@ -36,20 +38,24 @@ def list_projects(
     sort_order: str = Query("desc"),
     keyword: str | None = Query(None),
     db: Session = Depends(get_db),
+    current_user: AppUserModel = Depends(get_current_user),
 ) -> ProjectListResponse:
-    return project_service.list_projects(db, page, size, sort_by, sort_order, keyword)
+    return project_service.list_projects(db, page, size, sort_by, sort_order, keyword, current_user.id)
 
 
 @router.patch("/{project_id}", status_code=http_status.HTTP_200_OK)
 def update_project(
-    project_id: UUID,
     payload: ProjectUpdateRequest,
     db: Session = Depends(get_db),
+    project: ProjectModel = Depends(get_owned_project),
 ) -> ProjectResponse:
-    return project_service.update_project(db, project_id, payload)
+    return project_service.update_project(db, project.id, payload)
 
 
 @router.delete("/{project_id}", status_code=http_status.HTTP_200_OK)
-def delete_project(project_id: UUID, db: Session = Depends(get_db)) -> None:
-    project_service.delete_project(db, project_id)
+def delete_project(
+    db: Session = Depends(get_db),
+    project: ProjectModel = Depends(get_owned_project),
+) -> None:
+    project_service.delete_project(db, project.id)
     return None

--- a/backend/app/business/routers/projects.py
+++ b/backend/app/business/routers/projects.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.business.services import project_service
 from app.core.api.route import EnvelopeRouter
+from app.core.auth.dependencies import get_current_user
+from app.core.models.app_user import AppUser as AppUserModel
 from app.core.schemas.project import (
     ProjectCreateRequest,
     ProjectListResponse,
@@ -19,9 +21,11 @@ router = EnvelopeRouter()
 
 @router.post("", status_code=http_status.HTTP_201_CREATED)
 def create_project(
-    payload: ProjectCreateRequest, db: Session = Depends(get_db)
+    payload: ProjectCreateRequest,
+    db: Session = Depends(get_db),
+    current_user: AppUserModel = Depends(get_current_user),
 ) -> ProjectResponse:
-    return project_service.create_project(db, payload)
+    return project_service.create_project(db, payload, current_user.id)
 
 
 @router.get("", status_code=http_status.HTTP_200_OK)

--- a/backend/app/business/routers/stages.py
+++ b/backend/app/business/routers/stages.py
@@ -1,17 +1,20 @@
-from uuid import UUID
-
 from fastapi import Depends
 from fastapi import status as http_status
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.business.services import stage_service
+from app.business.dependencies import get_owned_project
 from app.core.api.route import EnvelopeRouter
+from app.core.models.project import Project as ProjectModel
 from app.core.schemas.stage import StageListResponse
 
 router = EnvelopeRouter()
 
 
 @router.get("", status_code=http_status.HTTP_200_OK)
-def list_stages(project_id: UUID, db: Session = Depends(get_db)) -> StageListResponse:
-    return stage_service.list_stages(db, project_id)
+def list_stages(
+    db: Session = Depends(get_db),
+    project: ProjectModel = Depends(get_owned_project),
+) -> StageListResponse:
+    return stage_service.list_stages(db, project.id)

--- a/backend/app/business/routers/steps.py
+++ b/backend/app/business/routers/steps.py
@@ -1,23 +1,27 @@
-from uuid import UUID
-
 from fastapi import Depends
 from fastapi import status as http_status
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.business.services import step_service
+from app.business.dependencies import get_owned_project, get_owned_step
 from app.core.api.route import EnvelopeRouter
+from app.core.models.project import Project as ProjectModel
+from app.core.models.step import Step as StepModel
 from app.core.schemas.step import RequiredStepListResponse, StepTreeResponse
+from uuid import UUID
 
 router = EnvelopeRouter()
 
 
 @router.get("/tree", status_code=http_status.HTTP_200_OK)
 def get_step_tree(
-    project_id: UUID, stage_id: UUID, db: Session = Depends(get_db)
+    stage_id: UUID,
+    db: Session = Depends(get_db),
+    project: ProjectModel = Depends(get_owned_project),
 ) -> StepTreeResponse:
     """project_id + stage_id 기준 Step 트리 + Footprint 경로 반환."""
-    return step_service.get_step_tree(db, project_id, stage_id)
+    return step_service.get_step_tree(db, project.id, stage_id)
 
 
 @router.get("/{stage_id}/required", status_code=http_status.HTTP_200_OK)
@@ -29,5 +33,8 @@ def get_required_steps(
 
 
 @router.post("/{step_id}/rollback", status_code=http_status.HTTP_200_OK)
-def rollback_step(step_id: UUID, db: Session = Depends(get_db)) -> None:
-    return step_service.rollback_step(db, step_id)
+def rollback_step(
+    db: Session = Depends(get_db),
+    step: StepModel = Depends(get_owned_step),
+) -> None:
+    return step_service.rollback_step(db, step.id)

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -108,11 +108,15 @@ def list_projects(
     sort_by: str,
     sort_order: str,
     keyword: str | None = None,
+    user_id: UUID | None = None,
 ) -> ProjectListResponse:
     if sort_by not in _ALLOWED_SORT_COLUMNS:
         sort_by = "created_at"
 
-    query = db.query(ProjectModel).filter(ProjectModel.is_deleted.is_(False))
+    query = db.query(ProjectModel).filter(
+        ProjectModel.is_deleted.is_(False),
+        ProjectModel.user_id == user_id,
+    )
 
     if keyword:
         query = query.filter(ProjectModel.name.ilike(f"%{keyword}%"))

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -25,7 +25,9 @@ from app.core.schemas.project import (
 _ALLOWED_SORT_COLUMNS: frozenset[str] = frozenset({"created_at", "updated_at", "name"})
 
 
-def create_project(db: Session, payload: ProjectCreateRequest) -> ProjectResponse:
+def create_project(
+    db: Session, payload: ProjectCreateRequest, user_id: UUID
+) -> ProjectResponse:
     if payload.name:
         existing = (
             db.query(ProjectModel)
@@ -40,6 +42,7 @@ def create_project(db: Session, payload: ProjectCreateRequest) -> ProjectRespons
 
     project = ProjectModel(
         name=payload.name if payload.name is not None else _generate_default_name(db),
+        user_id=user_id,
         duration_month=payload.duration_months,
         member_count=payload.member_count,
         description=payload.description,

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -61,6 +61,15 @@ class ProjectNotFoundError(PocoError):
         )
 
 
+class ProjectForbiddenError(PocoError):
+    def __init__(self, message: str = "해당 프로젝트에 대한 접근 권한이 없습니다."):
+        super().__init__(
+            code="PROJECT_FORBIDDEN",
+            message=message,
+            status_code=http_status.HTTP_403_FORBIDDEN,
+        )
+
+
 class StageNotFoundError(PocoError):
     def __init__(self, message: str = "Stage를 찾을 수 없습니다."):
         super().__init__(


### PR DESCRIPTION
## PR 요약
- 프로젝트 생성 시 로그인된 유저의 `user_id` 저장
- 프로젝트 목록 조회 시 본인 프로젝트만 반환
- `get_owned_project` / `get_owned_step` dependency로 모든 프로젝트 관련 API 소유권 검증 일원화

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `ProjectForbiddenError` (HTTP 403) 추가
- `app/business/dependencies.py` 신규 생성 — `get_owned_project`, `get_owned_step`
- `projects`, `stages`, `steps` 라우터에 소유권 검증 dependency 적용

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항