### PR TITLE
[#107] 소개 페이지 Pages 배포 반영 (로고 버튼·사이드바 간격·기술 스택 통일)

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,7 +24,8 @@ body > header {
 @media (min-width: 900px) {
   html,
   body {
-    padding-left: 210px !important;
+    padding-left: 165px !important;
+    padding-right: 45px !important;
     margin-left: 0 !important;
     box-sizing: border-box !important;
   }
@@ -46,7 +47,7 @@ body > header {
   position: fixed;
   top: 0;
   left: 0;
-  width: 280px;
+  width: 220px;
   height: 100vh;
   padding: 28px 18px 20px 22px;
   background: #f6f8fa;
@@ -200,7 +201,7 @@ body > header {
     </a>
     <a class="poco-btn poco-btn-live" href="https://poco.example.com" target="_blank" rel="noopener">
       <span class="icon">🐾</span>
-      <span>Poco 바로가기</span>
+      <span>서비스 바로가기</span>
     </a>
     <a class="poco-btn poco-btn-aws" href="#7-팀-소개">
       <span class="icon"><img src="./assets/aws_logo.png" alt="" /></span>
@@ -548,12 +549,12 @@ Poco는 참조 문서를 **그대로 노출하지 않는다.** 팀이 다음 자
 
 | 번호 | 한글명 | 영문명 | 설명 |
 |:---:|---|---|---|
-| 1 | 아이디어 구체화 | Ideation | 막연한 아이디어를 "왜 만들 가치가 있는가"로 다듬는다. |
-| 2 | 프로젝트 계획 | Planning | 기간·인원·역할을 정하고, 어떻게 일할지 설계한다. |
-| 3 | 요구사항 정의 | Requirement | 시스템이 "무엇을" 해야 하는지 구체적으로 정의한다. |
-| 4 | 설계 | Design | 요구사항을 구조·데이터·인터페이스로 그려낸다. |
-| 5 | 개발 | Development | 설계를 실제 동작하는 코드로 구현한다. |
-| 6 | 테스트 및 검증 | Test | 만든 것이 처음 정의한 요구사항을 충족하는지 확인한다. |
+| 1 | 아이디어 구체화 | *Ideation* | 막연한 아이디어를 "왜 만들 가치가 있는가"로 다듬는다. |
+| 2 | 프로젝트 계획 | *Planning* | 기간·인원·역할을 정하고, 어떻게 일할지 설계한다. |
+| 3 | 요구사항 정의 | *Requirement* | 시스템이 "무엇을" 해야 하는지 구체적으로 정의한다. |
+| 4 | 설계 | *Design* | 요구사항을 구조·데이터·인터페이스로 그려낸다. |
+| 5 | 개발 | *Development* | 설계를 실제 동작하는 코드로 구현한다. |
+| 6 | 테스트 및 검증 | *Test* | 만든 것이 처음 정의한 요구사항을 충족하는지 확인한다. |
 
 &nbsp;
 


### PR DESCRIPTION
## PR 요약
- PR #111의 master 머지 충돌로 인해 깨끗한 followup 브랜치로 재제출

## 변경 유형
- [x] 문서 수정

## 변경 사항
- **사이드바 디자인**
  - 폭 280px → 220px, 본문 padding 210px → 165px / right 45px 신설
  - 사이드바 하단에 gradient 버튼 3종 (GitHub 리포지토리 / 서비스 바로가기 / AWS 캡스톤디자인 59팀)
  - 로고 이미지 버튼 (`github_logo.png`, `aws_logo.png`) 적용
- **소개 페이지 (`index.md`)**
  - Cayman 테마 초록 헤더 숨김
  - 기술 스택 for-the-badge 사이즈로 통일
  - 6그룹 재정렬 (Frontend / Backend / AI & AWS / DevOps & External)
  - Stage 표 영문명 italic 처리
  - 섹션 간격 정리 (`---` 제거, `&nbsp;`로 대체)
- **README.md**
  - 발자국(🐾) 이모지 통일, flat-square 뱃지
  - 팀원 가로 4열 아바타 테이블, AWS Track 뱃지 추가

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- 문서 전용 PR로 API/DB 변경 없음
- 머지 후 GitHub Pages 자동 재빌드 1~2분 대기 → https://kookmin-sw.github.io/2026-capstone-59/ 에서 반영 확인
- 머지 후 `other/#107-landing-page` 브랜치는 삭제 가능