### PR TITLE
[#91][AI] accept + generate + side_panel 통합 병렬 오케스트레이터 추가

### DIFF
--- a/ai/__init__.py
+++ b/ai/__init__.py
@@ -1,9 +1,17 @@
 """Poco AI Orchestrator — backend 의존성 없이 독립 동작하는 AI 모듈."""
 
-from ai.services import generate_side_panel, generate_steps, judge_required_step
+from ai.services import (
+    accept_and_generate,
+    accept_and_generate_with_side_panels,
+    generate_side_panel,
+    generate_steps,
+    judge_required_step,
+)
 
 __all__ = [
     "generate_steps",
     "judge_required_step",
     "generate_side_panel",
+    "accept_and_generate",
+    "accept_and_generate_with_side_panels",
 ]

--- a/ai/services/__init__.py
+++ b/ai/services/__init__.py
@@ -12,11 +12,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+from typing import Any, List, Tuple
 
 from ai.clients.llm import LLMClient
 from ai.clients.rag import RAGClient
 from ai.schemas.accept import AcceptInput, AcceptOutput
+from ai.schemas.common import StepInfo
 from ai.schemas.generate import GenerateInput, GenerateOutput
 from ai.schemas.side_panel import SidePanelInput, SidePanelOutput
 from ai.services.required_step_judge import RequiredStepJudge
@@ -63,8 +65,64 @@ async def generate_side_panel(
     return await service.generate_side_panel(input_data)
 
 
+async def accept_and_generate(
+    accept_input: AcceptInput,
+    generate_input: GenerateInput,
+    bedrock_runtime_client: Any,
+    bedrock_agent_client: Any,
+    model_id: str,
+    kb_id: str,
+) -> Tuple[AcceptOutput, GenerateOutput]:
+    """accept 판단과 generate를 병렬 실행하여 응답 시간 단축."""
+    accept_result, generate_result = await asyncio.gather(
+        judge_required_step(accept_input, bedrock_runtime_client, model_id),
+        generate_steps(generate_input, bedrock_runtime_client, bedrock_agent_client, model_id, kb_id),
+    )
+    return accept_result, generate_result
+
+
+async def accept_and_generate_with_side_panels(
+    accept_input: AcceptInput,
+    generate_input: GenerateInput,
+    bedrock_runtime_client: Any,
+    bedrock_agent_client: Any,
+    model_id: str,
+    kb_id: str,
+) -> Tuple[AcceptOutput, GenerateOutput, List[SidePanelOutput]]:
+    """accept + generate를 병렬 실행(Stage A) 후 Step별 side_panel 3개를 병렬 실행(Stage B)."""
+    # Stage A: accept 판단과 Step 생성을 병렬 실행
+    accept_result, generate_result = await asyncio.gather(
+        judge_required_step(accept_input, bedrock_runtime_client, model_id),
+        generate_steps(generate_input, bedrock_runtime_client, bedrock_agent_client, model_id, kb_id),
+    )
+
+    # Stage B: 생성된 Step 3개의 side_panel을 병렬 실행
+    sp_inputs = [
+        SidePanelInput(
+            project_info=generate_input.project_info,
+            current_stage=generate_input.current_stage,
+            target_step=StepInfo(step_id="temp", name=step.name),
+            decision_history=generate_input.decision_history,
+            current_required_step=generate_input.current_required_step,
+        )
+        for step in generate_result.generated_steps
+    ]
+    side_panel_results: List[SidePanelOutput] = list(
+        await asyncio.gather(
+            *[
+                generate_side_panel(sp_input, bedrock_runtime_client, bedrock_agent_client, model_id, kb_id)
+                for sp_input in sp_inputs
+            ]
+        )
+    )
+
+    return accept_result, generate_result, side_panel_results
+
+
 __all__ = [
     "generate_steps",
     "judge_required_step",
     "generate_side_panel",
+    "accept_and_generate",
+    "accept_and_generate_with_side_panels",
 ]

--- a/ai/tests/test_orchestrator.py
+++ b/ai/tests/test_orchestrator.py
@@ -25,6 +25,8 @@ from ai.schemas.common import (
 from ai.schemas.generate import GenerateInput, GenerateOutput
 from ai.schemas.side_panel import SidePanelInput, SidePanelOutput
 from ai.services import (
+    accept_and_generate,
+    accept_and_generate_with_side_panels,
     generate_side_panel,
     generate_steps,
     judge_required_step,
@@ -467,3 +469,169 @@ class TestDeliveryInterface:
                     imported.add(node.module.split(".")[0])
             violations = imported & banned
             assert not violations, f"{path}: 백엔드 전용 패키지 import 발견 — {violations}"
+
+
+# ---------------------------------------------------------------------------
+# accept_and_generate
+# ---------------------------------------------------------------------------
+
+
+def _runtime_mock_for_accept_and_generate() -> MagicMock:
+    """accept → generate 순으로 invoke_model이 두 번 호출될 때 각각 올바른 응답을 반환."""
+    import io as _io
+    import json as _json
+
+    def _make_body(payload: dict) -> dict:
+        envelope = {"content": [{"type": "text", "text": _json.dumps(payload, ensure_ascii=False)}]}
+        return {"body": _io.BytesIO(_json.dumps(envelope, ensure_ascii=False).encode("utf-8"))}
+
+    mock = MagicMock()
+    mock.invoke_model.side_effect = [
+        _make_body({"is_current_required_step_completed": True}),
+        _make_body(_valid_generate_payload()),
+    ]
+    return mock
+
+
+class TestAcceptAndGenerate:
+    @pytest.mark.asyncio
+    async def test_returns_tuple_of_correct_types(self):
+        """병렬 실행 정상 흐름: (AcceptOutput, GenerateOutput) 튜플 반환."""
+        runtime = _runtime_mock_for_accept_and_generate()
+        agent = _bedrock_agent_mock()
+
+        result = await accept_and_generate(
+            accept_input=_accept_input(),
+            generate_input=_generate_input(),
+            bedrock_runtime_client=runtime,
+            bedrock_agent_client=agent,
+            model_id=_MODEL_ID,
+            kb_id=_KB_ID,
+        )
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_each_element_has_correct_type(self):
+        """반환 타입 검증: AcceptOutput과 GenerateOutput 각각."""
+        runtime = _runtime_mock_for_accept_and_generate()
+        agent = _bedrock_agent_mock()
+
+        accept_result, generate_result = await accept_and_generate(
+            accept_input=_accept_input(),
+            generate_input=_generate_input(),
+            bedrock_runtime_client=runtime,
+            bedrock_agent_client=agent,
+            model_id=_MODEL_ID,
+            kb_id=_KB_ID,
+        )
+
+        assert isinstance(accept_result, AcceptOutput)
+        assert isinstance(generate_result, GenerateOutput)
+        assert accept_result.is_current_required_step_completed is True
+        assert len(generate_result.generated_steps) == 3
+
+    @pytest.mark.asyncio
+    async def test_both_clients_called(self):
+        """병렬성 검증: runtime.invoke_model 2회, agent.retrieve 1회 호출."""
+        runtime = _runtime_mock_for_accept_and_generate()
+        agent = _bedrock_agent_mock()
+
+        await accept_and_generate(
+            accept_input=_accept_input(),
+            generate_input=_generate_input(),
+            bedrock_runtime_client=runtime,
+            bedrock_agent_client=agent,
+            model_id=_MODEL_ID,
+            kb_id=_KB_ID,
+        )
+
+        # accept(invoke) + generate(invoke) = 2회
+        assert runtime.invoke_model.call_count == 2
+        # generate만 RAG 사용 = 1회
+        assert agent.retrieve.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# accept_and_generate_with_side_panels
+# ---------------------------------------------------------------------------
+
+
+def _runtime_mock_for_full_pipeline() -> MagicMock:
+    """accept(1) + generate(1) + side_panel×3(3) = invoke_model 5회 응답."""
+    import io as _io
+    import json as _json
+
+    def _make_body(payload: dict) -> dict:
+        envelope = {"content": [{"type": "text", "text": _json.dumps(payload, ensure_ascii=False)}]}
+        return {"body": _io.BytesIO(_json.dumps(envelope, ensure_ascii=False).encode("utf-8"))}
+
+    mock = MagicMock()
+    mock.invoke_model.side_effect = [
+        _make_body({"is_current_required_step_completed": True}),   # accept
+        _make_body(_valid_generate_payload()),                        # generate
+        _make_body(_valid_side_panel_payload()),                     # side_panel Step 1
+        _make_body(_valid_side_panel_payload()),                     # side_panel Step 2
+        _make_body(_valid_side_panel_payload()),                     # side_panel Step 3
+    ]
+    return mock
+
+
+class TestAcceptAndGenerateWithSidePanels:
+    @pytest.mark.asyncio
+    async def test_returns_correct_types(self):
+        """반환 타입 검증: (AcceptOutput, GenerateOutput, list[SidePanelOutput])."""
+        runtime = _runtime_mock_for_full_pipeline()
+        agent = _bedrock_agent_mock()
+
+        result = await accept_and_generate_with_side_panels(
+            accept_input=_accept_input(),
+            generate_input=_generate_input(),
+            bedrock_runtime_client=runtime,
+            bedrock_agent_client=agent,
+            model_id=_MODEL_ID,
+            kb_id=_KB_ID,
+        )
+
+        accept_result, generate_result, sp_list = result
+        assert isinstance(accept_result, AcceptOutput)
+        assert isinstance(generate_result, GenerateOutput)
+        assert isinstance(sp_list, list)
+        assert all(isinstance(sp, SidePanelOutput) for sp in sp_list)
+
+    @pytest.mark.asyncio
+    async def test_side_panel_list_has_three_items(self):
+        """list[SidePanelOutput] 길이가 정확히 3."""
+        runtime = _runtime_mock_for_full_pipeline()
+        agent = _bedrock_agent_mock()
+
+        _, _, sp_list = await accept_and_generate_with_side_panels(
+            accept_input=_accept_input(),
+            generate_input=_generate_input(),
+            bedrock_runtime_client=runtime,
+            bedrock_agent_client=agent,
+            model_id=_MODEL_ID,
+            kb_id=_KB_ID,
+        )
+
+        assert len(sp_list) == 3
+
+    @pytest.mark.asyncio
+    async def test_invoke_and_retrieve_call_counts(self):
+        """invoke_model 5회 (accept 1 + generate 1 + side_panel 3), retrieve 7회 (generate 1 + side_panel 3×2)."""
+        runtime = _runtime_mock_for_full_pipeline()
+        agent = _bedrock_agent_mock()
+
+        await accept_and_generate_with_side_panels(
+            accept_input=_accept_input(),
+            generate_input=_generate_input(),
+            bedrock_runtime_client=runtime,
+            bedrock_agent_client=agent,
+            model_id=_MODEL_ID,
+            kb_id=_KB_ID,
+        )
+
+        assert runtime.invoke_model.call_count == 5
+        # generate: DOJ 1회 / side_panel 각 DOJ+Custom 2회 × 3 = 7회 합계
+        assert agent.retrieve.call_count == 7


### PR DESCRIPTION
## PR 요약
- 백엔드의 Accept 엔드포인트에서 한 번에 사용할 수 있도록, `accept` 판단 + `generate` Step 3개 + 각 Step의 `side_panel` 3개를 병렬 실행하는 오케스트레이터 2개를 `ai` 모듈에 추가.
- Closes #91

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `ai/services/__init__.py`
  - `accept_and_generate(accept_input, generate_input, ...) -> Tuple[AcceptOutput, GenerateOutput]` 추가 — `asyncio.gather`로 `judge_required_step` + `generate_steps` 병렬 실행
  - `accept_and_generate_with_side_panels(accept_input, generate_input, ...) -> Tuple[AcceptOutput, GenerateOutput, List[SidePanelOutput]]` 추가 — Stage A (accept + generate 병렬) → Stage B (생성된 Step 3개의 side_panel 3개 병렬)의 2단계 파이프라인
  - `SidePanelInput.target_step.step_id`는 `"temp"` placeholder로 조립 (백엔드가 DB 저장 후 실제 ID 할당)
- `ai/__init__.py`: 두 함수 re-export 추가
- `ai/tests/test_orchestrator.py`
  - `TestAcceptAndGenerate` 3개 — 반환 타입/값 검증 + invoke_model 2회, retrieve 1회 호출 검증
  - `TestAcceptAndGenerateWithSidePanels` 3개 — 반환 타입(길이 3) 검증 + invoke_model 5회(accept 1 + generate 1 + side_panel 3), retrieve 7회(generate DOJ 1 + side_panel 3×[DOJ+Custom] 6) 호출 검증
  - mock 팩토리 2개(`_runtime_mock_for_accept_and_generate`, `_runtime_mock_for_full_pipeline`) — `side_effect` 리스트로 순서대로 응답 반환

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai) — ai 모듈 전체 테스트 248/248 PASS
- [ ] 관련 API 정상 응답 확인 — 백엔드 통합 시 검증 예정
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행 — 해당 없음
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영 — 해당 없음

## 참고 사항
- **백엔드 연동 가이드**
  - 기존 `judge_required_step` + `generate_steps` 순차 호출을 쓰던 Accept 엔드포인트는 `accept_and_generate`로 대체하면 Bedrock 호출 2회가 병렬이 되어 체감 대기가 줄어들음.
  - 각 Step의 사이드패널까지 미리 생성해두고 싶다면 `accept_and_generate_with_side_panels`를 쓰면 돼요. 반환된 `List[SidePanelOutput]`을 `generated_steps` 순서 그대로 DB에 캐싱해두면, 사용자가 노드 클릭 시점엔 DB 조회만으로 즉시 응답 가능.
  - `target_step.step_id`의 `"temp"` 값은 AI 판단에 영향 없는 placeholder예요. 백엔드가 DB에 Step을 저장한 뒤 실제 UUID로 교체해서 사이드패널과 연결 부탁합니다.
- 248/248 테스트 통과.