### PR TITLE
[#120][AI] invoke_stream 이벤트 루프 블로킹 수정 — 단일 프로세스에서 3 스트림 동시 실행 안정화

### DIFF
--- a/ai/clients/llm.py
+++ b/ai/clients/llm.py
@@ -252,8 +252,13 @@ class LLMClient:
                 details=error_details,
             ) from exc
 
+        _SENTINEL = object()
         try:
-            for event in response["body"]:
+            event_iter = iter(response["body"])
+            while True:
+                event = await asyncio.to_thread(next, event_iter, _SENTINEL)
+                if event is _SENTINEL:
+                    break
                 chunk_bytes = event.get("chunk", {}).get("bytes") if isinstance(event, dict) else None
                 if not chunk_bytes:
                     # MagicMock 기반 이벤트는 dict가 아닐 수 있어 getattr fallback.

--- a/ai/tests/test_llm_client_stream.py
+++ b/ai/tests/test_llm_client_stream.py
@@ -129,3 +129,48 @@ class TestInvokeStream:
         chunks = await _collect(client.invoke_stream("prompt"))
 
         assert chunks == ["A", "B"]
+
+    @pytest.mark.asyncio
+    async def test_invoke_stream_does_not_block_event_loop(self) -> None:
+        """두 stream을 gather로 돌렸을 때 직렬화되지 않는다."""
+        import asyncio
+        import time as _time
+
+        class _SlowIterable:
+            def __init__(self, events, delay=0.05):
+                self._events = events
+                self._delay = delay
+                self._i = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self._i >= len(self._events):
+                    raise StopIteration
+                _time.sleep(self._delay)
+                e = self._events[self._i]
+                self._i += 1
+                return e
+
+        events = [_delta_event(f"c{i}") for i in range(5)]
+
+        bedrock = MagicMock()
+        bedrock.invoke_model_with_response_stream.side_effect = [
+            {"body": _SlowIterable(events)},
+            {"body": _SlowIterable(events)},
+        ]
+        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID, max_tokens=256)
+
+        async def _first_chunk_time(agen):
+            start = asyncio.get_event_loop().time()
+            async for _ in agen:
+                return asyncio.get_event_loop().time() - start
+            return float("inf")
+
+        gen1 = client.invoke_stream("p1")
+        gen2 = client.invoke_stream("p2")
+        t1, t2 = await asyncio.gather(_first_chunk_time(gen1), _first_chunk_time(gen2))
+
+        # 직렬화되면 t2 >= 5 * 0.05 = 0.25s. async면 t2 < 0.2s.
+        assert t2 < 0.2, f"두 번째 stream이 직렬화됨: t1={t1:.3f}s, t2={t2:.3f}s"


### PR DESCRIPTION
## 배경

PR #118(`feature/#118-ai-streaming-sidepanel`, 머지됨)에서 도입한 `LLMClient.invoke_stream`은 Bedrock EventStream을 동기 for-loop로 순회한다:

```python
for event in response["body"]:
    ...
    yield text
```

이 패턴은 단일 이벤트 루프에서 여러 stream을 `asyncio.gather`로 올렸을 때 iteration이 이벤트 루프를 블로킹하여, **3 stream이 사실상 직렬화되는 현상**을 유발. PR #118 CloudShell 실측에서 stream별 TTFT가 2.6s / 11.5s / 12s로 튄 것이 이 현상의 증거.

**영향 범위:** 백엔드가 uvicorn 단일 프로세스(개발용 EC2)에서 여러 SSE 연결을 한 이벤트 루프 위에 올릴 때 동일 증상 발생. 프로덕션 Lambda에서는 각 invocation이 독립이라 영향 없으나, 개발 환경 테스트가 임박하여 선제 수정 필요.

## 변경 요약

| 파일 | 변경 |
|---|---|
| `ai/clients/llm.py` | `invoke_stream`의 동기 for-loop를 `next()` + `asyncio.to_thread` 루프로 교체. 각 청크 대기 시간을 이벤트 루프가 아닌 스레드에서 소비 |
| `ai/tests/test_llm_client_stream.py` | 두 stream을 `gather`로 실행하여 직렬화되지 않는지 검증하는 테스트 1개 추가 |

- 시그니처/yield 값/예외 타입/로그 이벤트 이름 모두 byte-level 보존.
- 기존 4개 stream 테스트 무변경 통과.
- 테스트: 271 → **272 passed**.

## 실측 결과 비교 (CloudShell, N=5, Haiku 4.5)

### Per-run TTFT (각 run의 3 stream)

**Before (PR #118, 블로킹 있음):**
| Run | stream 0 | stream 1 | stream 2 |
|---|---|---|---|
| 0 | 12.9s | 12.0s | **2.7s** |
| 1 | 11.5s | 12.4s | **2.6s** |
| 2 | 12.2s | 11.5s | **2.6s** |
| 3 | 11.2s | **2.8s** | 12.0s |
| 4 | 11.2s | 11.4s | **2.6s** |

매 run마다 1개만 빠르고 나머지 2개는 ~11s — 직렬화 증상.

**After (본 PR, 블로킹 해소):**
| Run | stream 0 | stream 1 | stream 2 | spread |
|---|---|---|---|---|
| 0 | 2.74s | 2.69s | 2.86s | 0.17s |
| 1 | 3.24s | 2.71s | 2.67s | 0.58s |
| 2 | 2.83s | 3.07s | 2.81s | 0.26s |
| 3 | 2.82s | 2.77s | 2.83s | 0.06s |
| 4 | 2.76s | 2.78s | 2.85s | 0.09s |

3 stream 모두 2.6~3.2s 범위로 수렴. 진짜 병렬 실행 확인.

### Summary 비교

| 지표 | PR #118 (v1) | 본 PR (v2) |
|---|---|---|
| ttft p50 | 2.624s | 2.757s |
| ttft p100 | 2.794s | 2.810s |
| ttlt p50 | 12.494s | 12.788s |
| ttlt p100 | 13.890s | 14.347s |
| pipeline_ttft p50 | 5.525s | 5.798s |
| pipeline_ttft p100 | 5.710s | 6.889s |

**summary.ttft 값 자체는 거의 동일** — min 기준이라 PR #118에서도 가장 빠른 stream은 이미 ~2.6s였기 때문. 본 PR의 가치는 **나머지 2 stream도 동일하게 ~2.6s**라는 것.

## 구현 디테일

`asyncio.to_thread(next, iterator, sentinel)` 패턴 사용:

```python
event_iter = iter(response["body"])
while True:
    event = await asyncio.to_thread(next, event_iter, _SENTINEL)
    if event is _SENTINEL:
        break
    # 기존 처리 로직 동일
    ...
```

- `iter()` 호출은 CPU 가벼우므로 스레드 불필요
- 각 `next()` 호출이 HTTP 네트워크 대기를 포함하므로 `to_thread`로 스레드 offload
- sentinel로 `StopIteration`을 안전하게 처리 (PEP 479 회피)

## 영향 범위

- ✅ AI 모듈 내부 구현 변경. 공개 인터페이스·테스트 byte-level 보존.
- ✅ 백엔드가 단일 프로세스(uvicorn) 또는 다중 프로세스(Lambda) 어디서 호출해도 안전.
- ⬜ 백엔드 SSE 엔드포인트 구현은 별도 PR.