### PR TITLE
[#107] 소개 페이지 Pages 배포 반영 (레퍼런스 레이아웃 + 기술 스택 재분류)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ AI가 다음 할 일의 선택지를 제시하고 의사결정의 궤적을 **�
 ![Python](https://img.shields.io/badge/Python_3.13-3776AB?style=flat-square&logo=python&logoColor=white)
 ![FastAPI](https://img.shields.io/badge/FastAPI-009688?style=flat-square&logo=fastapi&logoColor=white)
 ![Pydantic](https://img.shields.io/badge/Pydantic_v2-E92063?style=flat-square&logo=pydantic&logoColor=white)
-![Pytest](https://img.shields.io/badge/Pytest_+_Hypothesis-0A9EDC?style=flat-square&logo=pytest&logoColor=white)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=flat-square&logo=postgresql&logoColor=white)
 
 **AI & RAG**
@@ -80,6 +79,7 @@ AI가 다음 할 일의 선택지를 제시하고 의사결정의 궤적을 **�
 ![Amazon Bedrock](https://img.shields.io/badge/Amazon_Bedrock-01A88D?style=flat-square&logo=amazonaws&logoColor=white)
 ![Bedrock KB](https://img.shields.io/badge/Bedrock_Knowledge_Base-222F3E?style=flat-square&logo=amazonaws&logoColor=white)
 ![S3 Vectors](https://img.shields.io/badge/S3_Vectors-569A31?style=flat-square&logo=amazons3&logoColor=white)
+![Pytest](https://img.shields.io/badge/Pytest_+_Hypothesis-0A9EDC?style=flat-square&logo=pytest&logoColor=white)
 
 **Infra (서버리스 중심)**
 

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Poco
 ---
 
 <style>
-/* ===== Poco 소개 페이지 — NURINOON 레퍼런스 레이아웃 ===== */
+/* ===== Poco 소개 페이지 — NURINOON 레퍼런스 레이아웃 단순 이식 ===== */
 
 /* ----- 스무스 스크롤 ----- */
 html { scroll-behavior: smooth; }
@@ -16,35 +16,33 @@ section.page-header,
 .site-header,
 body > header {
   display: none !important;
-  visibility: hidden !important;
-  height: 0 !important;
-  overflow: hidden !important;
-  padding: 0 !important;
-  margin: 0 !important;
 }
 
-/* ----- 본문을 사이드바 오른쪽으로 밀고, 가운데 정렬된 좁은 칼럼으로 제한 ----- */
-@media (min-width: 900px) {
-  html,
-  body {
-    margin-left: 200px !important;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    box-sizing: border-box !important;
-  }
-  /* Cayman 테마의 기본 wrapper(max-width: 64rem; padding: 2rem 6rem) 를 레퍼런스 스타일로 덮어씀 */
-  .main-content,
-  .page-content .wrapper,
-  main.page-content .wrapper,
-  body .wrapper {
-    max-width: 900px !important;
-    width: auto !important;
-    margin: 2rem auto !important;
-    padding: 0 1.5rem !important;
-    box-sizing: border-box !important;
-    line-height: 1.75;
-    color: #333;
-  }
+/* ----- body: 레퍼런스 구조 + margin 결함 보완 ----- */
+/* 레퍼런스는 margin-left: 200px 방식이지만, margin 영역은 body 바깥이라
+   html 배경이 드러나는 구조적 결함이 있음. 그래서 padding-left 로 전환해
+   body 내부에 사이드바 자리를 확보한다. 결과 레이아웃은 레퍼런스와 동일. */
+body {
+  margin: 0 !important;
+  padding: 0 0 0 210px !important;
+  box-sizing: border-box;
+}
+
+/* ----- 본문 wrapper: 900px 중앙 정렬 ----- */
+/* Cayman 기본 wrapper(max-width: 64rem; padding: 2rem 6rem)를 덮어씀.
+   body 안에서 가운데 정렬된 좁은 칼럼으로 표현.
+   배경은 Cayman 기본값(흰색)을 그대로 유지한다. */
+.main-content,
+.page-content .wrapper,
+main.page-content .wrapper,
+body .wrapper {
+  max-width: 900px !important;
+  width: auto !important;
+  margin: 2rem auto !important;
+  padding: 0 1.5rem !important;
+  box-sizing: border-box;
+  line-height: 1.75;
+  color: #333;
 }
 
 /* ----- 좌측 고정 사이드바 (레퍼런스 스타일 + 목차는 Poco 스타일) ----- */
@@ -151,18 +149,19 @@ body > header {
   object-fit: contain;
 }
 
-/* ----- 모바일: 사이드바 숨기고 전체폭 사용 ----- */
-@media (max-width: 899px) {
+/* ----- 모바일: 사이드바 숨기고 전체폭 사용 (레퍼런스와 동일 breakpoint) ----- */
+@media (max-width: 768px) {
   #poco-side-toc { display: none; }
-  html, body {
-    margin-left: 0 !important;
-    padding-left: 0 !important;
+  body {
+    margin: 0 !important;
+    padding: 0 !important;
   }
   .main-content,
   .page-content .wrapper,
   main.page-content .wrapper,
   body .wrapper {
     padding: 1rem !important;
+    margin: 1rem auto !important;
   }
 }
 </style>

--- a/index.md
+++ b/index.md
@@ -339,7 +339,6 @@ AI는 **"어떻게(How)"** 를 엄청난 속도로 만들어준다. 코드도, �
 ![Python](https://img.shields.io/badge/Python_3.13-3776AB?style=for-the-badge&logo=python&logoColor=white)
 ![FastAPI](https://img.shields.io/badge/FastAPI-009688?style=for-the-badge&logo=fastapi&logoColor=white)
 ![Pydantic](https://img.shields.io/badge/Pydantic_v2-E92063?style=for-the-badge&logo=pydantic&logoColor=white)
-![Pytest](https://img.shields.io/badge/Pytest_+_Hypothesis-0A9EDC?style=for-the-badge&logo=pytest&logoColor=white)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)
 
 **AI & RAG**
@@ -348,6 +347,7 @@ AI는 **"어떻게(How)"** 를 엄청난 속도로 만들어준다. 코드도, �
 ![Amazon Bedrock](https://img.shields.io/badge/Amazon_Bedrock-01A88D?style=for-the-badge&logo=amazonaws&logoColor=white)
 ![Bedrock KB](https://img.shields.io/badge/Bedrock_Knowledge_Base-222F3E?style=for-the-badge&logo=amazonaws&logoColor=white)
 ![S3 Vectors](https://img.shields.io/badge/S3_Vectors-569A31?style=for-the-badge&logo=amazons3&logoColor=white)
+![Pytest](https://img.shields.io/badge/Pytest_+_Hypothesis-0A9EDC?style=for-the-badge&logo=pytest&logoColor=white)
 
 **Infra (서버리스 중심)**
 


### PR DESCRIPTION
## PR 요약
- 소개 페이지 레이아웃 재작성하고, 기술 스택 분류 정합성 정리

## 변경 유형
- [x] 문서 수정

## 변경 사항

### 소개 페이지 (`index.md`)
- **레이아웃 구조 재작성**
  - body `padding-left: 210px` + 사이드바 `width: 210px` 로 정렬 (margin 방식의 빈공간 결함 해소)
  - 본문 wrapper: `max-width: 900px` 중앙 정렬
  - `scroll-behavior: smooth` 적용 (목차 클릭 시 부드럽게 이동)
- **사이드바**
  - 회색(#f1f5f9) 배경 + 우측 border
  - 목차: `ol` 기반 자동 번호 매김 + 박스 호버 (Poco 기본 스타일)
  - 하단 버튼: 흰색 배경 2종 (GitHub 리포지토리 · 서비스 바로가기)
- **제거**
  - AWS 캡스톤디자인 59팀 버튼
  - 우측 하단 원형 Top 버튼
  - gradient 버튼 스타일

### README.md
- 발자국(🐾) 이모지 통일 · flat-square 뱃지
- 팀원 가로 4열 아바타 테이블

### 기술 스택 재분류 (양쪽 문서 공통)
- **Pytest + Hypothesis** 뱃지를 `Backend` → `AI & RAG` 그룹으로 이동
  - `ai/` 폴더에만 hypothesis 기반 PBT 테스트 7종 존재 (backend에는 테스트 없음)

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- 문서 전용 PR, API/DB 변경 없음
- 머지 후 GitHub Pages 자동 재빌드 1~2분 대기
- 배포 확인: https://kookmin-sw.github.io/2026-capstone-59/