### PR TITLE
[#60][BE] Repository 레이어 도입으로 Service-DB 로직 분리

### DIFF
--- a/backend/app/ai/services/step_service.py
+++ b/backend/app/ai/services/step_service.py
@@ -1,6 +1,5 @@
 import json
 import uuid
-from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
@@ -8,13 +7,13 @@ from app.ai.services import orchestrator
 from app.ai.services.rag import retrieve
 from app.core.enums import StepStatus
 from app.core.exceptions import StepAlreadyAcceptedError, StepNotFoundError
-from app.core.models.project_required_step_status import ProjectRequiredStepStatus
-from app.core.models.required_step import RequiredStep as RequiredStepModel
-from app.core.models.project import ProjectStage
 from app.core.models.step import Step as StepModel
-from app.core.models.step import StepContent as StepContentModel
-from app.core.models.step import StepTree as StepTreeModel
-from app.core.models.stage import Stage as StageModel
+from app.core.repositories import (
+    project as project_repo,
+    required_step as required_step_repo,
+    stage as stage_repo,
+    step as step_repo,
+)
 from app.core.schemas.step import (
     AcceptedStepItem,
     AcceptRequest,
@@ -34,8 +33,10 @@ from app.core.schemas.step import (
 )
 
 
+# ────────────────────────── 스키마 변환 헬퍼 ──────────────────────────
+
+
 def _build_project_info(step: StepModel) -> ProjectInfo:
-    """Step에서 ProjectInfo 스키마를 구성."""
     project = step.project
     return ProjectInfo(
         project_id=project.id,
@@ -49,7 +50,6 @@ def _build_project_info(step: StepModel) -> ProjectInfo:
 
 
 def _build_current_stage(step: StepModel) -> CurrentStage:
-    """Step에서 CurrentStage 스키마를 구성."""
     stage = step.stage
     return CurrentStage(
         stage_id=stage.id,
@@ -58,191 +58,125 @@ def _build_current_stage(step: StepModel) -> CurrentStage:
     )
 
 
-def _get_fulfilled_required_step_ids(
-    db: Session, project_id: uuid.UUID
-) -> set[uuid.UUID]:
-    """프로젝트에서 이미 충족된 Required Step ID 집합."""
-    return {
-        row.required_step_id
-        for row in db.query(ProjectRequiredStepStatus).filter_by(
-            project_id=project_id, is_fulfilled=True
-        )
-    }
+def _to_current_required_step(rs) -> CurrentRequiredStep:
+    return CurrentRequiredStep(
+        step_id=rs.id,
+        name=rs.name,
+        is_completed=False,
+        goal=rs.goal,
+        entry_criteria=rs.entry_criteria,
+        fulfillment_criteria=rs.fulfillment_criteria,
+        minimum_fulfillment_count=rs.minimum_fulfillment_count,
+    )
 
 
 def _get_current_required_step(
     db: Session, stage_id: uuid.UUID, fulfilled_ids: set[uuid.UUID]
 ) -> CurrentRequiredStep | None:
-    """현재 Stage에서 미충족 첫 번째 Required Step을 반환."""
-    all_required = (
-        db.query(RequiredStepModel)
-        .filter(RequiredStepModel.stage_id == stage_id)
-        .order_by(RequiredStepModel.sequence)
-        .all()
-    )
+    """현재 Stage 에서 미충족 첫 번째 Required Step 반환."""
+    all_required = required_step_repo.get_required_steps_in_stage(db, stage_id)
     current_rs = next((rs for rs in all_required if rs.id not in fulfilled_ids), None)
-    if current_rs is None:
-        return None
-    return CurrentRequiredStep(
-        step_id=current_rs.id,
-        name=current_rs.name,
-        is_completed=False,
-        goal=current_rs.goal,
-        entry_criteria=current_rs.entry_criteria,
-        fulfillment_criteria=current_rs.fulfillment_criteria,
-        minimum_fulfillment_count=current_rs.minimum_fulfillment_count,
-    )
+    return _to_current_required_step(current_rs) if current_rs else None
 
 
 def _get_required_steps_status(
     db: Session, stage_id: uuid.UUID, fulfilled_ids: set[uuid.UUID]
 ) -> list[RequiredStepStatusItem]:
-    """Stage의 전체 Required Step 상태 목록."""
-    all_required = (
-        db.query(RequiredStepModel)
-        .filter(RequiredStepModel.stage_id == stage_id)
-        .order_by(RequiredStepModel.sequence)
-        .all()
-    )
     return [
         RequiredStepStatusItem(
             name=rs.name,
             order=rs.sequence,
             is_completed=rs.id in fulfilled_ids,
         )
-        for rs in all_required
+        for rs in required_step_repo.get_required_steps_in_stage(db, stage_id)
     ]
 
 
-def _insert_closure_rows(
-    db: Session, step_id: uuid.UUID, parent_step_id: uuid.UUID | None
-) -> None:
-    db.add(StepTreeModel(ancestor=step_id, descendant=step_id, depth=0))
-    if parent_step_id is None:
-        return
-    parent_ancestors = (
-        db.query(StepTreeModel).filter(StepTreeModel.descendant == parent_step_id).all()
-    )
-    for row in parent_ancestors:
-        db.add(
-            StepTreeModel(
-                ancestor=row.ancestor, descendant=step_id, depth=row.depth + 1
-            )
-        )
+# ────────────────────────────── Accept ──────────────────────────────
 
 
 async def accept_step(db: Session, step_id: uuid.UUID) -> StepAcceptResponse:
-    # ① 조회 및 검증
-    step = db.get(StepModel, step_id)
+    step = step_repo.get_step(db, step_id)
     if step is None:
         raise StepNotFoundError()
     if step.status == StepStatus.ACCEPTED:
         raise StepAlreadyAcceptedError()
 
-    # ② ACCEPTED 처리
     step.status = StepStatus.ACCEPTED
 
-    # ③ 형제 Step CANCELED
+    # 형제 Step 중 일반 Step 만 CANCELED
     if step.parent_step_id is not None:
-        siblings = (
-            db.query(StepModel)
-            .filter(
-                StepModel.parent_step_id == step.parent_step_id,
-                StepModel.id != step_id,
-                StepModel.status == StepStatus.READY,
-            )
-            .all()
-        )
-        for sibling in siblings:
+        for sibling in step_repo.get_ready_siblings(db, step.parent_step_id, step_id):
             if sibling.required_step_id is None:
                 sibling.status = StepStatus.CANCELED
 
     db.flush()
 
-    # ④ Bedrock 호출 (필수 Step 영역 안에 있을 때만)
+    # Bedrock 호출 (필수 Step 영역 안에 있을 때만)
     is_completed = False
     if step.belonging_required_step_id is not None:
-
-        # DB에 이미 완료된 상태면 Bedrock 호출 스킵
-        existing = db.get(
-            ProjectRequiredStepStatus,
-            {
-                "project_id": step.project_id,
-                "required_step_id": step.belonging_required_step_id,
-            },
+        existing = project_repo.get_required_step_status(
+            db, step.project_id, step.belonging_required_step_id
         )
         if existing and existing.is_fulfilled:
-            is_completed = True  # 이미 완료 → Bedrock 호출 안 함
+            is_completed = True
         else:
             request = _build_accept_request(db, step)
             result = await orchestrator.call_accept(request)
             is_completed = result.is_current_required_step_completed
             if is_completed:
-                _upsert_required_step_status(
-                    db,
-                    project_id=step.project_id,
-                    required_step_id=step.belonging_required_step_id,
+                project_repo.upsert_required_step_fulfilled(
+                    db, step.project_id, step.belonging_required_step_id
                 )
 
     db.commit()
-    # 스테이지 완료 여부 확인
-    all_required = (
-        db.query(RequiredStepModel)
-        .filter(RequiredStepModel.stage_id == step.stage_id)
-        .all()
-    )
-    updated_fulfilled_ids = _get_fulfilled_required_step_ids(db, step.project_id)
-    is_stage_completed = bool(all_required) and all(
-        rs.id in updated_fulfilled_ids for rs in all_required
-    )
 
-    if is_stage_completed:
-        next_stage = (
-            db.query(StageModel)
-            .filter(StageModel.sequence == step.stage.sequence + 1)
-            .first()
-        )
-        if next_stage:
-            next_project_stage = db.get(
-                ProjectStage,
-                {"project_id": step.project_id, "stage_id": next_stage.id},
-            )
-            if next_project_stage:
-                next_project_stage.is_active = True
-                db.commit()
+    # Stage 완료 여부 확인 + 다음 Stage 활성화
+    is_stage_completed = _check_and_advance_stage(db, step)
 
     return StepAcceptResponse(
         step_id=step_id,
         status=StepStatus.ACCEPTED,
         is_current_required_step_completed=is_completed,
-        is_current_stage_completed=is_stage_completed, 
+        is_current_stage_completed=is_stage_completed,
     )
 
 
+def _check_and_advance_stage(db: Session, step: StepModel) -> bool:
+    """현재 Stage 의 모든 Required Step 충족됐으면 다음 Stage 를 활성화한다."""
+    all_required = required_step_repo.get_required_steps_in_stage(db, step.stage_id)
+    fulfilled_ids = project_repo.get_fulfilled_required_step_ids(db, step.project_id)
+    is_completed = bool(all_required) and all(
+        rs.id in fulfilled_ids for rs in all_required
+    )
+    if not is_completed:
+        return False
+
+    next_stage = stage_repo.get_stage_by_sequence(db, step.stage.sequence + 1)
+    if next_stage is None:
+        return True
+
+    next_ps = project_repo.get_project_stage(db, step.project_id, next_stage.id)
+    if next_ps is not None:
+        next_ps.is_active = True
+        db.commit()
+    return True
+
+
 def _build_accept_request(db: Session, step: StepModel) -> AcceptRequest:
-    fulfilled_ids = _get_fulfilled_required_step_ids(db, step.project_id)
+    fulfilled_ids = project_repo.get_fulfilled_required_step_ids(db, step.project_id)
 
-    current_rs = db.get(RequiredStepModel, step.belonging_required_step_id)
-    current_required_step = None
-    if current_rs and current_rs.id not in fulfilled_ids:
-        current_required_step = CurrentRequiredStep(
-            step_id=current_rs.id,
-            name=current_rs.name,
-            is_completed=False,
-            goal=current_rs.goal,
-            entry_criteria=current_rs.entry_criteria,
-            fulfillment_criteria=current_rs.fulfillment_criteria,
-            minimum_fulfillment_count=current_rs.minimum_fulfillment_count,
-        )
+    current_rs = required_step_repo.get_required_step(
+        db, step.belonging_required_step_id
+    )
+    current_required_step = (
+        _to_current_required_step(current_rs)
+        if current_rs and current_rs.id not in fulfilled_ids
+        else None
+    )
 
-    accepted_in_required = (
-        db.query(StepModel)
-        .filter(
-            StepModel.project_id == step.project_id,
-            StepModel.belonging_required_step_id == step.belonging_required_step_id,
-            StepModel.status == StepStatus.ACCEPTED,
-        )
-        .all()
+    accepted_in_required = step_repo.get_accepted_steps_in_required(
+        db, step.project_id, step.belonging_required_step_id
     )
 
     rag_results = retrieve(f"{step.stage.name} {step.name}")
@@ -262,46 +196,26 @@ def _build_accept_request(db: Session, step: StepModel) -> AcceptRequest:
     )
 
 
-def _upsert_required_step_status(
-    db: Session,
-    project_id: uuid.UUID,
-    required_step_id: uuid.UUID,
-) -> None:
-    record = db.get(
-        ProjectRequiredStepStatus,
-        {"project_id": project_id, "required_step_id": required_step_id},
-    )
-    if record is None:
-        record = ProjectRequiredStepStatus(
-            project_id=project_id,
-            required_step_id=required_step_id,
-        )
-        db.add(record)
-    record.is_fulfilled = True
-    record.fulfilled_at = datetime.now(timezone.utc)
+# ────────────────────────────── Generate ──────────────────────────────
 
 
-async def generate_steps(db: Session, parent_step_id: uuid.UUID) -> StepGenerateResponse:
-    parent_step = db.get(StepModel, parent_step_id)
+async def generate_steps(
+    db: Session, parent_step_id: uuid.UUID
+) -> StepGenerateResponse:
+    parent_step = step_repo.get_step(db, parent_step_id)
     if parent_step is None:
         raise StepNotFoundError(f"Parent Step을 찾을 수 없습니다: {parent_step_id}")
 
-    # ① Bedrock으로 일반 Step 이름 3개 생성
     request = _build_generate_request(db, parent_step)
     result = await orchestrator.call_generate(request)
-    generated: list[dict] = result.generated_steps
+    generated = result.generated_steps
 
-    # ② 부모가 필수 Step 영역에 속하면 자식도 같은 영역에 속함
     belonging_rs_id = (
         parent_step.belonging_required_step_id or parent_step.required_step_id
     )
 
     steps: list[StepModel] = []
-
-    # ③ 필수 Step 노드 포함 여부 판단 + 생성/재사용
     _attach_or_create_required_step_node(db, parent_step, steps)
-
-    # ④ 일반 Step 생성
     _create_generated_step_nodes(db, parent_step, generated, belonging_rs_id, steps)
 
     db.commit()
@@ -325,7 +239,6 @@ async def generate_steps(db: Session, parent_step_id: uuid.UUID) -> StepGenerate
 def _attach_or_create_required_step_node(
     db: Session, parent_step: StepModel, steps: list[StepModel]
 ) -> None:
-    """다음 미충족 필수 Step 노드를 재사용하거나 새로 생성하여 steps에 추가."""
     next_rs_id = _get_next_unfulfilled_required_step_id(db, parent_step)
     if next_rs_id is None:
         return
@@ -337,32 +250,22 @@ def _attach_or_create_required_step_node(
     if already_inside:
         return
 
-    # 기존 READY 필수 Step 노드 재사용
-    existing_pending = (
-        db.query(StepModel)
-        .filter(
-            StepModel.project_id == parent_step.project_id,
-            StepModel.stage_id == parent_step.stage_id,
-            StepModel.required_step_id == next_rs_id,
-            StepModel.status == StepStatus.READY,
-        )
-        .first()
+    existing_pending = step_repo.get_existing_pending_required_step(
+        db, parent_step.project_id, parent_step.stage_id, next_rs_id
     )
 
     if existing_pending:
         existing_pending.parent_step_id = parent_step.id
         existing_pending.sort_order = 0
-        db.query(StepTreeModel).filter(
-            StepTreeModel.descendant == existing_pending.id
-        ).delete()
+        step_repo.delete_closure_for_descendant(db, existing_pending.id)
         db.flush()
-        _insert_closure_rows(db, existing_pending.id, parent_step.id)
+        step_repo.insert_closure_with_parent(db, existing_pending.id, parent_step.id)
         db.flush()
         steps.append(existing_pending)
     else:
-        next_rs = db.get(RequiredStepModel, next_rs_id)
-        req_step = StepModel(
-            id=uuid.uuid4(),
+        next_rs = required_step_repo.get_required_step(db, next_rs_id)
+        req_step = step_repo.add_step(
+            db,
             project_id=parent_step.project_id,
             stage_id=parent_step.stage_id,
             parent_step_id=parent_step.id,
@@ -372,23 +275,20 @@ def _attach_or_create_required_step_node(
             status=StepStatus.READY,
             sort_order=0,
         )
-        db.add(req_step)
-        db.flush()
-        _insert_closure_rows(db, req_step.id, parent_step.id)
+        step_repo.insert_closure_with_parent(db, req_step.id, parent_step.id)
         steps.append(req_step)
 
 
 def _create_generated_step_nodes(
     db: Session,
     parent_step: StepModel,
-    generated: list[dict],
+    generated: list,
     belonging_rs_id: uuid.UUID | None,
     steps: list[StepModel],
 ) -> None:
-    """AI가 생성한 일반 Step 이름들로 Step 노드를 생성하여 steps에 추가."""
     for i, item in enumerate(generated, start=1):
-        step = StepModel(
-            id=uuid.uuid4(),
+        step = step_repo.add_step(
+            db,
             project_id=parent_step.project_id,
             stage_id=parent_step.stage_id,
             parent_step_id=parent_step.id,
@@ -398,25 +298,17 @@ def _create_generated_step_nodes(
             status=StepStatus.READY,
             sort_order=i,
         )
-        db.add(step)
-        db.flush()
-        _insert_closure_rows(db, step.id, parent_step.id)
+        step_repo.insert_closure_with_parent(db, step.id, parent_step.id)
         steps.append(step)
 
 
 def _build_generate_request(db: Session, parent_step: StepModel) -> GenerateRequest:
-    fulfilled_ids = _get_fulfilled_required_step_ids(db, parent_step.project_id)
-
-    accepted_steps = (
-        db.query(StepModel)
-        .filter(
-            StepModel.project_id == parent_step.project_id,
-            StepModel.stage_id == parent_step.stage_id,
-            StepModel.status == StepStatus.ACCEPTED,
-        )
-        .all()
+    fulfilled_ids = project_repo.get_fulfilled_required_step_ids(
+        db, parent_step.project_id
     )
-
+    accepted_steps = step_repo.get_accepted_steps_in_stage(
+        db, parent_step.project_id, parent_step.stage_id
+    )
     rag_results = retrieve(f"{parent_step.stage.name} {parent_step.name}")
 
     return GenerateRequest(
@@ -437,51 +329,32 @@ def _build_generate_request(db: Session, parent_step: StepModel) -> GenerateRequ
 def _get_next_unfulfilled_required_step_id(
     db: Session, step: StepModel
 ) -> uuid.UUID | None:
-    fulfilled_ids = _get_fulfilled_required_step_ids(db, step.project_id)
-    query = db.query(RequiredStepModel).filter(
-        RequiredStepModel.stage_id == step.stage_id
-    )
-    if fulfilled_ids:
-        query = query.filter(RequiredStepModel.id.not_in(fulfilled_ids))
-    next_rs = query.order_by(RequiredStepModel.sequence).first()
+    fulfilled_ids = project_repo.get_fulfilled_required_step_ids(db, step.project_id)
+    all_rs = required_step_repo.get_required_steps_in_stage(db, step.stage_id)
+    next_rs = next((rs for rs in all_rs if rs.id not in fulfilled_ids), None)
     return next_rs.id if next_rs else None
 
 
-# 사이드 패널
+# ──────────────────────────── 사이드 패널 ────────────────────────────
+
+
 async def get_step_detail(db: Session, step_id: uuid.UUID) -> StepDetailResponse:
-    step = db.get(StepModel, step_id)
+    step = step_repo.get_step(db, step_id)
     if step is None:
         raise StepNotFoundError()
 
-    # 필수 Step → DB 캐시 반환. content가 없으면 RequiredStep 기본값으로 생성
+    # 필수 Step → DB 캐시 또는 RequiredStep 기본값으로 lazy 생성
     if step.required_step_id is not None:
         content = step.content
         if content is None:
-            rs = db.get(RequiredStepModel, step.required_step_id)
-            content = StepContentModel(step_id=step.id)
-            if rs is not None:
-                if rs.default_mentoring is not None:
-                    content.mentoring = json.dumps(
-                        rs.default_mentoring, ensure_ascii=False
-                    )
-                if rs.default_dictionary is not None:
-                    content.dictionary = json.dumps(
-                        rs.default_dictionary, ensure_ascii=False
-                    )
-            db.add(content)
+            content = _create_default_step_content(db, step)
             db.commit()
         return StepDetailResponse(
             is_required=True,
             step_id=step.id,
             name=step.name,
-            mentoring=(
-                json.loads(content.mentoring) if content and content.mentoring else None
-            ),
-            dictionary=(
-                json.loads(content.dictionary)
-                if content and content.dictionary
-                else None
-            ),
+            mentoring=_loads_or_none(content.mentoring if content else None),
+            dictionary=_loads_or_none(content.dictionary if content else None),
             template_url=content.template_url if content else None,
         )
 
@@ -492,21 +365,20 @@ async def get_step_detail(db: Session, step_id: uuid.UUID) -> StepDetailResponse
             is_required=False,
             step_id=step.id,
             name=step.name,
-            mentoring=json.loads(content.mentoring) if content.mentoring else None,
-            dictionary=(json.loads(content.dictionary) if content.dictionary else None),
+            mentoring=_loads_or_none(content.mentoring),
+            dictionary=_loads_or_none(content.dictionary),
         )
 
-    # AI 호출
     request = _build_side_panel_request(db, step)
     result = await orchestrator.call_side_panel(request)
 
-    # StepContent에 저장
     if content is None:
-        content = StepContentModel(step_id=step.id)
-        db.add(content)
+        content = step_repo.add_step_content(db, step.id)
 
     content.mentoring = json.dumps(result.mentoring.model_dump(), ensure_ascii=False)
-    content.dictionary = json.dumps([d.model_dump() for d in result.dictionary], ensure_ascii=False)
+    content.dictionary = json.dumps(
+        [d.model_dump() for d in result.dictionary], ensure_ascii=False
+    )
     db.commit()
 
     return StepDetailResponse(
@@ -518,20 +390,35 @@ async def get_step_detail(db: Session, step_id: uuid.UUID) -> StepDetailResponse
     )
 
 
-def _build_side_panel_request(db: Session, step: StepModel) -> SidePanelRequest:
-    fulfilled_ids = _get_fulfilled_required_step_ids(db, step.project_id)
-    stage = step.stage
-
-    accepted_steps = (
-        db.query(StepModel)
-        .filter(
-            StepModel.project_id == step.project_id,
-            StepModel.stage_id == step.stage_id,
-            StepModel.status == StepStatus.ACCEPTED,
-        )
-        .all()
+def _create_default_step_content(db: Session, step: StepModel):
+    """RequiredStep 의 default_mentoring/dictionary 를 StepContent 로 복사."""
+    rs = required_step_repo.get_required_step(db, step.required_step_id)
+    mentoring = (
+        json.dumps(rs.default_mentoring, ensure_ascii=False)
+        if rs and rs.default_mentoring
+        else None
+    )
+    dictionary = (
+        json.dumps(rs.default_dictionary, ensure_ascii=False)
+        if rs and rs.default_dictionary
+        else None
+    )
+    return step_repo.add_step_content(
+        db, step.id, mentoring=mentoring, dictionary=dictionary
     )
 
+
+def _loads_or_none(value: str | None):
+    return json.loads(value) if value else None
+
+
+def _build_side_panel_request(db: Session, step: StepModel) -> SidePanelRequest:
+    fulfilled_ids = project_repo.get_fulfilled_required_step_ids(db, step.project_id)
+    stage = step.stage
+
+    accepted_steps = step_repo.get_accepted_steps_in_stage(
+        db, step.project_id, step.stage_id
+    )
     rag_results = retrieve(f"{stage.name} {step.name}")
 
     return SidePanelRequest(

--- a/backend/app/business/dependencies.py
+++ b/backend/app/business/dependencies.py
@@ -3,12 +3,14 @@ from uuid import UUID
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
+from app.business.services import project_service
 from app.core.auth.dependencies import get_current_user
 from app.core.database import get_db
-from app.core.exceptions import ProjectForbiddenError, ProjectNotFoundError, StepNotFoundError
+from app.core.exceptions import ProjectForbiddenError, StepNotFoundError
 from app.core.models.app_user import AppUser as AppUserModel
 from app.core.models.project import Project as ProjectModel
 from app.core.models.step import Step as StepModel
+from app.core.repositories import step as step_repo
 
 
 def get_owned_project(
@@ -16,18 +18,8 @@ def get_owned_project(
     db: Session = Depends(get_db),
     current_user: AppUserModel = Depends(get_current_user),
 ) -> ProjectModel:
-    """project_id가 경로/쿼리 파라미터로 전달되는 엔드포인트에서
-    프로젝트 존재 여부 + 소유권을 한 번에 검증한다."""
-    project = (
-        db.query(ProjectModel)
-        .filter(
-            ProjectModel.id == project_id,
-            ProjectModel.is_deleted.is_(False),
-        )
-        .first()
-    )
-    if not project:
-        raise ProjectNotFoundError()
+    """프로젝트 존재 여부 + 소유권 검증."""
+    project = project_service.get_project_or_raise(db, project_id)
     if project.user_id != current_user.id:
         raise ProjectForbiddenError()
     return project
@@ -38,22 +30,12 @@ def get_owned_step(
     db: Session = Depends(get_db),
     current_user: AppUserModel = Depends(get_current_user),
 ) -> StepModel:
-    """step_id만 경로 파라미터로 전달되는 엔드포인트에서
-    step → project 소유권을 한 번에 검증한다."""
-    step = db.get(StepModel, step_id)
+    """step → project 소유권 검증."""
+    step = step_repo.get_step(db, step_id)
     if not step:
         raise StepNotFoundError()
 
-    project = (
-        db.query(ProjectModel)
-        .filter(
-            ProjectModel.id == step.project_id,
-            ProjectModel.is_deleted.is_(False),
-        )
-        .first()
-    )
-    if not project:
-        raise ProjectNotFoundError()
+    project = project_service.get_project_or_raise(db, step.project_id)
     if project.user_id != current_user.id:
         raise ProjectForbiddenError()
     return step

--- a/backend/app/business/services/auth_service.py
+++ b/backend/app/business/services/auth_service.py
@@ -12,7 +12,7 @@ from app.core.auth.jwt import (
 from app.core.config import settings
 from app.core.exceptions import UserNotFoundError
 from app.core.models.app_user import AppUser as AppUserModel
-from app.core.models.oauth_account import OAuthAccount as OAuthAccountModel
+from app.core.repositories import user as user_repo
 from app.core.schemas.auth import (
     AuthTokenResponse,
     OAuthTokens,
@@ -50,9 +50,7 @@ def refresh_access_token(refresh_token: str) -> AuthTokenResponse:
 
 
 def get_user_profile(db: Session, user: AppUserModel) -> UserProfileResponse:
-    oauth = (
-        db.query(OAuthAccountModel).filter(OAuthAccountModel.user_id == user.id).first()
-    )
+    oauth = user_repo.get_oauth_by_user_id(db, user.id)
     return UserProfileResponse(
         user_id=user.id,
         email=user.email,
@@ -67,42 +65,34 @@ def _get_or_create_user(
     user_info: OAuthUserInfo,
     oauth_tokens: OAuthTokens,
 ) -> AppUserModel:
-    oauth = (
-        db.query(OAuthAccountModel)
-        .filter(
-            OAuthAccountModel.provider == provider_name,
-            OAuthAccountModel.provider_user_id == user_info.provider_user_id,
-        )
-        .first()
-    )
-
     expires_at = (
         datetime.now(timezone.utc) + timedelta(seconds=oauth_tokens.expires_in)
         if oauth_tokens.expires_in
         else None
     )
 
+    oauth = user_repo.get_oauth_by_provider_and_user(
+        db, provider_name, user_info.provider_user_id
+    )
+
     if oauth:
-        oauth.access_token = oauth_tokens.access_token
-        if oauth_tokens.refresh_token:
-            oauth.refresh_token = oauth_tokens.refresh_token
-        oauth.token_expires_at = expires_at
+        user_repo.update_oauth_tokens(
+            oauth,
+            access_token=oauth_tokens.access_token,
+            refresh_token=oauth_tokens.refresh_token,
+            token_expires_at=expires_at,
+        )
         db.commit()
 
-        user = db.get(AppUserModel, oauth.user_id)
-        if not user or user.is_deleted:
+        user = user_repo.get_active_user(db, oauth.user_id)
+        if not user:
             raise UserNotFoundError()
         return user
 
     # 신규 사용자 생성
-    user = AppUserModel(
-        email=user_info.email,
-        nickname=user_info.nickname,
-    )
-    db.add(user)
-    db.flush()
-
-    oauth = OAuthAccountModel(
+    user = user_repo.add_user(db, email=user_info.email, nickname=user_info.nickname)
+    user_repo.add_oauth_account(
+        db,
         user_id=user.id,
         provider=provider_name,
         provider_user_id=user_info.provider_user_id,
@@ -110,7 +100,6 @@ def _get_or_create_user(
         refresh_token=oauth_tokens.refresh_token,
         token_expires_at=expires_at,
     )
-    db.add(oauth)
     db.commit()
     db.refresh(user)
     return user

--- a/backend/app/business/services/project_service.py
+++ b/backend/app/business/services/project_service.py
@@ -1,21 +1,17 @@
 import json
-import uuid
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from app.core.enums import StepStatus
 from app.core.exceptions import DuplicateProjectNameError, ProjectNotFoundError
 from app.core.models.project import Project as ProjectModel
-from app.core.models.project import ProjectStage as ProjectStageModel
-from app.core.models.project_required_step_status import (
-    ProjectRequiredStepStatus as ProjectRequiredStepStatusModel,
+from app.core.repositories import (
+    project as project_repo,
+    required_step as required_step_repo,
+    stage as stage_repo,
+    step as step_repo,
 )
-from app.core.models.required_step import RequiredStep as RequiredStepModel
-from app.core.models.stage import Stage as StageModel
-from app.core.models.step import Step as StepModel
-from app.core.models.step import StepContent as StepContentModel
-from app.core.models.step import StepTree as StepTreeModel
-from app.core.enums import StepStatus
 from app.core.schemas.project import (
     ProjectCreateRequest,
     ProjectListItemResponse,
@@ -31,48 +27,32 @@ def create_project(
     db: Session, payload: ProjectCreateRequest, user_id: UUID
 ) -> ProjectResponse:
     if payload.name:
-        existing = (
-            db.query(ProjectModel)
-            .filter(
-                ProjectModel.name == payload.name,
-                ProjectModel.is_deleted.is_(False),
-            )
-            .first()
-        )
+        existing = project_repo.get_active_project_by_name(db, payload.name)
         if existing:
             raise DuplicateProjectNameError()
 
-    project = ProjectModel(
-        name=payload.name if payload.name is not None else _generate_default_name(db),
-        user_id=user_id,
-        duration_month=payload.duration_months,
-        member_count=payload.member_count,
-        description=payload.description,
-        constraint_text=payload.constraint,
-        prompt=payload.prompt,
+    project = project_repo.add_project(
+        db,
+        ProjectModel(
+            name=(
+                payload.name if payload.name is not None else _generate_default_name(db)
+            ),
+            user_id=user_id,
+            duration_month=payload.duration_months,
+            member_count=payload.member_count,
+            description=payload.description,
+            constraint_text=payload.constraint,
+            prompt=payload.prompt,
+        ),
     )
-    db.add(project)
-    db.flush()
 
-    stages = db.query(StageModel).order_by(StageModel.sequence).all()
-    for i, stage in enumerate(stages):
-        db.add(
-            ProjectStageModel(
-                project_id=project.id,
-                stage_id=stage.id,
-                is_active=(i == 0),
-            )
-        )
+    stages = stage_repo.get_all_stages_ordered(db)
+    project_repo.create_initial_project_stages(db, project.id, [s.id for s in stages])
 
-    required_steps = db.query(RequiredStepModel).all()
-    for rs in required_steps:
-        db.add(
-            ProjectRequiredStepStatusModel(
-                project_id=project.id,
-                required_step_id=rs.id,
-                is_fulfilled=False,
-            )
-        )
+    required_steps = required_step_repo.get_all_required_steps(db)
+    project_repo.create_initial_project_rs_statuses(
+        db, project.id, [rs.id for rs in required_steps]
+    )
 
     _create_initial_steps_for_each_stage(db, project.id)
 
@@ -83,12 +63,9 @@ def create_project(
 
 def _create_initial_steps_for_each_stage(db: Session, project_id: UUID) -> None:
     """각 Stage의 첫 번째(sequence=1) Required Step을 루트 Step으로 생성."""
-    first_required_steps = (
-        db.query(RequiredStepModel).filter(RequiredStepModel.sequence == 1).all()
-    )
-    for rs in first_required_steps:
-        step = StepModel(
-            id=uuid.uuid4(),
+    for rs in required_step_repo.get_first_rs_of_stages(db):
+        step = step_repo.add_step(
+            db,
             project_id=project_id,
             stage_id=rs.stage_id,
             parent_step_id=None,
@@ -98,15 +75,22 @@ def _create_initial_steps_for_each_stage(db: Session, project_id: UUID) -> None:
             status=StepStatus.READY,
             sort_order=0,
         )
-        db.add(step)
-        db.flush()
-        db.add(StepTreeModel(ancestor=step.id, descendant=step.id, depth=0))
+        step_repo.insert_closure_self(db, step.id)
         if rs.default_mentoring is not None or rs.default_dictionary is not None:
-            db.add(StepContentModel(
-                step_id=step.id,
-                mentoring=json.dumps(rs.default_mentoring, ensure_ascii=False) if rs.default_mentoring else None,
-                dictionary=json.dumps(rs.default_dictionary, ensure_ascii=False) if rs.default_dictionary else None,
-            ))
+            step_repo.add_step_content(
+                db,
+                step.id,
+                mentoring=(
+                    json.dumps(rs.default_mentoring, ensure_ascii=False)
+                    if rs.default_mentoring
+                    else None
+                ),
+                dictionary=(
+                    json.dumps(rs.default_dictionary, ensure_ascii=False)
+                    if rs.default_dictionary
+                    else None
+                ),
+            )
 
 
 def list_projects(
@@ -121,19 +105,9 @@ def list_projects(
     if sort_by not in _ALLOWED_SORT_COLUMNS:
         sort_by = "created_at"
 
-    query = db.query(ProjectModel).filter(
-        ProjectModel.is_deleted.is_(False),
-        ProjectModel.user_id == user_id,
+    projects, total_count = project_repo.get_projects_by_user(
+        db, user_id, page, size, sort_by, sort_order, keyword
     )
-
-    if keyword:
-        query = query.filter(ProjectModel.name.ilike(f"%{keyword}%"))
-
-    sort_col = getattr(ProjectModel, sort_by)
-    query = query.order_by(sort_col.desc() if sort_order == "desc" else sort_col.asc())
-
-    total_count = query.count()
-    projects = query.offset((page - 1) * size).limit(size).all()
 
     return ProjectListResponse(
         projects=[
@@ -161,27 +135,22 @@ def list_projects(
 def update_project(
     db: Session, project_id: UUID, payload: ProjectUpdateRequest
 ) -> ProjectResponse:
-    project = _get_project_or_raise(db, project_id)
+    project = get_project_or_raise(db, project_id)
 
     if payload.name is not None:
-        existing = (
-            db.query(ProjectModel)
-            .filter(
-                ProjectModel.name == payload.name,
-                ProjectModel.id != project_id,
-                ProjectModel.is_deleted.is_(False),
-            )
-            .first()
+        existing = project_repo.get_active_project_by_name(
+            db, payload.name, exclude_id=project_id
         )
         if existing:
             raise DuplicateProjectNameError()
-        project.name = payload.name
-    if payload.description is not None:
-        project.description = payload.description
-    if payload.duration_months is not None:
-        project.duration_month = payload.duration_months
-    if payload.member_count is not None:
-        project.member_count = payload.member_count
+
+    project_repo.update_project_fields(
+        project,
+        name=payload.name,
+        description=payload.description,
+        duration_month=payload.duration_months,
+        member_count=payload.member_count,
+    )
 
     db.commit()
     db.refresh(project)
@@ -189,38 +158,21 @@ def update_project(
 
 
 def delete_project(db: Session, project_id: UUID) -> None:
-    project = _get_project_or_raise(db, project_id)
-    project.is_deleted = True
+    project = get_project_or_raise(db, project_id)
+    project_repo.soft_delete_project(project)
     db.commit()
 
 
-def _get_project_or_raise(db: Session, project_id: UUID) -> ProjectModel:
-    project = (
-        db.query(ProjectModel)
-        .filter(
-            ProjectModel.id == project_id,
-            ProjectModel.is_deleted.is_(False),
-        )
-        .first()
-    )
+def get_project_or_raise(db: Session, project_id: UUID) -> ProjectModel:
+    project = project_repo.get_active_project_by_id(db, project_id)
     if not project:
         raise ProjectNotFoundError()
     return project
 
 
 def _get_current_stage_sequence(db: Session, project_id: UUID) -> int:
-    """is_active=True인 Stage의 sequence를 반환."""
-    row = (
-        db.query(StageModel.sequence)
-        .join(ProjectStageModel, ProjectStageModel.stage_id == StageModel.id)
-        .filter(
-            ProjectStageModel.project_id == project_id,
-            ProjectStageModel.is_active.is_(True),
-        )
-        .order_by(StageModel.sequence)
-        .first()
-    )
-    return row[0] if row else 1
+    seq = project_repo.get_active_stage_sequence(db, project_id)
+    return seq if seq is not None else 1
 
 
 def _to_project_response(db: Session, project: ProjectModel) -> ProjectResponse:
@@ -236,15 +188,7 @@ def _to_project_response(db: Session, project: ProjectModel) -> ProjectResponse:
 
 def _generate_default_name(db: Session) -> str:
     base = "새 프로젝트"
-    existing_names = (
-        db.query(ProjectModel.name)
-        .filter(
-            ProjectModel.name.ilike(f"{base}%"),
-            ProjectModel.is_deleted.is_(False),
-        )
-        .all()
-    )
-    existing_names = {row[0] for row in existing_names}
+    existing_names = project_repo.get_active_names_by_prefix(db, base)
 
     if base not in existing_names:
         return base

--- a/backend/app/business/services/stage_service.py
+++ b/backend/app/business/services/stage_service.py
@@ -2,41 +2,24 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.core.exceptions import ProjectNotFoundError
-from app.core.models.project import Project as ProjectModel
-from app.core.models.project import ProjectStage as ProjectStageModel
-from app.core.models.stage import Stage as StageModel
+from app.business.services import project_service
+from app.core.repositories import project as project_repo
 from app.core.schemas.stage import StageListItem, StageListResponse
 
 
 def list_stages(db: Session, project_id: UUID) -> StageListResponse:
-    project = (
-        db.query(ProjectModel)
-        .filter(
-            ProjectModel.id == project_id,
-            ProjectModel.is_deleted.is_(False),
-        )
-        .first()
+    project_service.get_project_or_raise(db, project_id)
+
+    rows = project_repo.get_project_stages_with_stage(db, project_id)
+
+    return StageListResponse(
+        stages=[
+            StageListItem(
+                stage_id=stage.id,
+                stage_sequence=stage.sequence,
+                stage_name=stage.name,
+                is_active=ps.is_active,
+            )
+            for ps, stage in rows
+        ]
     )
-    if not project:
-        raise ProjectNotFoundError()
-
-    rows = (
-        db.query(ProjectStageModel, StageModel)
-        .join(StageModel, StageModel.id == ProjectStageModel.stage_id)
-        .filter(ProjectStageModel.project_id == project_id)
-        .order_by(StageModel.sequence)
-        .all()
-    )
-
-    stages = [
-        StageListItem(
-            stage_id=stage.id,
-            stage_sequence=stage.sequence,
-            stage_name=stage.name,
-            is_active=ps.is_active,
-        )
-        for ps, stage in rows
-    ]
-
-    return StageListResponse(stages=stages)

--- a/backend/app/business/services/step_service.py
+++ b/backend/app/business/services/step_service.py
@@ -4,14 +4,13 @@ from sqlalchemy.orm import Session
 
 from app.core.enums import StepStatus
 from app.core.exceptions import InvalidRollbackTargetError, StepNotFoundError
-from app.core.models.project import ProjectStage as ProjectStageModel
-from app.core.models.project_required_step_status import (
-    ProjectRequiredStepStatus as ProjectRequiredStepStatusModel,
-)
-from app.core.models.required_step import RequiredStep as RequiredStepModel
-from app.core.models.stage import Stage as StageModel
 from app.core.models.step import Step as StepModel
-from app.core.models.step import StepTree as StepTreeModel
+from app.core.repositories import (
+    project as project_repo,
+    required_step as required_step_repo,
+    stage as stage_repo,
+    step as step_repo,
+)
 from app.core.schemas.step import (
     RequiredStepItem,
     RequiredStepListResponse,
@@ -24,189 +23,104 @@ def get_step_tree(
     db: Session, project_id: uuid.UUID, stage_id: uuid.UUID
 ) -> StepTreeResponse:
     """Step 트리 + Footprint 경로를 조립하여 반환."""
-    steps = (
-        db.query(StepModel)
-        .filter(StepModel.project_id == project_id, StepModel.stage_id == stage_id)
-        .order_by(StepModel.sort_order)
-        .all()
+    steps = step_repo.get_steps_by_stage(db, project_id, stage_id)
+    return StepTreeResponse(
+        current_path=_build_current_path(steps),
+        steps=_build_tree(steps),
     )
-
-    current_path = _build_current_path(steps)
-    roots = _build_tree(steps)
-
-    return StepTreeResponse(current_path=current_path, steps=roots)
 
 
 def rollback_step(db: Session, step_id: uuid.UUID) -> None:
-    step = db.get(StepModel, step_id)
+    step = step_repo.get_step(db, step_id)
     if step is None:
         raise StepNotFoundError()
 
     # ① children 존재 여부 검사
-    has_child = (
-        db.query(StepModel.id).filter(StepModel.parent_step_id == step_id).first()
-        is not None
-    )
-    if has_child:
+    if step_repo.has_children(db, step_id):
         raise InvalidRollbackTargetError("자식 Step이 있는 Step은 롤백할 수 없습니다.")
 
-    # ⓪ 롤백 대상이 현재 진행 Stage보다 낮은 Stage이면 윗 Stage들을 모두 정리
+    # ⓪ 롤백 대상이 현재 진행 Stage보다 낮은 Stage이면 윗 Stage 정리
     _wipe_upper_stages_if_needed(db, step)
 
-    # ② 클로저 테이블로 조상 + 자기 자신을 depth 오름차순으로 조회
-    #    depth=0(자기 자신)은 ACCEPTED 처리에서 제외 — Accept API에서 별도로 처리.
-    ancestor_rows = (
-        db.query(StepTreeModel)
-        .filter(StepTreeModel.descendant == step_id)
-        .order_by(StepTreeModel.depth.asc())
-        .all()
-    )
+    # ② 클로저 테이블로 조상 조회 (depth=0 자기 자신은 제외)
+    ancestor_rows = step_repo.get_ancestors_ordered(db, step_id)
     ancestor_ids = {row.ancestor for row in ancestor_rows if row.depth > 0}
 
     # ③ 프로젝트의 기존 ACCEPTED 흐름을 모두 CANCELED 처리
-    previously_accepted = (
-        db.query(StepModel)
-        .filter(
-            StepModel.project_id == step.project_id,
-            StepModel.status == StepStatus.ACCEPTED,
-        )
-        .all()
+    step_repo.set_status_bulk(
+        step_repo.get_accepted_steps_by_project(db, step.project_id),
+        StepStatus.CANCELED,
     )
-    for s in previously_accepted:
-        s.status = StepStatus.CANCELED
 
     # ④ 조상들만 ACCEPTED 처리 (롤백 대상은 Accept API에서 처리)
-    accepted_targets: list[StepModel] = []
     if ancestor_ids:
-        accepted_targets = (
-            db.query(StepModel).filter(StepModel.id.in_(ancestor_ids)).all()
+        step_repo.set_status_bulk(
+            step_repo.get_steps_by_ids(db, ancestor_ids),
+            StepStatus.ACCEPTED,
         )
-        for s in accepted_targets:
-            s.status = StepStatus.ACCEPTED
 
     db.flush()
 
-    # ⑤ Belonging Required Step 이후의 모든 Required Step 상태 fulfilled 해제
+    # ⑤ Belonging Required Step 이후의 Required Step 들 fulfilled 해제
     _unfulfill_required_steps_from(db, step)
 
     db.commit()
 
 
 def _wipe_upper_stages_if_needed(db: Session, target_step: StepModel) -> None:
-    """롤백 대상이 현재 진행 중인 Stage보다 낮은 Stage라면 윗 Stage들의
-    Step / StepTree / ProjectRequiredStepStatus를 모두 삭제하고,
-    ProjectStage.is_active를 롤백 대상 Stage로 옮긴다."""
+    """롤백 대상이 현재 진행 중인 Stage보다 낮으면 윗 Stage들의 Step / Required Step Status를 정리."""
     target_stage = target_step.stage
     target_seq = target_stage.sequence
 
-    current_active_seq = (
-        db.query(StageModel.sequence)
-        .join(ProjectStageModel, ProjectStageModel.stage_id == StageModel.id)
-        .filter(
-            ProjectStageModel.project_id == target_step.project_id,
-            ProjectStageModel.is_active.is_(True),
-        )
-        .scalar()
+    current_active_seq = project_repo.get_active_stage_sequence(
+        db, target_step.project_id
     )
     if current_active_seq is None or current_active_seq <= target_seq:
-        return  # 윗 Stage가 없으므로 정리할 게 없음
+        return
 
-    upper_stage_ids = [
-        sid
-        for (sid,) in db.query(StageModel.id)
-        .filter(StageModel.sequence > target_seq)
-        .all()
-    ]
+    upper_stage_ids = stage_repo.get_stage_ids_after_sequence(db, target_seq)
     if not upper_stage_ids:
         return
 
-    # ① 윗 Stage의 모든 Step 삭제 — parent_step_id FK가 자기 참조라
-    #    먼저 NULL 처리로 끊은 뒤 일괄 DELETE. StepTree는 ondelete=CASCADE로 자동 정리.
-    db.query(StepModel).filter(
-        StepModel.project_id == target_step.project_id,
-        StepModel.stage_id.in_(upper_stage_ids),
-    ).update({"parent_step_id": None}, synchronize_session=False)
+    # ① 윗 Stage Step 정리 (자기참조 FK 회피용 NULL → DELETE)
+    step_repo.detach_steps_from_parent_in_stages(
+        db, target_step.project_id, upper_stage_ids
+    )
     db.flush()
+    step_repo.delete_steps_in_stages(db, target_step.project_id, upper_stage_ids)
 
-    db.query(StepModel).filter(
-        StepModel.project_id == target_step.project_id,
-        StepModel.stage_id.in_(upper_stage_ids),
-    ).delete(synchronize_session=False)
-
-    # ② 윗 Stage의 Required Step Status는 삭제하지 않고 fulfilled 만 해제
-    upper_rs_ids_subq = (
-        db.query(RequiredStepModel.id)
-        .filter(RequiredStepModel.stage_id.in_(upper_stage_ids))
-        .subquery()
+    # ② 윗 Stage Required Step Status fulfilled 해제
+    upper_rs_ids = required_step_repo.get_required_step_ids_in_stages(
+        db, upper_stage_ids
     )
-    db.query(ProjectRequiredStepStatusModel).filter(
-        ProjectRequiredStepStatusModel.project_id == target_step.project_id,
-        ProjectRequiredStepStatusModel.required_step_id.in_(
-            db.query(upper_rs_ids_subq)
-        ),
-    ).update(
-        {"is_fulfilled": False, "fulfilled_at": None},
-        synchronize_session=False,
+    project_repo.unfulfill_by_required_step_ids(
+        db, target_step.project_id, upper_rs_ids
     )
 
-    # ③ ProjectStage.is_active 이동: 윗 Stage → False, 롤백 대상 Stage → True
-    db.query(ProjectStageModel).filter(
-        ProjectStageModel.project_id == target_step.project_id,
-        ProjectStageModel.stage_id.in_(upper_stage_ids),
-    ).update({"is_active": False}, synchronize_session=False)
-    db.query(ProjectStageModel).filter(
-        ProjectStageModel.project_id == target_step.project_id,
-        ProjectStageModel.stage_id == target_stage.id,
-    ).update({"is_active": True}, synchronize_session=False)
+    # ③ ProjectStage.is_active 이동
+    project_repo.deactivate_project_stages(db, target_step.project_id, upper_stage_ids)
+    project_repo.activate_project_stage(db, target_step.project_id, target_stage.id)
     db.flush()
 
 
 def _unfulfill_required_steps_from(db: Session, step: StepModel) -> None:
-    """롤백 대상의 Belonging Required Step부터 같은 Stage의 이후(sequence ≥) 모든
-    Required Step의 ProjectRequiredStepStatus를 is_fulfilled=False로 되돌린다.
-
-    belonging_required_step_id가 없으면 step 자신의 required_step_id를 사용.
-    둘 다 없으면 (필수 Step 영역 밖) 아무 작업도 하지 않는다."""
+    """롤백 대상의 Belonging Required Step 부터 같은 Stage 의 이후 Required Step 들 fulfilled 해제."""
     base_rs_id = step.belonging_required_step_id or step.required_step_id
     if base_rs_id is None:
         return
 
-    base_rs = db.get(RequiredStepModel, base_rs_id)
+    base_rs = required_step_repo.get_required_step(db, base_rs_id)
     if base_rs is None:
         return
 
-    # 같은 Stage에서 sequence가 base 이상인 Required Step의 status 레코드 일괄 해제
-    target_rs_ids_subq = (
-        db.query(RequiredStepModel.id)
-        .filter(
-            RequiredStepModel.stage_id == base_rs.stage_id,
-            RequiredStepModel.sequence >= base_rs.sequence,
-        )
-        .subquery()
+    target_rs_ids = required_step_repo.get_required_step_ids_from_sequence(
+        db, base_rs.stage_id, base_rs.sequence
     )
-    records = (
-        db.query(ProjectRequiredStepStatusModel)
-        .filter(
-            ProjectRequiredStepStatusModel.project_id == step.project_id,
-            ProjectRequiredStepStatusModel.required_step_id.in_(
-                db.query(target_rs_ids_subq)
-            ),
-        )
-        .all()
-    )
-    for record in records:
-        record.is_fulfilled = False
-        record.fulfilled_at = None
+    project_repo.unfulfill_by_required_step_ids(db, step.project_id, target_rs_ids)
 
 
 def get_required_steps(db: Session, stage_id: uuid.UUID) -> RequiredStepListResponse:
-    """특정 Stage의 Required Step 목록 조회."""
-    required_steps = (
-        db.query(RequiredStepModel)
-        .filter(RequiredStepModel.stage_id == stage_id)
-        .order_by(RequiredStepModel.sequence)
-        .all()
-    )
+    required_steps = required_step_repo.get_required_steps_in_stage(db, stage_id)
     return RequiredStepListResponse(
         required_steps=[
             RequiredStepItem(
@@ -248,7 +162,6 @@ def _build_current_path(steps: list[StepModel]) -> list[uuid.UUID]:
 
 
 def _build_tree(steps: list[StepModel]) -> list[StepTreeNode]:
-    """flat한 Step 리스트를 재귀 트리 구조로 조립."""
     node_map: dict[uuid.UUID, StepTreeNode] = {
         s.id: StepTreeNode(
             step_id=s.id,

--- a/backend/app/core/auth/dependencies.py
+++ b/backend/app/core/auth/dependencies.py
@@ -8,6 +8,7 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.core.exceptions import InvalidTokenError, UserNotFoundError
 from app.core.models.app_user import AppUser as AppUserModel
+from app.core.repositories import user as user_repo
 
 
 def get_current_user_id(
@@ -25,14 +26,7 @@ def get_current_user(
     db: Session = Depends(get_db),
 ) -> AppUserModel:
     """JWT 검증 + DB에서 AppUser 조회. is_deleted 체크."""
-    user = (
-        db.query(AppUserModel)
-        .filter(
-            AppUserModel.id == user_id,
-            AppUserModel.is_deleted.is_(False),
-        )
-        .first()
-    )
+    user = user_repo.get_active_user(db, user_id)
     if not user:
         raise UserNotFoundError()
     return user

--- a/backend/app/core/repositories/__init__.py
+++ b/backend/app/core/repositories/__init__.py
@@ -1,0 +1,9 @@
+"""Repository 레이어.
+
+DB 접근 로직을 service 레이어에서 분리한다.
+
+규칙:
+- Repository 함수는 SQLAlchemy 모델/raw 데이터를 반환한다 (Pydantic 스키마 변환 X).
+- Repository는 `db.flush()` 까지만 수행한다. `db.commit()` 은 Service 레이어가 트랜잭션 경계로서 책임진다.
+- Repository는 도메인 예외를 raise 하지 않는다 (없으면 None 반환). 검증/예외 처리는 Service에서 한다.
+"""

--- a/backend/app/core/repositories/project.py
+++ b/backend/app/core/repositories/project.py
@@ -1,0 +1,217 @@
+"""Project / ProjectStage / ProjectRequiredStepStatus repository."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.models.project import Project, ProjectStage
+from app.core.models.project_required_step_status import ProjectRequiredStepStatus
+from app.core.models.stage import Stage
+
+
+# ── Project ────────────────────────────────────────────────────────────
+
+
+def get_active_project_by_id(db: Session, project_id: UUID) -> Project | None:
+    return (
+        db.query(Project)
+        .filter(Project.id == project_id, Project.is_deleted.is_(False))
+        .first()
+    )
+
+
+def get_active_project_by_name(
+    db: Session, name: str, exclude_id: UUID | None = None
+) -> Project | None:
+    query = db.query(Project).filter(
+        Project.name == name, Project.is_deleted.is_(False)
+    )
+    if exclude_id is not None:
+        query = query.filter(Project.id != exclude_id)
+    return query.first()
+
+
+def get_active_names_by_prefix(db: Session, prefix: str) -> set[str]:
+    rows = (
+        db.query(Project.name)
+        .filter(Project.name.ilike(f"{prefix}%"), Project.is_deleted.is_(False))
+        .all()
+    )
+    return {row[0] for row in rows}
+
+
+def get_projects_by_user(
+    db: Session,
+    user_id: UUID | None,
+    page: int,
+    size: int,
+    sort_by: str,
+    sort_order: str,
+    keyword: str | None = None,
+) -> tuple[list[Project], int]:
+    query = db.query(Project).filter(
+        Project.is_deleted.is_(False),
+        Project.user_id == user_id,
+    )
+    if keyword:
+        query = query.filter(Project.name.ilike(f"%{keyword}%"))
+
+    sort_col = getattr(Project, sort_by)
+    query = query.order_by(sort_col.desc() if sort_order == "desc" else sort_col.asc())
+
+    total_count = query.count()
+    projects = query.offset((page - 1) * size).limit(size).all()
+    return projects, total_count
+
+
+def add_project(db: Session, project: Project) -> Project:
+    db.add(project)
+    db.flush()
+    return project
+
+
+def soft_delete_project(project: Project) -> None:
+    project.is_deleted = True
+
+
+def update_project_fields(project: Project, **fields: Any) -> Project:
+    for k, v in fields.items():
+        if v is not None:
+            setattr(project, k, v)
+    return project
+
+
+# ── ProjectStage ───────────────────────────────────────────────────────
+
+
+def get_project_stage(
+    db: Session, project_id: UUID, stage_id: UUID
+) -> ProjectStage | None:
+    return db.get(ProjectStage, {"project_id": project_id, "stage_id": stage_id})
+
+
+def get_active_stage_sequence(db: Session, project_id: UUID) -> int | None:
+    """프로젝트의 현재 활성 Stage sequence."""
+    row = (
+        db.query(Stage.sequence)
+        .join(ProjectStage, ProjectStage.stage_id == Stage.id)
+        .filter(
+            ProjectStage.project_id == project_id,
+            ProjectStage.is_active.is_(True),
+        )
+        .order_by(Stage.sequence)
+        .first()
+    )
+    return row[0] if row else None
+
+
+def get_project_stages_with_stage(
+    db: Session, project_id: UUID
+) -> list[tuple[ProjectStage, Stage]]:
+    return (
+        db.query(ProjectStage, Stage)
+        .join(Stage, Stage.id == ProjectStage.stage_id)
+        .filter(ProjectStage.project_id == project_id)
+        .order_by(Stage.sequence)
+        .all()
+    )
+
+
+def create_initial_project_stages(
+    db: Session, project_id: UUID, stage_ids_in_order: Iterable[UUID]
+) -> None:
+    """첫 번째 Stage만 is_active=True로 일괄 생성."""
+    for i, stage_id in enumerate(stage_ids_in_order):
+        db.add(
+            ProjectStage(
+                project_id=project_id,
+                stage_id=stage_id,
+                is_active=(i == 0),
+            )
+        )
+
+
+def deactivate_project_stages(
+    db: Session, project_id: UUID, stage_ids: Iterable[UUID]
+) -> None:
+    db.query(ProjectStage).filter(
+        ProjectStage.project_id == project_id,
+        ProjectStage.stage_id.in_(list(stage_ids)),
+    ).update({"is_active": False}, synchronize_session=False)
+
+
+def activate_project_stage(db: Session, project_id: UUID, stage_id: UUID) -> None:
+    db.query(ProjectStage).filter(
+        ProjectStage.project_id == project_id,
+        ProjectStage.stage_id == stage_id,
+    ).update({"is_active": True}, synchronize_session=False)
+
+
+# ── ProjectRequiredStepStatus ──────────────────────────────────────────
+
+
+def get_required_step_status(
+    db: Session, project_id: UUID, required_step_id: UUID
+) -> ProjectRequiredStepStatus | None:
+    return db.get(
+        ProjectRequiredStepStatus,
+        {"project_id": project_id, "required_step_id": required_step_id},
+    )
+
+
+def get_fulfilled_required_step_ids(db: Session, project_id: UUID) -> set[UUID]:
+    return {
+        row.required_step_id
+        for row in db.query(ProjectRequiredStepStatus).filter_by(
+            project_id=project_id, is_fulfilled=True
+        )
+    }
+
+
+def create_initial_project_rs_statuses(
+    db: Session, project_id: UUID, required_step_ids: Iterable[UUID]
+) -> None:
+    for rs_id in required_step_ids:
+        db.add(
+            ProjectRequiredStepStatus(
+                project_id=project_id,
+                required_step_id=rs_id,
+                is_fulfilled=False,
+            )
+        )
+
+
+def upsert_required_step_fulfilled(
+    db: Session, project_id: UUID, required_step_id: UUID
+) -> ProjectRequiredStepStatus:
+    record = get_required_step_status(db, project_id, required_step_id)
+    if record is None:
+        record = ProjectRequiredStepStatus(
+            project_id=project_id,
+            required_step_id=required_step_id,
+        )
+        db.add(record)
+    record.is_fulfilled = True
+    record.fulfilled_at = datetime.now(timezone.utc)
+    return record
+
+
+def unfulfill_by_required_step_ids(
+    db: Session, project_id: UUID, required_step_ids: Iterable[UUID]
+) -> None:
+    """주어진 required_step_id 들의 status 를 일괄 미충족 처리."""
+    ids = list(required_step_ids)
+    if not ids:
+        return
+    db.query(ProjectRequiredStepStatus).filter(
+        ProjectRequiredStepStatus.project_id == project_id,
+        ProjectRequiredStepStatus.required_step_id.in_(ids),
+    ).update(
+        {"is_fulfilled": False, "fulfilled_at": None},
+        synchronize_session=False,
+    )

--- a/backend/app/core/repositories/required_step.py
+++ b/backend/app/core/repositories/required_step.py
@@ -1,0 +1,61 @@
+"""RequiredStep repository."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.models.required_step import RequiredStep
+
+
+def get_required_step(db: Session, rs_id: UUID) -> RequiredStep | None:
+    return db.get(RequiredStep, rs_id)
+
+
+def get_all_required_steps(db: Session) -> list[RequiredStep]:
+    return db.query(RequiredStep).all()
+
+
+def get_required_steps_in_stage(db: Session, stage_id: UUID) -> list[RequiredStep]:
+    return (
+        db.query(RequiredStep)
+        .filter(RequiredStep.stage_id == stage_id)
+        .order_by(RequiredStep.sequence)
+        .all()
+    )
+
+
+def get_first_rs_of_stages(db: Session) -> list[RequiredStep]:
+    """각 Stage 의 sequence=1 인 Required Step 들."""
+    return db.query(RequiredStep).filter(RequiredStep.sequence == 1).all()
+
+
+def get_required_step_ids_in_stages(
+    db: Session, stage_ids: Iterable[UUID]
+) -> list[UUID]:
+    ids = list(stage_ids)
+    if not ids:
+        return []
+    return [
+        rs_id
+        for (rs_id,) in db.query(RequiredStep.id)
+        .filter(RequiredStep.stage_id.in_(ids))
+        .all()
+    ]
+
+
+def get_required_step_ids_from_sequence(
+    db: Session, stage_id: UUID, min_sequence: int
+) -> list[UUID]:
+    """같은 Stage 안에서 sequence >= min_sequence 인 Required Step ID 들."""
+    return [
+        rs_id
+        for (rs_id,) in db.query(RequiredStep.id)
+        .filter(
+            RequiredStep.stage_id == stage_id,
+            RequiredStep.sequence >= min_sequence,
+        )
+        .all()
+    ]

--- a/backend/app/core/repositories/stage.py
+++ b/backend/app/core/repositories/stage.py
@@ -1,0 +1,23 @@
+"""Stage repository."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.models.stage import Stage
+
+
+def get_all_stages_ordered(db: Session) -> list[Stage]:
+    return db.query(Stage).order_by(Stage.sequence).all()
+
+
+def get_stage_by_sequence(db: Session, sequence: int) -> Stage | None:
+    return db.query(Stage).filter(Stage.sequence == sequence).first()
+
+
+def get_stage_ids_after_sequence(db: Session, sequence: int) -> list[UUID]:
+    return [
+        sid for (sid,) in db.query(Stage.id).filter(Stage.sequence > sequence).all()
+    ]

--- a/backend/app/core/repositories/step.py
+++ b/backend/app/core/repositories/step.py
@@ -1,0 +1,214 @@
+"""Step / StepContent / StepTree repository."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.enums import StepStatus
+from app.core.models.step import Step, StepContent, StepTree
+
+
+# ── Step ───────────────────────────────────────────────────────────────
+
+
+def get_step(db: Session, step_id: UUID) -> Step | None:
+    return db.get(Step, step_id)
+
+
+def get_steps_by_ids(db: Session, step_ids: Iterable[UUID]) -> list[Step]:
+    ids = list(step_ids)
+    if not ids:
+        return []
+    return db.query(Step).filter(Step.id.in_(ids)).all()
+
+
+def get_steps_by_stage(db: Session, project_id: UUID, stage_id: UUID) -> list[Step]:
+    return (
+        db.query(Step)
+        .filter(Step.project_id == project_id, Step.stage_id == stage_id)
+        .order_by(Step.sort_order)
+        .all()
+    )
+
+
+def get_accepted_steps_in_stage(
+    db: Session, project_id: UUID, stage_id: UUID
+) -> list[Step]:
+    return (
+        db.query(Step)
+        .filter(
+            Step.project_id == project_id,
+            Step.stage_id == stage_id,
+            Step.status == StepStatus.ACCEPTED,
+        )
+        .all()
+    )
+
+
+def get_accepted_steps_in_required(
+    db: Session, project_id: UUID, belonging_required_step_id: UUID
+) -> list[Step]:
+    return (
+        db.query(Step)
+        .filter(
+            Step.project_id == project_id,
+            Step.belonging_required_step_id == belonging_required_step_id,
+            Step.status == StepStatus.ACCEPTED,
+        )
+        .all()
+    )
+
+
+def get_accepted_steps_by_project(db: Session, project_id: UUID) -> list[Step]:
+    return (
+        db.query(Step)
+        .filter(
+            Step.project_id == project_id,
+            Step.status == StepStatus.ACCEPTED,
+        )
+        .all()
+    )
+
+
+def get_ready_siblings(
+    db: Session, parent_step_id: UUID, exclude_step_id: UUID
+) -> list[Step]:
+    return (
+        db.query(Step)
+        .filter(
+            Step.parent_step_id == parent_step_id,
+            Step.id != exclude_step_id,
+            Step.status == StepStatus.READY,
+        )
+        .all()
+    )
+
+
+def has_children(db: Session, step_id: UUID) -> bool:
+    return db.query(Step.id).filter(Step.parent_step_id == step_id).first() is not None
+
+
+def get_existing_pending_required_step(
+    db: Session, project_id: UUID, stage_id: UUID, required_step_id: UUID
+) -> Step | None:
+    return (
+        db.query(Step)
+        .filter(
+            Step.project_id == project_id,
+            Step.stage_id == stage_id,
+            Step.required_step_id == required_step_id,
+            Step.status == StepStatus.READY,
+        )
+        .first()
+    )
+
+
+def get_steps_with_required_step_id_no_content(
+    db: Session,
+) -> list[Step]:
+    """required_step_id IS NOT NULL 이면서 StepContent가 없는 Step 들."""
+    existing = {row.step_id for row in db.query(StepContent.step_id).all()}
+    query = db.query(Step).filter(Step.required_step_id.isnot(None))
+    if existing:
+        query = query.filter(Step.id.not_in(existing))
+    return query.all()
+
+
+def add_step(db: Session, **fields: Any) -> Step:
+    step = Step(**fields)
+    db.add(step)
+    db.flush()
+    return step
+
+
+def detach_steps_from_parent_in_stages(
+    db: Session, project_id: UUID, stage_ids: Iterable[UUID]
+) -> None:
+    """Step.parent_step_id 를 NULL 로 끊는다 (FK 자기참조 회피용)."""
+    ids = list(stage_ids)
+    if not ids:
+        return
+    db.query(Step).filter(
+        Step.project_id == project_id,
+        Step.stage_id.in_(ids),
+    ).update({"parent_step_id": None}, synchronize_session=False)
+
+
+def delete_steps_in_stages(
+    db: Session, project_id: UUID, stage_ids: Iterable[UUID]
+) -> None:
+    ids = list(stage_ids)
+    if not ids:
+        return
+    db.query(Step).filter(
+        Step.project_id == project_id,
+        Step.stage_id.in_(ids),
+    ).delete(synchronize_session=False)
+
+
+def set_status_bulk(steps: Iterable[Step], status: str) -> None:
+    for s in steps:
+        s.status = status
+
+
+# ── StepContent ────────────────────────────────────────────────────────
+
+
+def get_step_content(db: Session, step_id: UUID) -> StepContent | None:
+    return db.get(StepContent, step_id)
+
+
+def add_step_content(
+    db: Session,
+    step_id: UUID,
+    *,
+    mentoring: str | None = None,
+    dictionary: str | None = None,
+    template_url: str | None = None,
+) -> StepContent:
+    content = StepContent(
+        step_id=step_id,
+        mentoring=mentoring,
+        dictionary=dictionary,
+        template_url=template_url,
+    )
+    db.add(content)
+    return content
+
+
+# ── StepTree (closure table) ───────────────────────────────────────────
+
+
+def insert_closure_self(db: Session, step_id: UUID) -> None:
+    db.add(StepTree(ancestor=step_id, descendant=step_id, depth=0))
+
+
+def insert_closure_with_parent(
+    db: Session, step_id: UUID, parent_step_id: UUID | None
+) -> None:
+    insert_closure_self(db, step_id)
+    if parent_step_id is None:
+        return
+    parent_ancestors = (
+        db.query(StepTree).filter(StepTree.descendant == parent_step_id).all()
+    )
+    for row in parent_ancestors:
+        db.add(StepTree(ancestor=row.ancestor, descendant=step_id, depth=row.depth + 1))
+
+
+def delete_closure_for_descendant(db: Session, step_id: UUID) -> None:
+    db.query(StepTree).filter(StepTree.descendant == step_id).delete()
+
+
+def get_ancestors_ordered(db: Session, step_id: UUID) -> list[StepTree]:
+    """depth 오름차순. depth=0(자기 자신) 포함."""
+    return (
+        db.query(StepTree)
+        .filter(StepTree.descendant == step_id)
+        .order_by(StepTree.depth.asc())
+        .all()
+    )

--- a/backend/app/core/repositories/user.py
+++ b/backend/app/core/repositories/user.py
@@ -1,0 +1,85 @@
+"""AppUser / OAuthAccount repository."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.models.app_user import AppUser
+from app.core.models.oauth_account import OAuthAccount
+
+
+# ── AppUser ────────────────────────────────────────────────────────────
+
+
+def get_active_user(db: Session, user_id: UUID) -> AppUser | None:
+    return (
+        db.query(AppUser)
+        .filter(AppUser.id == user_id, AppUser.is_deleted.is_(False))
+        .first()
+    )
+
+
+def add_user(db: Session, *, email: str, nickname: str | None) -> AppUser:
+    user = AppUser(email=email, nickname=nickname)
+    db.add(user)
+    db.flush()
+    return user
+
+
+# ── OAuthAccount ───────────────────────────────────────────────────────
+
+
+def get_oauth_by_provider_and_user(
+    db: Session, provider: str, provider_user_id: str
+) -> OAuthAccount | None:
+    return (
+        db.query(OAuthAccount)
+        .filter(
+            OAuthAccount.provider == provider,
+            OAuthAccount.provider_user_id == provider_user_id,
+        )
+        .first()
+    )
+
+
+def get_oauth_by_user_id(db: Session, user_id: UUID) -> OAuthAccount | None:
+    return db.query(OAuthAccount).filter(OAuthAccount.user_id == user_id).first()
+
+
+def add_oauth_account(
+    db: Session,
+    *,
+    user_id: UUID,
+    provider: str,
+    provider_user_id: str,
+    access_token: str | None,
+    refresh_token: str | None,
+    token_expires_at: datetime | None,
+) -> OAuthAccount:
+    account = OAuthAccount(
+        user_id=user_id,
+        provider=provider,
+        provider_user_id=provider_user_id,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_expires_at=token_expires_at,
+    )
+    db.add(account)
+    return account
+
+
+def update_oauth_tokens(
+    account: OAuthAccount,
+    *,
+    access_token: str | None,
+    refresh_token: str | None,
+    token_expires_at: datetime | None,
+) -> OAuthAccount:
+    account.access_token = access_token
+    if refresh_token:
+        account.refresh_token = refresh_token
+    account.token_expires_at = token_expires_at
+    return account


### PR DESCRIPTION
## PR 요약
- Service 레이어에 흩어져 있던 DB 접근 로직을 `core/repositories` 로 분리
- 트랜잭션 경계 명확화: Repository 는 `flush()`까지, `commit()`은 Service 가 담당
- 프로젝트 존재 검증 헬퍼 `project_service.get_project_or_raise` 도입 후 중복 검증 로직 통합

## 변경 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `app/core/repositories/` 신규 생성
  - `project.py` (Project / ProjectStage / ProjectRequiredStepStatus)
  - `step.py` (Step / StepContent / StepTree)
  - `required_step.py`
  - `stage.py`
  - `user.py` (AppUser / OAuthAccount)
- 모든 Service 파일에서 `db.query` / `db.get` 직접 호출 제거 후 repository 호출로 대체
  - `business/services/{project,stage,step,auth}_service.py`
  - `ai/services/step_service.py`
- `business/dependencies.py`, `core/auth/dependencies.py` 도 repository 사용
- `stage_service.list_stages`, `dependencies.get_owned_project/get_owned_step` 에서 `project_service.get_project_or_raise` 활용

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 \`alembic revision --autogenerate\` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- Repository 규칙은 `app/core/repositories/__init__.py` 모듈 docstring 에 명시
- 기존 동작은 모두 보존 (OAuth 토큰 갱신 동작 포함)