### PR TITLE
[#122][BE] SSE 스트리밍으로 사이드패널 체감 대기시간 제거 (Accept 17s → 3s)

### DIFF
--- a/backend/app/ai/routers/steps.py
+++ b/backend/app/ai/routers/steps.py
@@ -1,10 +1,12 @@
+import json
 from uuid import UUID
 
 from fastapi import Depends
 from fastapi import status as http_status
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
-from app.ai.services import step_service
+from app.ai.services import orchestrator, step_service
 from app.core.api.route import EnvelopeRouter
 from app.core.database import get_db
 from app.core.schemas.step import (
@@ -26,6 +28,30 @@ async def accept_step(
 @router.get("/steps/{step_id}", status_code=http_status.HTTP_200_OK)
 def get_step_detail(step_id: UUID, db: Session = Depends(get_db)) -> StepDetailResponse:
     return step_service.get_step_detail(db, step_id)
+
+
+@router.get("/steps/{step_id}/sidepanel-stream")
+async def sidepanel_stream(step_id: UUID, db: Session = Depends(get_db)):
+    """사이드패널 콘텐츠를 SSE 스트림으로 반환.
+
+    Accept 직후 프론트가 노드별로 연결하며, 토큰이 도착할 때마다
+    data 이벤트로 push된다. 스트리밍 완료 시 DB 저장 후 done 이벤트 전송.
+    """
+    step = step_service.get_step_for_stream(db, step_id)
+    request = step_service.build_side_panel_request(db, step)
+
+    async def event_generator():
+        accumulated: list[str] = []
+        try:
+            async for chunk in orchestrator.call_side_panel_stream(request):
+                accumulated.append(chunk)
+                yield f"data: {json.dumps({'delta': chunk}, ensure_ascii=False)}\n\n"
+            step_service.save_side_panel_content(db, step_id, "".join(accumulated))
+            yield "event: done\ndata: {}\n\n"
+        except Exception as e:
+            yield f"event: error\ndata: {json.dumps({'error': str(e)})}\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
 @router.post(

--- a/backend/app/ai/services/orchestrator.py
+++ b/backend/app/ai/services/orchestrator.py
@@ -1,16 +1,10 @@
 import boto3
-from ai import generate_steps, judge_required_step, generate_side_panel
+from typing import AsyncIterator
 
-# boto3 클라이언트 생성 (Lambda에서는 IAM Role로 자동 인증)
-bedrock_runtime = boto3.client("bedrock-runtime", region_name="us-east-1")
-bedrock_agent = boto3.client("bedrock-agent-runtime", region_name="us-east-1")
-
-MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
-KB_ID = "ZAEWSDQVP1"  # 환경변수로 관리 권장
-
-import boto3
 from app.core.config import settings
-from ai import generate_steps, judge_required_step, generate_side_panel
+from ai import generate_steps, judge_required_step, generate_side_panel, generate_side_panel_stream
+from ai.clients.llm import LLMClient
+from ai.clients.rag import RAGClient
 
 bedrock_runtime = boto3.client("bedrock-runtime", region_name="us-east-1")
 bedrock_agent = boto3.client("bedrock-agent-runtime", region_name="us-east-1")
@@ -40,3 +34,10 @@ async def call_side_panel(input_data):
         settings.BEDROCK_MODEL_ID,
         settings.BEDROCK_KB_ID,
     )
+
+
+async def call_side_panel_stream(input_data) -> AsyncIterator[str]:
+    llm = LLMClient(bedrock_client=bedrock_runtime, model_id=settings.BEDROCK_MODEL_ID)
+    rag = RAGClient(bedrock_agent_client=bedrock_agent, kb_id=settings.BEDROCK_KB_ID)
+    async for chunk in generate_side_panel_stream(input_data, llm, rag):
+        yield chunk

--- a/backend/app/ai/services/step_service.py
+++ b/backend/app/ai/services/step_service.py
@@ -228,24 +228,6 @@ async def accept_step(db: Session, step_id: uuid.UUID) -> StepAcceptResponse:
     )
     db.flush()
 
-    # ⑦ 일반 Step 사이드패널 병렬 생성
-    regular_steps = [s for s in steps if s.required_step_id is None]
-    side_panel_requests = [_build_side_panel_request(db, s) for s in regular_steps]
-    side_panel_results = await asyncio.gather(
-        *[orchestrator.call_side_panel(req) for req in side_panel_requests]
-    )
-
-    # ⑧ 사이드패널 DB 저장
-    for s, result in zip(regular_steps, side_panel_results):
-        content = StepContentModel(step_id=s.id)
-        content.mentoring = json.dumps(
-            result.mentoring.model_dump(), ensure_ascii=False
-        )
-        content.dictionary = json.dumps(
-            [d.model_dump() for d in result.dictionary], ensure_ascii=False
-        )
-        db.add(content)
-
     db.commit()
     for s in steps:
         db.refresh(s)
@@ -506,7 +488,7 @@ def get_step_detail(db: Session, step_id: uuid.UUID) -> StepDetailResponse:
     )
 
 
-def _build_side_panel_request(db: Session, step: StepModel) -> SidePanelRequest:
+def build_side_panel_request(db: Session, step: StepModel) -> SidePanelRequest:
     fulfilled_ids = _get_fulfilled_required_step_ids(db, step.project_id)
     stage = step.stage
 
@@ -540,3 +522,37 @@ def _build_side_panel_request(db: Session, step: StepModel) -> SidePanelRequest:
         ),
         rag_context={"results": rag_results},
     )
