### PR TITLE
[#90][FE]  canvas UI 및 api 수정

### DIFF
--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -27,3 +27,4 @@ api.interceptors.response.use(
 )
 
 export const getMe = () => api.get('/auth/me')
+export const logout = () => api.post('/auth/logout')

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -38,9 +38,6 @@ addCsrfInterceptor(aiApi)
 export const getStepTree = (projectId, stageId) =>
   api.get('/steps/tree', { params: { project_id: projectId, stage_id: stageId } })
 
-export const generateSteps = (stepId) =>
-  aiApi.post(`/steps/${stepId}/generate`)
-
 export const acceptStep = (stepId) =>
   aiApi.post(`/steps/${stepId}/accept`)
 

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -188,7 +188,19 @@ export default function CanvasPage() {
   }
 
   async function executeAccept() {
-    if (selectedStep.data?.status === 'CANCELED') {
+    const status = selectedStep.data?.status
+
+    const needsRollback = status === 'CANCELED' || (status === 'READY' && (() => {
+      const parentEdge = edges.find(e => e.target === selectedStep.id)
+      if (!parentEdge) return false
+      const siblings = nodes.filter(n =>
+        n.id !== selectedStep.id &&
+        edges.some(e => e.source === parentEdge.source && e.target === n.id)
+      )
+      return siblings.some(n => n.data?.status === 'ACCEPTED')
+    })())
+
+    if (needsRollback) {
       try {
         await rollbackStep(selectedStep.id)
       } catch (err) {

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -46,6 +46,7 @@ export default function CanvasPage() {
 
   const timerRef = useRef(null)
   const currentRequiredStepName = useRef(null)
+  const autoOpenedStageRef = useRef(null)
 
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
@@ -71,6 +72,19 @@ export default function CanvasPage() {
     const { nodes: n, edges: e } = flattenTree(treeData.steps ?? [], stage?.stage_sequence)
     setNodes(n)
     setEdges(e)
+
+    if (autoOpenedStageRef.current !== stageId) {
+      const firstRequired = n.find((node) => node.type === 'requiredStepNode')
+      if (firstRequired) {
+        autoOpenedStageRef.current = stageId
+        setSelectedStep(firstRequired)
+        setStepDetail(null)
+        try {
+          const detail = await getStepDetail(firstRequired.id)
+          setStepDetail(detail)
+        } catch {}
+      }
+    }
   }
 
   useEffect(() => {
@@ -93,6 +107,7 @@ export default function CanvasPage() {
   useEffect(() => {
     setSelectedStep(null)
     setStepDetail(null)
+    autoOpenedStageRef.current = null
   }, [selectedStageId])
 
   const uiStages = stages.map(s => ({

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -35,7 +35,9 @@ export default function CanvasPage() {
   const [stages, setStages] = useState([])
   const [currentStageSequence, setCurrentStageSequence] = useState(1)
   const [selectedStageId, setSelectedStageId] = useState(null)
-  const [navCollapsed, setNavCollapsed] = useState(false)
+  const [navCollapsed, setNavCollapsed] = useState(
+    () => localStorage.getItem('navCollapsed') === 'true'
+  )
   const [selectedStep, setSelectedStep] = useState(null)
   const [stepDetail, setStepDetail] = useState(null)
   const [contextMenu, setContextMenu] = useState(null)
@@ -60,8 +62,13 @@ export default function CanvasPage() {
       const list = data.stages ?? []
       setStages(list)
       const active = list.find(s => s.is_active)
-      if (active) {
-        setCurrentStageSequence(active.stage_sequence)
+      if (active) setCurrentStageSequence(active.stage_sequence)
+
+      const saved = sessionStorage.getItem(`selectedStage_${projectId}`)
+      const savedStage = list.find(s => s.stage_id === saved)
+      if (savedStage) {
+        setSelectedStageId(savedStage.stage_id)
+      } else if (active) {
         setSelectedStageId(active.stage_id)
       }
     })
@@ -298,10 +305,16 @@ export default function CanvasPage() {
           stages={uiStages}
           currentStageId={currentStageId}
           selectedStageId={selectedStageId}
-          onSelectStage={(id) => setSelectedStageId(id)}
+          onSelectStage={(id) => {
+            setSelectedStageId(id)
+            sessionStorage.setItem(`selectedStage_${projectId}`, id)
+          }}
           collapsed={navCollapsed}
-          onToggle={() => setNavCollapsed(!navCollapsed)}
-        />
+          onToggle={() => {
+            const next = !navCollapsed
+            setNavCollapsed(next)
+            localStorage.setItem('navCollapsed', next)
+          }}        />
 
         <div className={styles.canvasWrapper}>
           <ToastAlarm

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -84,7 +84,8 @@ export default function CanvasPage() {
           const detail = await getStepDetail(firstRequired.id)
           setStepDetail(detail)
         } catch {
-          // }
+          // 상세 정보 로드 실패해도 노드 선택은 유지
+        }
       }
     }
   }

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -14,7 +14,7 @@ import StepNode from '../components/canvas/StepNode'
 import RequiredStepNode from '../components/canvas/RequiredStepNode'
 
 import { getStages } from '../api/stage'
-import { getStepTree, getStepDetail, acceptStep, generateSteps, rollbackStep } from '../api/step'
+import { getStepTree, getStepDetail, acceptStep, rollbackStep } from '../api/step'
 
 import { STAGE_ENGLISH, flattenTree } from '../utils/canvasUtils'
 
@@ -244,20 +244,6 @@ export default function CanvasPage() {
             const active = list.find(s => s.is_active)
             if (active) setCurrentStageSequence(active.stage_sequence)
           })
-        }
-      }
-    }
-
-    let retryCount = 0
-    while (retryCount < 3) {
-      try {
-        await generateSteps(selectedStep.id)
-        break
-      } catch {
-        retryCount++
-        if (retryCount === 3) {
-          alert('Step 생성에 실패했어요. 다시 시도해주세요.')
-          return
         }
       }
     }

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -47,6 +47,7 @@ export default function CanvasPage() {
   const timerRef = useRef(null)
   const currentRequiredStepName = useRef(null)
   const autoOpenedStageRef = useRef(null)
+  const shouldFitViewRef = useRef(false)
 
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
@@ -82,24 +83,27 @@ export default function CanvasPage() {
         try {
           const detail = await getStepDetail(firstRequired.id)
           setStepDetail(detail)
-        } catch {}
+        } catch {
+          // }
       }
     }
   }
 
   useEffect(() => {
     if (!rfInstance || nodes.length === 0) return
-    if (nodes.length >= 4) {
-      ;(async () => {
-        await rfInstance.fitView({ duration: 0, padding: 0.1 })
-        const { y, zoom } = rfInstance.getViewport()
-        rfInstance.setViewport({ x: 80 - 50 * zoom, y, zoom }, { duration: 200 })
-      })()
-    }
+    if (!shouldFitViewRef.current) return
+    shouldFitViewRef.current = false
+    if (nodes.length < 4) return
+    ;(async () => {
+      await rfInstance.fitView({ duration: 0, padding: 0.1 })
+      const { y, zoom } = rfInstance.getViewport()
+      rfInstance.setViewport({ x: 80 - 50 * zoom, y, zoom }, { duration: 200 })
+    })()
   }, [nodes, rfInstance])
 
   useEffect(() => {
     if (!selectedStageId || !projectId) return
+    shouldFitViewRef.current = true 
     fetchAndRenderTree(selectedStageId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedStageId, projectId])

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,31 +1,51 @@
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { getMe, logout } from '../api/auth'
 import styles from './LandingPage.module.css'
 
 export default function LandingPage() {
   const navigate = useNavigate()
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
+
+  useEffect(() => {
+    getMe()
+      .then(() => setIsLoggedIn(true))
+      .catch(() => setIsLoggedIn(false))
+  }, [])
+
+  async function handleLogout() {
+    try {
+      await logout()
+    } catch {
+      // 로그아웃 실패해도 일단 클라이언트에서는 로그인 상태 해제
+    }
+    setIsLoggedIn(false)
+  }
 
   return (
     <div className={styles.page}>
-      {/* 네비바 */}
       <nav className={styles.nav}>
         <div className={styles.logo}>
-          {/* 로고 SVG 추후 추가 */}
           <span>poco</span>
         </div>
-        <button className={styles.loginBtn} onClick={() => navigate('/login')}>
-          로그인
-        </button>
+        {isLoggedIn ? (
+          <button className={styles.loginBtn} onClick={handleLogout}>
+            로그아웃
+          </button>
+        ) : (
+          <button className={styles.loginBtn} onClick={() => navigate('/login')}>
+            로그인
+          </button>
+        )}
       </nav>
 
-      {/* 메인 영역 */}
       <section className={styles.hero}>
         <p className={styles.subtitle}>Your AI Development Partner</p>
         <img src="/poco-logo-text.svg" alt="poco" className={styles.pocoText} />
-        <button className={styles.startBtn} onClick={() => navigate('/login')}>
+        <button className={styles.startBtn} onClick={() => navigate(isLoggedIn ? '/projects' : '/login')}>
           Get started!
         </button>
       </section>
-
     </div>
   )
 }

--- a/frontend/src/pages/ProjectListPage.jsx
+++ b/frontend/src/pages/ProjectListPage.jsx
@@ -31,15 +31,7 @@ export default function ProjectListPage() {
   const [isEditing, setIsEditing] = useState(false)
   const [editData, setEditData] = useState({})
   const [deleteModal, setDeleteModal] = useState(null)
-
-  // TODO: API 연동 후 아래 주석 해제, 더미 데이터 및 초기값 제거
-  // useEffect(() => {
-  //   getProjects({ page, size }).then((data) => {
-  //     setProjects(data.projects)
-  //     setTotalCount(data.total_count)
-  //   })
-  // }, [page])
-
+  
   useEffect(() => {
     getProjects({ page, size, sort_by: sortBy }).then((data) => {
       setProjects(data.projects ?? [])
@@ -107,7 +99,7 @@ export default function ProjectListPage() {
   return (
     <div className={styles.layout}>
       <header className={styles.header}>
-        <div className={styles.logo}onClick={() => navigate('/')}style={{ cursor: 'pointer' }}><span>poco</span></div>
+        <div className={styles.logo}onClick={() => navigate('/projects')}style={{ cursor: 'pointer' }}><span>poco</span></div>
       </header>
 
       <div className={styles.body}>


### PR DESCRIPTION
## PR 요약
- Accept 시 자동 줌 조정 제거, 스테이지 전환 시에만 fitView 적용
- 각 스테이지 첫 필수 Step 진입 시 사이드패널 자동 오픈
- 랜딩 페이지 로그인 상태에 따라 로그인/로그아웃 버튼 분기
- 스테이지 선택 상태 새로고침 유지 (sessionStorage), 네비 collapse 상태 저장 (localStorage)
- READY 노드 롤백 로직 추가 (형제 중 ACCEPTED 있을 때)
- accept API에 generate 통합 — generateSteps 호출 제거

## 변경 유형
- [x] 새로운 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 변경 사항
- `CanvasPage.jsx`: fitView 조건 수정, 필수 Step 자동 오픈, rollback 조건 추가, generateSteps 제거
- `LandingPage.jsx`: getMe() 기반 로그인 상태 분기, 로그아웃 처리
- `ProjectListPage.jsx`: 로고 클릭 시 `/projects`로 이동
- `auth.js`: logout 함수 추가
- `step.js`: generateSteps 제거

## 체크리스트
- [x] 빌드 가능한 상태

## 참고 사항
- accept 응답에 generated_steps 포함되도록 API 명세 변경됨