### PR TITLE
[#118][AI] AI 모듈 SSE 스트리밍 지원 — 사이드패널 체감 대기 제거

### DIFF
--- a/ai/clients/llm.py
+++ b/ai/clients/llm.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 import uuid
 from json import JSONDecodeError
-from typing import Any, Optional, TypeVar
+from typing import Any, AsyncIterator, Optional, TypeVar
 
 from botocore.exceptions import BotoCoreError, ClientError
 from pydantic import BaseModel, ValidationError
@@ -192,4 +193,111 @@ class LLMClient:
         raise AIGenerationFailedError(
             message="AI 생성에 실패했습니다 (재시도 초과).",
             details=details,
+        )
+
+    async def invoke_stream(
+        self,
+        prompt: str,
+        max_tokens: Optional[int] = None,
+    ) -> AsyncIterator[str]:
+        """Bedrock Claude 스트리밍 호출. content_block_delta의 text만 yield.
+
+        - Pydantic 검증 없음. 재시도 없음.
+        - max_tokens 우선순위: 인자 > self.max_tokens > 생성자 기본값 (invoke와 동일).
+        - ClientError/BotoCoreError → BedrockAPIError로 래핑하여 re-raise.
+        - JSON decode 실패 청크는 log warning 후 skip (스트림 전체는 계속).
+        """
+        correlation_id = str(uuid.uuid4())
+        effective_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
+        request_body = json.dumps(
+            {
+                "anthropic_version": _ANTHROPIC_VERSION,
+                "max_tokens": effective_max_tokens,
+                "temperature": self.temperature,
+                "messages": [{"role": "user", "content": prompt}],
+            }
+        )
+
+        _log(
+            logging.INFO,
+            "llm_invoke_stream_start",
+            correlation_id=correlation_id,
+            model_id=self.model_id,
+            max_tokens=effective_max_tokens,
+            prompt_len=len(prompt),
+        )
+
+        start = time.perf_counter()
+        total_chunks = 0
+
+        try:
+            response = await asyncio.to_thread(
+                self.bedrock_client.invoke_model_with_response_stream,
+                modelId=self.model_id,
+                body=request_body,
+                contentType="application/json",
+            )
+        except (ClientError, BotoCoreError) as exc:
+            elapsed = time.perf_counter() - start
+            error_details = {
+                "correlation_id": correlation_id,
+                "model_id": self.model_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+                "elapsed_s": round(elapsed, 3),
+            }
+            _log(logging.ERROR, "llm_invoke_stream_failed", **error_details)
+            raise BedrockAPIError(
+                message="Bedrock 스트리밍 호출에 실패했습니다.",
+                details=error_details,
+            ) from exc
+
+        try:
+            for event in response["body"]:
+                chunk_bytes = event.get("chunk", {}).get("bytes") if isinstance(event, dict) else None
+                if not chunk_bytes:
+                    # MagicMock 기반 이벤트는 dict가 아닐 수 있어 getattr fallback.
+                    chunk_obj = getattr(event, "get", lambda _k, _d=None: None)("chunk", {})
+                    chunk_bytes = chunk_obj.get("bytes") if isinstance(chunk_obj, dict) else None
+                if not chunk_bytes:
+                    continue
+                try:
+                    payload = json.loads(chunk_bytes.decode("utf-8"))
+                except (JSONDecodeError, UnicodeDecodeError) as exc:
+                    _log(
+                        logging.WARNING,
+                        "llm_invoke_stream_chunk_skipped",
+                        correlation_id=correlation_id,
+                        reason=type(exc).__name__,
+                    )
+                    continue
+                if payload.get("type") != "content_block_delta":
+                    continue
+                text = payload.get("delta", {}).get("text", "")
+                if text:
+                    total_chunks += 1
+                    yield text
+        except (ClientError, BotoCoreError) as exc:
+            elapsed = time.perf_counter() - start
+            error_details = {
+                "correlation_id": correlation_id,
+                "model_id": self.model_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+                "elapsed_s": round(elapsed, 3),
+            }
+            _log(logging.ERROR, "llm_invoke_stream_failed", **error_details)
+            raise BedrockAPIError(
+                message="Bedrock 스트리밍 수신 중 오류가 발생했습니다.",
+                details=error_details,
+            ) from exc
+
+        elapsed = time.perf_counter() - start
+        _log(
+            logging.INFO,
+            "llm_invoke_stream_end",
+            correlation_id=correlation_id,
+            model_id=self.model_id,
+            total_chunks=total_chunks,
+            elapsed_s=round(elapsed, 3),
         )

--- a/ai/latency_simulator.py
+++ b/ai/latency_simulator.py
@@ -50,6 +50,7 @@ from ai.services.step_generator import StepGenerator
 
 
 SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION_STREAMING = "1.1"
 SCENARIO_TAG = "stage1_r1_problem_definition"
 DEFAULT_BASELINE_PATH = Path(".kiro/specs/ai-latency-optimization/baseline.json")
 
@@ -242,6 +243,98 @@ async def _run_pipeline(
     }
 
 
+async def _consume_stream(
+    label: str,
+    sp_gen: SidePanelGenerator,
+    input_data: SidePanelInput,
+) -> Dict[str, Any]:
+    """SidePanelGenerator.generate_stream을 소비하며 TTFT/TTLT 측정."""
+    start = time.perf_counter()
+    first_chunk_at: Optional[float] = None
+    chunks: List[str] = []
+    try:
+        async for chunk in sp_gen.generate_stream(input_data):
+            if first_chunk_at is None:
+                first_chunk_at = time.perf_counter()
+            chunks.append(chunk)
+    except BaseException as exc:  # noqa: BLE001
+        elapsed = time.perf_counter() - start
+        raise _StageError(label, elapsed, exc) from exc
+    end = time.perf_counter()
+    ttft = (first_chunk_at - start) if first_chunk_at is not None else 0.0
+    ttlt = end - start
+    return {
+        "label": label,
+        "ttft_s": ttft,
+        "ttlt_s": ttlt,
+        "aggregated_text": "".join(chunks),
+    }
+
+
+async def _run_pipeline_streaming(
+    step_gen: StepGenerator,
+    judge: RequiredStepJudge,
+    sp_gen: SidePanelGenerator,
+) -> Dict[str, Any]:
+    """Stage A는 non-stream 그대로, Stage B만 3개 병렬 스트림."""
+    # --- Stage A (기존 동일) ---
+    t0 = time.perf_counter()
+    judge_coro = _measure_call("judge", judge.judge_required_step(_build_accept_input()))
+    gen_coro = _measure_call("generate", step_gen.generate_steps(_build_generate_input()))
+    judge_m, gen_m = await asyncio.gather(judge_coro, gen_coro)
+    stage_a_s = time.perf_counter() - t0
+
+    gen_output: GenerateOutput = gen_m["result"]
+    judge_output: AcceptOutput = judge_m["result"]
+
+    # --- Stage B (streaming × 3) ---
+    t1 = time.perf_counter()
+    sp_tasks = [
+        _consume_stream(
+            f"side_panel_{i}",
+            sp_gen,
+            _build_side_panel_input(step),
+        )
+        for i, step in enumerate(gen_output.generated_steps)
+    ]
+    sp_results = await asyncio.gather(*sp_tasks)
+    stage_b_wall_s = time.perf_counter() - t1
+
+    ttfts = [r["ttft_s"] for r in sp_results]
+    ttlts = [r["ttlt_s"] for r in sp_results]
+    stage_b_ttft_s = min(ttfts) if ttfts else 0.0
+    stage_b_ttlt_s = max(ttlts) if ttlts else 0.0
+    pipeline_ttft_s = stage_a_s + stage_b_ttft_s
+    pipeline_ttlt_s = stage_a_s + stage_b_ttlt_s
+
+    return {
+        "judge_s": judge_m["elapsed_s"],
+        "generate_s": gen_m["elapsed_s"],
+        "side_panel_streams": [
+            {
+                "label": r["label"],
+                "ttft_s": r["ttft_s"],
+                "ttlt_s": r["ttlt_s"],
+            }
+            for r in sp_results
+        ],
+        "stage_a_s": stage_a_s,
+        "stage_b_wall_s": stage_b_wall_s,
+        "stage_b_ttft_s": stage_b_ttft_s,
+        "stage_b_ttlt_s": stage_b_ttlt_s,
+        "pipeline_ttft_s": pipeline_ttft_s,
+        "pipeline_ttlt_s": pipeline_ttlt_s,
+        "outputs": {
+            "judge": judge_output.model_dump(mode="json"),
+            "generate": gen_output.model_dump(mode="json"),
+            "side_panels": [
+                {"label": r["label"], "aggregated_text": r["aggregated_text"]}
+                for r in sp_results
+            ],
+        },
+    }
+
+
 # ---------------------------------------------------------------------------
 # 통계 (외부 의존성 없음)
 # ---------------------------------------------------------------------------
@@ -294,6 +387,39 @@ def _strip_outputs_for_run(run: Dict[str, Any]) -> Dict[str, Any]:
         "stage_a_s": run["stage_a_s"],
         "stage_b_s": run["stage_b_s"],
         "pipeline_s": run["pipeline_s"],
+    }
+
+
+def _strip_outputs_for_stream_run(run: Dict[str, Any]) -> Dict[str, Any]:
+    """streaming per_run 저장 시 응답 본문을 제거하고 타이밍만 남긴다."""
+    return {
+        "judge_s": run["judge_s"],
+        "generate_s": run["generate_s"],
+        "side_panel_streams": run["side_panel_streams"],
+        "stage_a_s": run["stage_a_s"],
+        "stage_b_wall_s": run["stage_b_wall_s"],
+        "stage_b_ttft_s": run["stage_b_ttft_s"],
+        "stage_b_ttlt_s": run["stage_b_ttlt_s"],
+        "pipeline_ttft_s": run["pipeline_ttft_s"],
+        "pipeline_ttlt_s": run["pipeline_ttlt_s"],
+    }
+
+
+def _summarize_streaming(per_run: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """streaming per_run 집계 — ttft/ttlt/pipeline_ttft/pipeline_ttlt × (p50, p100)."""
+
+    def field(pick) -> Dict[str, float]:
+        vals = [pick(r) for r in per_run]
+        return {"p50": _percentile(vals, 0.5), "p100": _percentile(vals, 1.0)}
+
+    return {
+        "judge": field(lambda r: r["judge_s"]),
+        "generate": field(lambda r: r["generate_s"]),
+        "stage_a": field(lambda r: r["stage_a_s"]),
+        "ttft": field(lambda r: r["stage_b_ttft_s"]),
+        "ttlt": field(lambda r: r["stage_b_ttlt_s"]),
+        "pipeline_ttft": field(lambda r: r["pipeline_ttft_s"]),
+        "pipeline_ttlt": field(lambda r: r["pipeline_ttlt_s"]),
     }
 
 
@@ -385,6 +511,46 @@ def _print_summary(summary: Dict[str, Any], runs_count: int) -> None:
         print(f"  {label} p50={p50:.3f}s  p100={p100:.3f}s")
 
 
+def _print_stream_run(index: int, total: int, run: Dict[str, Any]) -> None:
+    _section(f"Run {index + 1}/{total} — Pipeline Latency (streaming)")
+    print("  Stage A (judge ∥ generate)")
+    print(f"    judge        : {run['judge_s']:.3f}s")
+    print(f"    generate     : {run['generate_s']:.3f}s")
+    print(f"    stage_a_s    : {run['stage_a_s']:.3f}s  (= max of the two)")
+    print("  Stage B (side_panel × 3, streaming)")
+    for stream in run["side_panel_streams"]:
+        print(
+            f"    {stream['label']}: "
+            f"ttft={stream['ttft_s']:.3f}s  ttlt={stream['ttlt_s']:.3f}s"
+        )
+    print(
+        f"    stage_b      : ttft={run['stage_b_ttft_s']:.3f}s (min)  "
+        f"ttlt={run['stage_b_ttlt_s']:.3f}s (max)  wall={run['stage_b_wall_s']:.3f}s"
+    )
+    print(
+        f"  Pipeline       : ttft={run['pipeline_ttft_s']:.3f}s  "
+        f"ttlt={run['pipeline_ttlt_s']:.3f}s"
+    )
+
+
+def _print_stream_summary(summary: Dict[str, Any], runs_count: int) -> None:
+    _section(f"Summary — streaming (N={runs_count})")
+    fields = [
+        ("judge", "judge         "),
+        ("generate", "generate      "),
+        ("stage_a", "stage_a       "),
+        ("ttft", "ttft          "),
+        ("ttlt", "ttlt          "),
+        ("pipeline_ttft", "pipeline_ttft "),
+        ("pipeline_ttlt", "pipeline_ttlt "),
+    ]
+    for key, label in fields:
+        entry = summary.get(key, {})
+        p50 = entry.get("p50", 0.0)
+        p100 = entry.get("p100", 0.0)
+        print(f"  {label} p50={p50:.3f}s  p100={p100:.3f}s")
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -414,6 +580,11 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
             "Baseline 기록 모드. target 파일이 이미 존재하면 refuse(exit 2). "
             "--output 미지정 시 기본 경로 .kiro/specs/ai-latency-optimization/baseline.json 사용"
         ),