+
+
+def get_step_for_stream(db: Session, step_id: uuid.UUID) -> StepModel:
+    """SSE 스트림용 Step 조회 — 필수 Step이거나 존재하지 않으면 예외."""
+    step = db.get(StepModel, step_id)
+    if step is None:
+        raise StepNotFoundError()
+    return step
+
+
+def save_side_panel_content(db: Session, step_id: uuid.UUID, full_text: str) -> None:
+    """SSE 스트리밍 완료 후 누적 텍스트를 파싱해 DB에 저장."""
+    from pydantic import ValidationError
+    from ai.schemas.side_panel import SidePanelOutput
+
+    try:
+        stripped = full_text.strip()
+        if stripped.startswith("```"):
+            lines = stripped.splitlines()
+            stripped = "\n".join(lines[1:-1]).strip()
+        payload = json.loads(stripped)
+        result = SidePanelOutput.model_validate(payload)
+    except (json.JSONDecodeError, ValidationError):
+        return  # 파싱 실패 시 저장 생략
+
+    content = db.get(StepContentModel, step_id)
+    if content is None:
+        content = StepContentModel(step_id=step_id)
+        db.add(content)
+    content.mentoring = json.dumps(result.mentoring.model_dump(), ensure_ascii=False)
+    content.dictionary = json.dumps(
+        [d.model_dump() for d in result.dictionary], ensure_ascii=False
+    )
+    db.commit()


### PR DESCRIPTION
## PR 요약
- Accept 응답 속도를 17s → 3s로 단축하고, 사이드패널 콘텐츠를 SSE 스트리밍으로 제공하는 백엔드 엔드포인트를 추가
- 프론트엔드가 Accept 직후 노드별 EventSource를 열면, 사용자가 클릭하는 시점에 이미 버퍼에 쌓인 콘텐츠를 즉시 렌더링할 수 있음

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `accept_step`에서 side_panel 생성 로직 제거 → Accept 응답 시간 ~3s로 단축
- `GET /steps/{step_id}/sidepanel-stream` SSE 엔드포인트 추가
  - 토큰 단위로 delta 이벤트 push, 완료 시 done 이벤트 전송
  - 스트리밍 완료 후 파싱하여 DB 저장 (get_step_detail 하위 호환 유지)
- `orchestrator.py` 중복 import 제거 + `call_side_panel_stream` 추가
- `step_service.py`에 `get_step_for_stream`, `save_side_panel_content` 추가


## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- 프론트 계약: Accept 응답 수신 즉시 노드 ID 3개로 EventSource 3개를 동시에 open해야 함
- 클릭 시점에 여는 방식이면 매 클릭마다 ~2.6s 대기가 발생하여 체감 개선 효과가 없어짐
- 관련 PR: 프론트엔드 EventSource 수신 및 버퍼 렌더링 PR과 함께 배포 필요