+    )
+    parser.add_argument(
+        "--streaming",
+        action="store_true",
+        help="Stage B를 스트리밍 모드로 실행하고 TTFT/TTLT를 측정한다 (artifact schema 1.1).",
     )
     return parser.parse_args(argv)
 
@@ -466,7 +637,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         for i in range(args.runs):
             try:
                 # run마다 새 event loop를 사용해 run 간 상태 오염을 방지
-                run_result = asyncio.run(_run_pipeline(step_gen, judge, sp_gen))
+                if args.streaming:
+                    run_result = asyncio.run(_run_pipeline_streaming(step_gen, judge, sp_gen))
+                else:
+                    run_result = asyncio.run(_run_pipeline(step_gen, judge, sp_gen))
             except _StageError as e:
                 print(
                     f"[fail] stage={e.label} "
@@ -482,18 +656,26 @@ def main(argv: Optional[List[str]] = None) -> int:
                 return 1
 
             per_run_full.append(run_result)
-            per_run.append(_strip_outputs_for_run(run_result))
-            _print_run(i, args.runs, run_result)
+            if args.streaming:
+                per_run.append(_strip_outputs_for_stream_run(run_result))
+                _print_stream_run(i, args.runs, run_result)
+            else:
+                per_run.append(_strip_outputs_for_run(run_result))
+                _print_run(i, args.runs, run_result)
     except KeyboardInterrupt:
         print()
         print("[interrupt] 사용자 중단", file=sys.stderr)
         return 130
 
-    summary = _summarize(per_run)
-    _print_summary(summary, args.runs)
+    if args.streaming:
+        summary = _summarize_streaming(per_run)
+        _print_stream_summary(summary, args.runs)
+    else:
+        summary = _summarize(per_run)
+        _print_summary(summary, args.runs)
 
     artifact = {
-        "schema_version": SCHEMA_VERSION,
+        "schema_version": SCHEMA_VERSION_STREAMING if args.streaming else SCHEMA_VERSION,
         "timestamp": _utc_now_iso(),
         "model_id": ai_settings.MODEL_ID,
         "scenario": SCENARIO_TAG,
@@ -501,6 +683,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         "per_run": per_run,
         "summary": summary,
     }
+    if args.streaming:
+        artifact["mode"] = "streaming"
 
     if args.output or args.baseline:
         out_path = Path(args.output) if args.output else DEFAULT_BASELINE_PATH

--- a/ai/services/__init__.py
+++ b/ai/services/__init__.py
@@ -12,7 +12,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, AsyncIterator
 
 from ai.clients.llm import LLMClient
 from ai.clients.rag import RAGClient
@@ -63,8 +63,26 @@ async def generate_side_panel(
     return await service.generate_side_panel(input_data)
 
 
+async def generate_side_panel_stream(
+    input_data: SidePanelInput,
+    llm_client: LLMClient,
+    rag_client: RAGClient,
+) -> AsyncIterator[str]:
+    """side_panel 시나리오 — 스트리밍 경로.
+
+    기존 generate_side_panel과 달리, 백엔드가 LLMClient/RAGClient를 미리
+    만들어 주입하는 형태. SSE 엔드포인트 당 연결을 유지하며 청크를 즉시
+    yield한다. Pydantic 검증은 수행하지 않으며, 순수 텍스트 청크를 그대로
+    전달한다.
+    """
+    service = SidePanelGenerator(llm=llm_client, rag=rag_client)
+    async for chunk in service.generate_stream(input_data):
+        yield chunk
+
+
 __all__ = [
     "generate_steps",
     "judge_required_step",
     "generate_side_panel",
+    "generate_side_panel_stream",
 ]

--- a/ai/services/side_panel_generator.py
+++ b/ai/services/side_panel_generator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import Any, AsyncIterator
 
 from ai.clients.llm import LLMClient
 from ai.clients.rag import RAGClient
@@ -59,6 +59,47 @@ class SidePanelGenerator:
         self.llm = llm
         self.rag = rag
 
+    def _build_prompt(
+        self,
+        input_data: SidePanelInput,
+        doj_chunks: list[RetrievedChunk],
+        custom_chunks: list[RetrievedChunk],
+    ) -> str:
+        stage = input_data.current_stage
+        project = input_data.project_info
+        target = input_data.target_step
+
+        decision_history_json = json.dumps(
+            [item.model_dump(mode='json') for item in input_data.decision_history],
+            ensure_ascii=False,
+        )
+
+        if input_data.current_required_step is not None:
+            required_step_info = json.dumps(
+                input_data.current_required_step.model_dump(mode='json'),
+                ensure_ascii=False,
+            )
+        else:
+            required_step_info = _NONE_LABEL
+
+        rag_context_text = _format_rag_context(doj_chunks, custom_chunks)
+
+        return PromptTemplate.load_and_render(
+            _SCENARIO,
+            project_name=_coerce(project.name),
+            duration_months=str(project.duration_months),
+            member_count=str(project.member_count),
+            description=_coerce(project.description),
+            constraints=_coerce(project.constraints),
+            initial_prompt=project.initial_prompt,
+            stage_sequence=str(stage.stage_sequence),
+            stage_name=stage.name,
+            target_step_name=target.name,
+            decision_history=decision_history_json,
+            current_required_step_info=required_step_info,
+            rag_context=rag_context_text,
+        )
+
     async def generate_side_panel(self, input_data: SidePanelInput) -> SidePanelOutput:
         """입력을 받아 Claude로 사이드패널 콘텐츠를 생성한다.
 
@@ -79,36 +120,7 @@ class SidePanelGenerator:
             self.rag.search_custom(custom_query, num_results=2),
         )
 
-        decision_history_json = json.dumps(
-            [item.model_dump(mode='json') for item in input_data.decision_history],
-            ensure_ascii=False,
-        )
-
-        if input_data.current_required_step is not None:
-            required_step_info = json.dumps(
-                input_data.current_required_step.model_dump(mode='json'),
-                ensure_ascii=False,
-            )
-        else:
-            required_step_info = _NONE_LABEL
-
-        rag_context_text = _format_rag_context(doj_chunks, custom_chunks)
-
-        prompt = PromptTemplate.load_and_render(
-            _SCENARIO,
-            project_name=_coerce(project.name),
-            duration_months=str(project.duration_months),
-            member_count=str(project.member_count),
-            description=_coerce(project.description),
-            constraints=_coerce(project.constraints),
-            initial_prompt=project.initial_prompt,
-            stage_sequence=str(stage.stage_sequence),
-            stage_name=stage.name,
-            target_step_name=target.name,
-            decision_history=decision_history_json,
-            current_required_step_info=required_step_info,
-            rag_context=rag_context_text,
-        )
+        prompt = self._build_prompt(input_data, doj_chunks, custom_chunks)
 
         logger.info(
             json.dumps(
@@ -128,3 +140,45 @@ class SidePanelGenerator:
         )
 
         return await self.llm.invoke(prompt, SidePanelOutput, max_tokens=2048)
+
+    async def generate_stream(
+        self, input_data: SidePanelInput
+    ) -> AsyncIterator[str]:
+        """사이드패널 콘텐츠를 Bedrock 스트리밍으로 yield.
+
+        프롬프트 조립은 sync 경로(_build_prompt)와 공유하여 byte-identical.
+        LLM 호출은 invoke_stream으로 대체하며 청크는 변형 없이 그대로 yield.
+        """
+        stage = input_data.current_stage
+        project = input_data.project_info
+        target = input_data.target_step
+
+        doj_query = f"Stage {stage.stage_sequence} {stage.name} {target.name}"
+        custom_query = target.name
+
+        doj_chunks, custom_chunks = await asyncio.gather(
+            self.rag.search_doj(doj_query, num_results=3),
+            self.rag.search_custom(custom_query, num_results=2),
+        )
+
+        prompt = self._build_prompt(input_data, doj_chunks, custom_chunks)
+
+        logger.info(
+            json.dumps(
+                {
+                    "event": "side_panel_stream_start",
+                    "project_id": str(project.project_id),
+                    "stage_sequence": stage.stage_sequence,
+                    "target_step_name": target.name,
+                    "doj_chunks": len(doj_chunks),
+                    "custom_chunks": len(custom_chunks),
+                    "has_required_step": input_data.current_required_step is not None,
+                    "prompt_len": len(prompt),
+                },
+                ensure_ascii=False,
+                default=str,
+            )
+        )
+
+        async for chunk in self.llm.invoke_stream(prompt, max_tokens=2048):
+            yield chunk

--- a/ai/tests/test_latency_simulator_streaming.py
+++ b/ai/tests/test_latency_simulator_streaming.py
@@ -1,0 +1,191 @@
+"""ai/latency_simulator.py --streaming 경로 단위 테스트."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ai import latency_simulator as ls
+from ai.schemas.accept import AcceptOutput
+from ai.schemas.common import GeneratedStep
+from ai.schemas.generate import GenerateOutput
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _async_gen(chunks: list, first_chunk_delay: float = 0.0):
+    """fake chunks를 지연과 함께 yield하는 async generator."""
+    import asyncio as _asyncio
+
+    for i, c in enumerate(chunks):
+        if i == 0 and first_chunk_delay > 0:
+            await _asyncio.sleep(first_chunk_delay)
+        yield c
+
+
+def _mock_stream_services(first_chunk_delay: float = 0.0, total_chunks: int = 3):
+    """스트리밍 경로용 mock 서비스 3종."""
+    valid_generate = GenerateOutput(
+        generated_steps=[
+            GeneratedStep(name="A", description="a"),
+            GeneratedStep(name="B", description="b"),
+            GeneratedStep(name="C", description="c"),
+        ]
+    )
+    valid_judge = AcceptOutput(is_current_required_step_completed=True)
+
+    step_gen = MagicMock()
+    step_gen.generate_steps = AsyncMock(return_value=valid_generate)
+
+    judge = MagicMock()
+    judge.judge_required_step = AsyncMock(return_value=valid_judge)
+
+    sp_gen = MagicMock()
+    chunks_list = [f"chunk_{i}" for i in range(total_chunks)]
+    sp_gen.generate_stream = MagicMock(
+        side_effect=lambda _input: _async_gen(chunks_list, first_chunk_delay)
+    )
+
+    return step_gen, judge, sp_gen
+
+
+def _mock_non_stream_services():
+    """non-stream 경로용 mock 서비스 (test_latency_simulator_cli._mock_services 동일)."""
+    from ai.schemas.common import (
+        CommonMistake,
+        DictionaryItem,
+        MentoringContent,
+        RecommendedMethod,
+    )
+    from ai.schemas.side_panel import SidePanelOutput
+
+    valid_generate = GenerateOutput(
+        generated_steps=[
+            GeneratedStep(name="A", description="a"),
+            GeneratedStep(name="B", description="b"),
+            GeneratedStep(name="C", description="c"),
+        ]
+    )
+    valid_side_panel = SidePanelOutput(
+        mentoring=MentoringContent(
+            description="d",
+            recommended_methods=[
+                RecommendedMethod(title="t1", content="c1"),
+                RecommendedMethod(title="t2", content="c2"),
+            ],
+            common_mistakes=[
+                CommonMistake(mistake="m", bad_example="b", good_example="g"),
+            ],
+            one_line_tip="tip",
+        ),
+        dictionary=[
+            DictionaryItem(term="x", definition="y"),
+            DictionaryItem(term="z", definition="w"),
+        ],
+    )
+    valid_judge = AcceptOutput(is_current_required_step_completed=True)
+
+    step_gen = MagicMock()
+    step_gen.generate_steps = AsyncMock(return_value=valid_generate)
+
+    judge = MagicMock()
+    judge.judge_required_step = AsyncMock(return_value=valid_judge)
+
+    sp_gen = MagicMock()
+    sp_gen.generate_side_panel = AsyncMock(return_value=valid_side_panel)
+
+    return step_gen, judge, sp_gen
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgsStreaming:
+    def test_streaming_flag_true(self) -> None:
+        args = ls._parse_args(["--streaming"])
+        assert args.streaming is True
+
+    def test_streaming_flag_default_false(self) -> None:
+        args = ls._parse_args([])
+        assert args.streaming is False
+
+
+class TestTtftTtltCalculation:
+    @pytest.mark.asyncio
+    async def test_first_chunk_delay_measured_as_ttft(self) -> None:
+        """첫 번째 청크 지연이 TTFT로 측정되는지 검증."""
+        sp_gen = MagicMock()
+        sp_gen.generate_stream = MagicMock(
+            side_effect=lambda _inp: _async_gen(["X", "Y"], first_chunk_delay=0.1)
+        )
+
+        fake_input = MagicMock()
+        result = await ls._consume_stream("label_0", sp_gen, fake_input)
+
+        assert result["label"] == "label_0"
+        assert 0.08 <= result["ttft_s"] <= 0.3, f"ttft={result['ttft_s']}"
+        assert result["ttlt_s"] >= result["ttft_s"]
+        assert result["aggregated_text"] == "XY"
+
+
+class TestStreamingArtifactSchema:
+    def test_summary_has_streaming_fields(self, tmp_path: Path) -> None:
+        """--streaming artifact가 schema 1.1 + 필수 필드를 갖는지 검증."""
+        target = tmp_path / "stream_out.json"
+        with patch.object(ls, "_build_services", return_value=_mock_stream_services()):
+            exit_code = ls.main([
+                "--streaming", "--output", str(target), "--runs", "2",
+            ])
+
+        assert exit_code == 0
+        artifact = json.loads(target.read_text(encoding="utf-8"))
+
+        assert artifact["schema_version"] == "1.1"
+        assert artifact["mode"] == "streaming"
+
+        summary = artifact["summary"]
+        for key in ["ttft", "ttlt", "pipeline_ttft", "pipeline_ttlt"]:
+            assert key in summary, f"missing key: {key}"
+            assert "p50" in summary[key]
+            assert "p100" in summary[key]
+
+        for run in artifact["per_run"]:
+            assert "side_panel_streams" in run
+            assert len(run["side_panel_streams"]) == 3
+            for stream in run["side_panel_streams"]:
+                assert set(stream.keys()) == {"label", "ttft_s", "ttlt_s"}
+            for key in ["stage_b_ttft_s", "stage_b_ttlt_s",
+                        "pipeline_ttft_s", "pipeline_ttlt_s"]:
+                assert key in run, f"missing run key: {key}"
+
+
+class TestNonStreamingSchemaPreserved:
+    def test_non_stream_artifact_has_no_mode_field_and_v1_schema(
+        self, tmp_path: Path
+    ) -> None:
+        """non-stream artifact는 schema 1.0이고 mode 필드가 없어야 함."""
+        target = tmp_path / "non_stream_out.json"
+        with patch.object(ls, "_build_services", return_value=_mock_non_stream_services()):
+            exit_code = ls.main(["--output", str(target), "--runs", "1"])
+
+        assert exit_code == 0
+        artifact = json.loads(target.read_text(encoding="utf-8"))
+
+        assert artifact["schema_version"] == "1.0"
+        assert "mode" not in artifact
+
+        for run in artifact["per_run"]:
+            for key in ["judge_s", "generate_s", "side_panel_s",
+                        "stage_a_s", "stage_b_s", "pipeline_s"]:
+                assert key in run, f"missing run key: {key}"
+            for key in ["side_panel_streams", "stage_b_ttft_s", "pipeline_ttft_s"]:
+                assert key not in run, f"unexpected streaming key: {key}"

--- a/ai/tests/test_llm_client_stream.py
+++ b/ai/tests/test_llm_client_stream.py
@@ -1,0 +1,131 @@
+"""ai/clients/llm.py LLMClient.invoke_stream 단위 테스트."""
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from ai.clients.llm import LLMClient
+from ai.exceptions import BedrockAPIError
+
+MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _delta_event(text: str) -> dict:
+    payload = {"type": "content_block_delta", "delta": {"text": text}}
+    return {"chunk": {"bytes": json.dumps(payload).encode("utf-8")}}
+
+
+def _non_delta_event() -> dict:
+    payload = {"type": "message_start"}
+    return {"chunk": {"bytes": json.dumps(payload).encode("utf-8")}}
+
+
+def _invalid_chunk_event() -> dict:
+    return {"chunk": {"bytes": b"{not valid json"}}
+
+
+def _stream_response(events: list) -> dict:
+    return {"body": iter(events)}
+
+
+async def _collect(agen) -> list:
+    result = []
+    async for chunk in agen:
+        result.append(chunk)
+    return result
+
+
+def _make_bedrock_mock(events: list) -> MagicMock:
+    bedrock = MagicMock()
+    bedrock.invoke_model_with_response_stream.return_value = _stream_response(events)
+    return bedrock
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeStream:
+    @pytest.mark.asyncio
+    async def test_invoke_stream_yields_chunks(self) -> None:
+        """delta event → 텍스트 yield, non-delta event는 건너뜀."""
+        events = [
+            _non_delta_event(),
+            _delta_event("A"),
+            _delta_event("B"),
+            _delta_event("C"),
+        ]
+        bedrock = _make_bedrock_mock(events)
+        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
+
+        chunks = await _collect(client.invoke_stream("prompt"))
+
+        assert chunks == ["A", "B", "C"]
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_max_tokens_priority(self) -> None:
+        """invoke_stream max_tokens 3단 우선순위 검증."""
+
+        def _captured_max_tokens(bedrock: MagicMock) -> int:
+            body_str = bedrock.invoke_model_with_response_stream.call_args.kwargs["body"]
+            return json.loads(body_str)["max_tokens"]
+
+        # Case 1: 명시값 > 생성자 값
+        bedrock1 = _make_bedrock_mock([])
+        client1 = LLMClient(bedrock_client=bedrock1, model_id=MODEL_ID, max_tokens=4096)
+        await _collect(client1.invoke_stream("p", max_tokens=512))
+        assert _captured_max_tokens(bedrock1) == 512
+
+        # Case 2: 생성자 값 사용 (invoke_stream max_tokens 생략)
+        bedrock2 = _make_bedrock_mock([])
+        client2 = LLMClient(bedrock_client=bedrock2, model_id=MODEL_ID, max_tokens=2048)
+        await _collect(client2.invoke_stream("p"))
+        assert _captured_max_tokens(bedrock2) == 2048
+
+        # Case 3: 생성자 기본값 4096 폴백
+        bedrock3 = _make_bedrock_mock([])
+        client3 = LLMClient(bedrock_client=bedrock3, model_id=MODEL_ID)
+        await _collect(client3.invoke_stream("p"))
+        assert _captured_max_tokens(bedrock3) == 4096
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_raises_bedrock_api_error_on_client_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """invoke_model_with_response_stream ClientError → BedrockAPIError."""
+        bedrock = MagicMock()
+        bedrock.invoke_model_with_response_stream.side_effect = ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}},
+            "InvokeModelWithResponseStream",
+        )
+        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(BedrockAPIError):
+                await _collect(client.invoke_stream("prompt"))
+
+        assert any("llm_invoke_stream_failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_skips_invalid_chunks(self) -> None:
+        """invalid JSON 청크는 skip하고 스트림 계속."""
+        events = [
+            _delta_event("A"),
+            _invalid_chunk_event(),
+            _delta_event("B"),
+        ]
+        bedrock = _make_bedrock_mock(events)
+        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
+
+        chunks = await _collect(client.invoke_stream("prompt"))
+
+        assert chunks == ["A", "B"]

--- a/ai/tests/test_side_panel_generator_stream.py
+++ b/ai/tests/test_side_panel_generator_stream.py
@@ -1,0 +1,194 @@
+"""SidePanelGenerator.generate_stream 단위 테스트."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.schemas.common import (
+    CommonMistake,
+    DecisionHistoryItem,
+    DictionaryItem,
+    MentoringContent,
+    ProjectInfo,
+    RecommendedMethod,
+    RequiredStepInfo,
+    RetrievedChunk,
+    StageInfo,
+    StepInfo,
+)
+from ai.schemas.side_panel import SidePanelInput, SidePanelOutput
+from ai.services.side_panel_generator import SidePanelGenerator
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (기존 test_side_panel_generator.py와 동일 구조, 독립 정의)
+# ---------------------------------------------------------------------------
+
+
+def _project() -> ProjectInfo:
+    return ProjectInfo(
+        project_id="proj-1",
+        name="배달 라이더 경로 최적화 앱",
+        duration_months=3,
+        member_count=4,
+        description="배달 라이더 경로 비효율 문제 해결",
+        constraints="React + FastAPI",
+        initial_prompt="배달 라이더 경로 최적화 서비스를 만들고 싶음",
+    )
+
+
+def _stage() -> StageInfo:
+    return StageInfo(stage_id="stage-1", stage_sequence=1, name="아이디어 구체화")
+
+
+def _required_step() -> RequiredStepInfo:
+    return RequiredStepInfo(
+        step_id="rs-1",
+        name="핵심 컨셉 정의",
+        is_completed=False,
+        goal="문제를 어떤 해결책으로 풀지 정리",
+        entry_criteria="문제와 사용자에 대한 맥락이 존재",
+        fulfillment_criteria=["해결 접근", "경쟁 비교", "차별점", "주요 기능"],
+        minimum_fulfillment_count=2,
+    )
+
+
+def _input_full() -> SidePanelInput:
+    return SidePanelInput(
+        project_info=_project(),
+        current_stage=_stage(),
+        target_step=StepInfo(step_id="ts-1", name="경쟁 서비스 조사"),
+        decision_history=[
+            DecisionHistoryItem(step_id="s0", name="문제/기회 정의", status="ACCEPTED"),
+        ],
+        current_required_step=_required_step(),
+    )
+
+
+def _valid_output() -> SidePanelOutput:
+    return SidePanelOutput(
+        mentoring=MentoringContent(
+            description="이 Step에서는 ...",
+            recommended_methods=[
+                RecommendedMethod(title="경쟁 서비스 찾기", content="3~5개 후보를 모은다."),
+                RecommendedMethod(title="사용자 리뷰 모으기", content="앱스토어 리뷰를 모은다."),
+            ],
+            common_mistakes=[
+                CommonMistake(
+                    mistake="이름만 모으고 끝내기",
+                    bad_example="A사, B사가 있다",
+                    good_example="A사는 ~를 잘하지만 ~가 부족하다",
+                ),
+            ],
+            one_line_tip="기존 대안이 놓친 틈을 찾자.",
+        ),
+        dictionary=[
+            DictionaryItem(term="페르소나", definition="타겟 사용자를 대표하는 가상 인물"),
+            DictionaryItem(term="MVP", definition="최소 기능만 갖춘 초기 제품"),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _async_gen(chunks: list):
+    for c in chunks:
+        yield c
+
+
+def _make_stream_service(
+    chunks: list,
+    doj_return=None,
+    custom_return=None,
+):
+    llm = MagicMock()
+    llm.invoke_stream = MagicMock(return_value=_async_gen(chunks))
+
+    rag = MagicMock()
+    rag.search_doj = AsyncMock(return_value=doj_return if doj_return is not None else [])
+    rag.search_custom = AsyncMock(return_value=custom_return if custom_return is not None else [])
+
+    return SidePanelGenerator(llm=llm, rag=rag), llm, rag
+
+
+def _make_service(
+    llm_return=None,
+    doj_return=None,
+    custom_return=None,
+):
+    llm = MagicMock()
+    llm.invoke = AsyncMock(return_value=llm_return if llm_return is not None else _valid_output())
+
+    rag = MagicMock()
+    rag.search_doj = AsyncMock(return_value=doj_return if doj_return is not None else [])
+    rag.search_custom = AsyncMock(return_value=custom_return if custom_return is not None else [])
+
+    return SidePanelGenerator(llm=llm, rag=rag), llm, rag
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateStream:
+    @pytest.mark.asyncio
+    async def test_calls_rag_with_reduced_num_results(self) -> None:
+        """RAG 호출 시 num_results=3(doj), num_results=2(custom)."""
+        service, _, rag = _make_stream_service(chunks=["x"])
+
+        async for _ in service.generate_stream(_input_full()):
+            pass
+
+        assert rag.search_doj.await_args.kwargs.get("num_results") == 3
+        assert rag.search_custom.await_args.kwargs.get("num_results") == 2
+
+    @pytest.mark.asyncio
+    async def test_calls_invoke_stream_with_max_tokens_2048(self) -> None:
+        """invoke_stream 호출 시 max_tokens=2048이 전달되는지 검증."""
+        service, llm, _ = _make_stream_service(chunks=["x"])
+
+        async for _ in service.generate_stream(_input_full()):
+            pass
+
+        assert llm.invoke_stream.call_args.kwargs["max_tokens"] == 2048
+
+    @pytest.mark.asyncio
+    async def test_yields_chunks_unchanged(self) -> None:
+        """invoke_stream 청크가 변형 없이 그대로 yield되는지 검증."""
+        service, _, _ = _make_stream_service(chunks=["A", "B", "C"])
+
+        collected = []
+        async for chunk in service.generate_stream(_input_full()):
+            collected.append(chunk)
+
+        assert collected == ["A", "B", "C"]
+
+    @pytest.mark.asyncio
+    async def test_prompt_identical_to_non_stream(self) -> None:
+        """sync/stream 경로가 같은 입력·RAG 결과에 대해 byte-identical 프롬프트를 생성."""
+        doj = [RetrievedChunk(text="DOJ chunk", relevance_score=0.9)]
+        custom = [RetrievedChunk(text="Custom chunk", relevance_score=0.8)]
+        inp = _input_full()
+
+        # Sync path
+        sync_service, sync_llm, _ = _make_service(
+            llm_return=_valid_output(), doj_return=doj, custom_return=custom,
+        )
+        await sync_service.generate_side_panel(inp)
+        sync_prompt = sync_llm.invoke.await_args.args[0]
+
+        # Stream path — 같은 RAG 결과
+        stream_service, stream_llm, _ = _make_stream_service(
+            chunks=["x"], doj_return=doj, custom_return=custom,
+        )
+        async for _ in stream_service.generate_stream(inp):
+            pass
+        stream_prompt = stream_llm.invoke_stream.call_args.args[0]
+
+        assert sync_prompt == stream_prompt, "sync/stream 프롬프트가 불일치"


### PR DESCRIPTION
## 배경

PR #117 (`ai-latency-optimization`)은 Pipeline p50를 23.1s → 17.0s로 단축하며 AI 모듈 내부 수단의 한계에 도달. 추가 단축은 모델 교체 또는 콘텐츠 감량이라는 trade-off를 요구해 폐기.

본 PR은 **실제 시간**이 아닌 **사용자 체감 시간** 축에서 해결. Bedrock의 `invoke_model_with_response_stream` API로 side_panel을 토큰 단위 스트리밍하여, 백엔드가 SSE 엔드포인트로 프론트에 push할 수 있도록 AI 모듈을 확장.

**본 PR 범위:** AI 모듈만. 백엔드 SSE 엔드포인트와 프론트 EventSource 렌더링은 별도 PR.

## 변경 요약

| 파일 | 변경 |
|---|---|
| `ai/clients/llm.py` | `LLMClient.invoke_stream` 메서드 additive 추가 (기존 `invoke` 무변경) |
| `ai/services/side_panel_generator.py` | `_build_prompt` private 헬퍼 추출 + `generate_stream` 메서드 추가 (기존 `generate_side_panel` 무변경) |
| `ai/services/__init__.py` | `generate_side_panel_stream` 모듈 레벨 함수 추가 + `__all__` 확장 |
| `ai/latency_simulator.py` | `--streaming` CLI 플래그 + TTFT/TTLT 측정 경로 추가. 기존 non-stream 경로 (schema v1.0) byte-level 보존 |
| 신규 테스트 3파일 | `test_llm_client_stream.py`, `test_side_panel_generator_stream.py`, `test_latency_simulator_streaming.py` |

- 기존 퍼블릭 인터페이스 byte-level 보존
- 테스트: 271 passed (기존 258 + #117의 8 + 본 PR 13). 기존 테스트는 한 줄도 수정되지 않음
- LOC: +906 / -26 (대부분 신규 테스트)

## 실측 결과 (CloudShell, N=5, us-east-1, Haiku 4.5)

| 지표 | p50 | p100 |
|---|---|---|
| judge | 0.753s | 0.811s |
| generate | 2.900s | 2.922s |
| stage_a | 2.903s | 2.923s |
| **single-stream TTFT** | **2.624s** | **2.794s** |
| ttlt | 12.494s | 13.890s |
| pipeline_ttft | 5.525s | 5.710s |
| pipeline_ttlt | 15.409s | 16.776s |

5 run 실패/예외 0회.

### Single-stream TTFT 2.6s의 분해

`generate_side_panel_stream` 호출 → 첫 yield까지의 시간 분해:

| 구간 | 시간 |
|---|---|
| RAG 검색 (doj+custom 병렬) | ~1.5s |
| 프롬프트 조립 | <0.01s |
| Bedrock 스트림 시작 지연 | ~1.1s |
| **합계 (single-stream TTFT)** | **~2.6s** |

design.md에서 "TTFT ≤ 1.5s"로 설정한 목표는 **Bedrock 스트림 시작 지연만**을 의미했고, 그 구간은 ~1.1s로 달성. 다만 사용자 체감 상의 "첫 토큰 도착"은 RAG 검색까지 포함하므로 2.6s가 된다. 추가 단축은 RAG 결과 캐싱, Stage A의 RAG 결과 재사용 등으로 가능하나 별도 Spec으로 분리.

### Pipeline 체감 개선

| | Non-stream (PR #117) | Streaming (본 PR) | Δ |
|---|---|---|---|
| "AI가 일 시작" 체감 시점 (Accept → 첫 토큰) | ~17.0s | **~5.5s** | **-67%** |
| 전체 완료 (Accept → 마지막 토큰) | 17.0s | 15.4s | -9% |

### Simulator artifact 주의

`per_run[i].side_panel_streams`를 보면 3 stream 중 1개만 ~2.6s, 나머지 2개는 ~11s TTFT로 기록된다. **프로덕션이 아니라 simulator 전용 artifact**이다:

- simulator는 1개 프로세스 + 1개 asyncio 이벤트 루프에서 `asyncio.gather`로 3 stream을 올림
- `invoke_stream` 내부의 동기 iteration이 이벤트 루프를 블로킹하므로 사실상 직렬화됨
- 프로덕션에서는 각 SSE 엔드포인트가 **독립 Lambda invocation**에서 실행되므로 이벤트 루프가 분리됨. 3개 엔드포인트 각각의 TTFT는 single-stream 측정값인 ~2.6s

simulator 아티팩트이므로 프로덕션 wiring에는 영향 없음. 의미 있는 지표는 `stage_b_ttft_s` (3 stream 중 min, 즉 single-stream 성능) = **p50 2.624s**.

## 백엔드 인터페이스 계약

```python
from ai.services import generate_side_panel_stream

async def event_generator():
    try:
        async for chunk in generate_side_panel_stream(
            input_data, llm_client, rag_client
        ):
            yield f"data: {json.dumps({'delta': chunk})}\n\n"
        yield "event: done\ndata: {}\n\n"
    except Exception as e:
        yield f"event: error\ndata: {json.dumps({'error': str(e)})}\n\n"

return StreamingResponse(event_generator(), media_type="text/event-stream")
```

AI 모듈 보장:
- 호출 즉시 (RAG + 프롬프트 조립 완료 후) 첫 토큰 yield 시작
- yield 청크는 한국어 텍스트의 일부 (개별 청크가 유효한 JSON이 아닐 수 있음 — 누적 후 파싱은 프론트 책임)
- 순서는 Bedrock 스트림 순서 그대로, 변형·버퍼링·재인코딩 없음
- 예외는 그대로 propagate

백엔드 책임 (본 PR 범위 밖):
- SSE 이벤트 포맷 변환
- 노드별 엔드포인트 라우팅 (3개 독립 스트림)
- 사용자 Accept 시 미완료 stream close
- 에러 복구

## 영향 범위

- ✅ AI 모듈: additive, 기존 퍼블릭 계약·테스트 byte-level 보존
- ⬜ 백엔드: `ai.services.generate_side_panel_stream`을 사용하는 SSE 엔드포인트 구현 (별도 PR)
- ⬜ 프론트: EventSource 수신, 노드별 버퍼 누적, 점진 JSON 파싱, 타이핑 애니메이션 (별도 PR)