### PR TITLE
[#106][FE] rollback 로직 및 사이드 패널 로직 수정

### DIFF
--- a/frontend/src/components/canvas/SidePanel.jsx
+++ b/frontend/src/components/canvas/SidePanel.jsx
@@ -327,7 +327,7 @@ function MentoringContent({ raw, isLoading }) {
   )
 }
 
-export default function SidePanel({ step, detail, isOpen, onClose, onAccept, hasChildren }) {
+export default function SidePanel({ step, detail, isOpen, onClose, onAccept, hasChildren, isAccepting }) {
   const [activeTab, setActiveTab] = useState('mentoring')
   const [lastStep, setLastStep] = useState(step)
 
@@ -434,7 +434,7 @@ export default function SidePanel({ step, detail, isOpen, onClose, onAccept, has
 
       <div className={styles.footer}>
         {(status !== 'ACCEPTED' || !hasChildren) && (
-          <button className={styles.acceptBtn} onClick={onAccept}>
+          <button className={styles.acceptBtn} onClick={onAccept} disabled={isAccepting}>
             <HiCheck size={15} />
             accept
           </button>

--- a/frontend/src/components/canvas/SidePanel.module.css
+++ b/frontend/src/components/canvas/SidePanel.module.css
@@ -424,6 +424,11 @@
   opacity: 0.85;
 }
 
+.acceptBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .skeleton {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -45,6 +45,7 @@ export default function CanvasPage() {
   const [toastVisible, setToastVisible] = useState(false)
   const [rfInstance, setRfInstance] = useState(null)
   const [rollbackModal, setRollbackModal] = useState(false)
+  const [isAccepting, setIsAccepting] = useState(false)
 
   const timerRef = useRef(null)
   const currentRequiredStepName = useRef(null)
@@ -162,6 +163,7 @@ export default function CanvasPage() {
 
   async function handleAccept() {
     if (!selectedStep) return
+    if (isAccepting) return
 
     const selectedStage = stages.find((s) => s.stage_id === selectedStageId)
     const nextStage = stages.find(
@@ -220,6 +222,7 @@ export default function CanvasPage() {
   }
 
  async function executeAccept({ skipRollback = false } = {}) {
+  setIsAccepting(true)
   const status = selectedStep.data?.status
 
   const needsRollback =
@@ -299,6 +302,7 @@ export default function CanvasPage() {
   }
 
   await fetchAndRenderTree(selectedStageId)
+  setIsAccepting(false)
   setSelectedStep(null)
   setStepDetail(null)
 }
@@ -399,6 +403,7 @@ export default function CanvasPage() {
           step={selectedStep}
           detail={stepDetail}
           isOpen={!!selectedStep}
+          isAccepting={isAccepting}
           hasChildren={selectedHasChildren}
           onClose={() => { setSelectedStep(null); setStepDetail(null) }}
           onAccept={handleAccept}

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -16,7 +16,7 @@ import RequiredStepNode from '../components/canvas/RequiredStepNode'
 import { getStages } from '../api/stage'
 import { getStepTree, getStepDetail, acceptStep, rollbackStep } from '../api/step'
 
-import { STAGE_ENGLISH, flattenTree } from '../utils/canvasUtils'
+import { STAGE_ENGLISH, flattenTree, getStageProgressFromTree, findRequiredStep } from '../utils/canvasUtils'
 
 import styles from './CanvasPage.module.css'
 import { HiOutlineUser } from 'react-icons/hi'
@@ -56,17 +56,6 @@ export default function CanvasPage() {
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
 
   const onConnect = (params) => setEdges((eds) => addEdge(params, eds))
-
-  function getStageProgressFromTree(nodes, edges) {
-    const firstRequired = nodes.find(
-      (node) =>
-        node.type === 'requiredStepNode' &&
-        !edges.some((edge) => edge.target === node.id)
-    )
-    return firstRequired
-      ? edges.some((edge) => edge.source === firstRequired.id)
-      : false
-  }
 
   useEffect(() => {
     if (!projectId) return
@@ -221,15 +210,6 @@ export default function CanvasPage() {
     await executeAccept({ skipRollback: true })
   }
 
-  function findRequiredStep(nodeId) {
-    const parentEdge = edges.find((e) => e.target === nodeId)
-    if (!parentEdge) return null
-    const parentNode = nodes.find((n) => n.id === parentEdge.source)
-    if (!parentNode) return null
-    if (parentNode.type === 'requiredStepNode') return parentNode
-    return findRequiredStep(parentNode.id)
-  }
-
  async function executeAccept({ skipRollback = false } = {}) {
   const status = selectedStep.data?.status
 
@@ -276,7 +256,7 @@ export default function CanvasPage() {
     const requiredNode =
       selectedStep.type === 'requiredStepNode'
         ? selectedStep
-        : findRequiredStep(selectedStep.id)
+        : findRequiredStep(selectedStep.id, nodes, edges)
 
     const name = requiredNode?.data?.label
     if (name) {
@@ -313,7 +293,6 @@ export default function CanvasPage() {
   setSelectedStep(null)
   setStepDetail(null)
 }
-
 
   function handleNodeContextMenu(event, node) {
     event.preventDefault()

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -166,27 +166,37 @@ export default function CanvasPage() {
     if (isAccepting) return
 
     const selectedStage = stages.find((s) => s.stage_id === selectedStageId)
-    const nextStage = stages.find(
-      (s) => s.stage_sequence === (selectedStage?.stage_sequence ?? 0) + 1
+    if (!selectedStage) return
+
+    const hasLaterCompletedStage = stages.some(
+      (s) =>
+        s.stage_sequence > selectedStage.stage_sequence &&
+        s.stage_sequence < currentStageSequence
     )
 
-    if (nextStage?.is_active) {
-      if (stageHasProgressRef.current[nextStage.stage_id] === undefined) {
+    if (hasLaterCompletedStage) {
+      setRollbackModal(true)
+      return
+    }
+
+    const activeStage = stages.find((s) => s.is_active)
+
+    if (activeStage && activeStage.stage_sequence > selectedStage.stage_sequence) {
+      if (stageHasProgressRef.current[activeStage.stage_id] === undefined) {
         try {
-          const treeData = await getStepTree(projectId, nextStage.stage_id)
+          const treeData = await getStepTree(projectId, activeStage.stage_id)
           const { nodes: n, edges: e } = flattenTree(
             treeData.steps ?? [],
-            nextStage.stage_sequence
+            activeStage.stage_sequence
           )
-          stageHasProgressRef.current[nextStage.stage_id] =
-            getStageProgressFromTree(n, e)
+          stageHasProgressRef.current[activeStage.stage_id] = getStageProgressFromTree(n, e)
         } catch {
-          alert('다음 스테이지 진행 여부를 확인하지 못했어요. 다시 시도해주세요.')
+          alert('잠시후 다시 시도해주세요.')
           return
         }
       }
 
-      if (stageHasProgressRef.current[nextStage.stage_id] === true) {
+      if (stageHasProgressRef.current[activeStage.stage_id] === true) {
         setRollbackModal(true)
         return
       }

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -56,6 +56,17 @@ export default function CanvasPage() {
 
   const onConnect = (params) => setEdges((eds) => addEdge(params, eds))
 
+  function getStageProgressFromTree(nodes, edges) {
+    const firstRequired = nodes.find(
+      (node) =>
+        node.type === 'requiredStepNode' &&
+        !edges.some((edge) => edge.target === node.id)
+    )
+    return firstRequired
+      ? edges.some((edge) => edge.source === firstRequired.id)
+      : false
+  }
+
   useEffect(() => {
     if (!projectId) return
     getStages(projectId).then((data) => {

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -51,6 +51,7 @@ export default function CanvasPage() {
   const autoOpenedStageRef = useRef(null)
   const shouldFitViewRef = useRef(false)
   const stageHasProgressRef = useRef({})
+  const detailRequestRef = useRef(0)
 
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
@@ -93,11 +94,15 @@ export default function CanvasPage() {
         autoOpenedStageRef.current = stageId
         setSelectedStep(firstRequired)
         setStepDetail(null)
+
+        const requestId = ++detailRequestRef.current
+
         try {
           const detail = await getStepDetail(firstRequired.id)
+          if (requestId !== detailRequestRef.current) return
           setStepDetail(detail)
         } catch {
-          // 상세 정보 로드 실패해도 노드 선택은 유지
+          //
         }
       }
     }
@@ -143,11 +148,15 @@ export default function CanvasPage() {
   async function handleNodeClick(event, node) {
     setSelectedStep(node)
     setStepDetail(null)
+
+    const requestId = ++detailRequestRef.current
+
     try {
       const detail = await getStepDetail(node.id)
+      if (requestId !== detailRequestRef.current) return
       setStepDetail(detail)
     } catch {
-      // 상세 정보 로드 실패해도 노드 선택은 유지
+      //
     }
   }
 

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -50,6 +50,7 @@ export default function CanvasPage() {
   const currentRequiredStepName = useRef(null)
   const autoOpenedStageRef = useRef(null)
   const shouldFitViewRef = useRef(false)
+  const stageHasProgressRef = useRef({})
 
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
@@ -72,16 +73,13 @@ export default function CanvasPage() {
     getStages(projectId).then((data) => {
       const list = data.stages ?? []
       setStages(list)
-      const active = list.find(s => s.is_active)
+      const active = list.find((s) => s.is_active)
       if (active) setCurrentStageSequence(active.stage_sequence)
 
       const saved = sessionStorage.getItem(`selectedStage_${projectId}`)
-      const savedStage = list.find(s => s.stage_id === saved)
-      if (savedStage) {
-        setSelectedStageId(savedStage.stage_id)
-      } else if (active) {
-        setSelectedStageId(active.stage_id)
-      }
+      const savedStage = list.find((s) => s.stage_id === saved)
+      if (savedStage) setSelectedStageId(savedStage.stage_id)
+      else if (active) setSelectedStageId(active.stage_id)
     })
   }, [projectId])
 
@@ -89,11 +87,19 @@ export default function CanvasPage() {
     const treeData = await getStepTree(projectId, stageId)
     const stage = stages.find((s) => s.stage_id === stageId)
     const { nodes: n, edges: e } = flattenTree(treeData.steps ?? [], stage?.stage_sequence)
+
+    const hasProgress = getStageProgressFromTree(n, e)
+    stageHasProgressRef.current[stageId] = hasProgress
+
     setNodes(n)
     setEdges(e)
 
-    if (autoOpenedStageRef.current !== stageId) {
-      const firstRequired = n.find((node) => node.type === 'requiredStepNode')
+    if (!hasProgress && autoOpenedStageRef.current !== stageId) {
+      const firstRequired = n.find(
+        (node) =>
+          node.type === 'requiredStepNode' &&
+          !e.some((edge) => edge.target === node.id)
+      )
       if (firstRequired) {
         autoOpenedStageRef.current = stageId
         setSelectedStep(firstRequired)
@@ -122,7 +128,7 @@ export default function CanvasPage() {
 
   useEffect(() => {
     if (!selectedStageId || !projectId) return
-    shouldFitViewRef.current = true 
+    shouldFitViewRef.current = true
     fetchAndRenderTree(selectedStageId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedStageId, projectId])
@@ -133,7 +139,7 @@ export default function CanvasPage() {
     autoOpenedStageRef.current = null
   }, [selectedStageId])
 
-  const uiStages = stages.map(s => ({
+  const uiStages = stages.map((s) => ({
     id: s.stage_id,
     sequence: s.stage_sequence,
     name: s.stage_name,
@@ -143,13 +149,7 @@ export default function CanvasPage() {
       : 'locked',
   }))
 
-  const currentStageId = stages.find(s => s.is_active)?.stage_id ?? null
-  const targetSeq = stages.find(s => s.stage_id === selectedStageId)?.stage_sequence ?? 0
-  const currentSeq = stages.find(s => s.stage_id === currentStageId)?.stage_sequence ?? 0
-  const stagesToClear = uiStages
-    .filter(s => s.sequence > targetSeq && s.sequence <= currentSeq)
-    .map(s => s.sequence)
-    .join(', ')
+  const currentStageId = stages.find((s) => s.is_active)?.stage_id ?? null
 
   async function handleNodeClick(event, node) {
     setSelectedStep(node)
@@ -165,112 +165,155 @@ export default function CanvasPage() {
   async function handleAccept() {
     if (!selectedStep) return
 
-    if (selectedStageId !== currentStageId) {
-      setRollbackModal(selectedStageId)
-      return
+    const selectedStage = stages.find((s) => s.stage_id === selectedStageId)
+    const nextStage = stages.find(
+      (s) => s.stage_sequence === (selectedStage?.stage_sequence ?? 0) + 1
+    )
+
+    if (nextStage?.is_active) {
+      if (stageHasProgressRef.current[nextStage.stage_id] === undefined) {
+        try {
+          const treeData = await getStepTree(projectId, nextStage.stage_id)
+          const { nodes: n, edges: e } = flattenTree(
+            treeData.steps ?? [],
+            nextStage.stage_sequence
+          )
+          stageHasProgressRef.current[nextStage.stage_id] =
+            getStageProgressFromTree(n, e)
+        } catch {
+          alert('다음 스테이지 진행 여부를 확인하지 못했어요. 다시 시도해주세요.')
+          return
+        }
+      }
+
+      if (stageHasProgressRef.current[nextStage.stage_id] === true) {
+        setRollbackModal(true)
+        return
+      }
     }
 
     await executeAccept()
   }
 
   async function handleRollbackConfirm() {
-    setRollbackModal(null)
-    currentRequiredStepName.current = null
+    setRollbackModal(false)
 
-    await executeAccept()
-
-    const data = await getStages(projectId)
-    const list = data.stages ?? []
-    setStages(list)
-    const active = list.find(s => s.is_active)
-    if (active) {
-      setCurrentStageSequence(active.stage_sequence)
-      setSelectedStageId(active.stage_id)
+    try {
+      await rollbackStep(selectedStep.id)
+    } catch (err) {
+      const msg =
+        err?.code === 'INVALID_ROLLBACK_TARGET'
+          ? '자식 Step이 있는 노드는 롤백할 수 없어요.\n마지막 Step을 선택해주세요.'
+          : '롤백에 실패했어요. 다시 시도해주세요.'
+      alert(msg)
+      return
     }
+
+    const selectedStage = stages.find((s) => s.stage_id === selectedStageId)
+    const nextStage = stages.find(
+      (s) => s.stage_sequence === (selectedStage?.stage_sequence ?? 0) + 1
+    )
+
+    if (nextStage) {
+      stageHasProgressRef.current[nextStage.stage_id] = false
+    }
+
+    await executeAccept({ skipRollback: true })
   }
 
   function findRequiredStep(nodeId) {
-    const parentEdge = edges.find(e => e.target === nodeId)
+    const parentEdge = edges.find((e) => e.target === nodeId)
     if (!parentEdge) return null
-    const parentNode = nodes.find(n => n.id === parentEdge.source)
+    const parentNode = nodes.find((n) => n.id === parentEdge.source)
     if (!parentNode) return null
     if (parentNode.type === 'requiredStepNode') return parentNode
     return findRequiredStep(parentNode.id)
   }
 
-  async function executeAccept() {
-    const status = selectedStep.data?.status
+ async function executeAccept({ skipRollback = false } = {}) {
+  const status = selectedStep.data?.status
 
-    const needsRollback = status === 'CANCELED' || (status === 'READY' && (() => {
-      const parentEdge = edges.find(e => e.target === selectedStep.id)
-      if (!parentEdge) return false
-      const siblings = nodes.filter(n =>
-        n.id !== selectedStep.id &&
-        edges.some(e => e.source === parentEdge.source && e.target === n.id)
-      )
-      return siblings.some(n => n.data?.status === 'ACCEPTED')
-    })())
+  const needsRollback =
+    status === 'CANCELED' ||
+    (status === 'READY' &&
+      (() => {
+        const parentEdge = edges.find((e) => e.target === selectedStep.id)
+        if (!parentEdge) return false
 
-    if (needsRollback) {
-      try {
-        await rollbackStep(selectedStep.id)
-      } catch (err) {
-        const msg =
-          err?.code === 'INVALID_ROLLBACK_TARGET'
-            ? '자식 Step이 있는 노드는 롤백할 수 없어요.\n마지막 Step을 선택해주세요.'
-            : '롤백에 실패했어요. 다시 시도해주세요.'
-        alert(msg)
-        return
-      }
-    }
+        const siblings = nodes.filter(
+          (n) =>
+            n.id !== selectedStep.id &&
+            edges.some((e) => e.source === parentEdge.source && e.target === n.id)
+        )
 
-    let acceptResult
+        return siblings.some((n) => n.data?.status === 'ACCEPTED')
+      })())
+
+  if (!skipRollback && needsRollback) {
     try {
-      acceptResult = await acceptStep(selectedStep.id)
+      await rollbackStep(selectedStep.id)
     } catch (err) {
-      if (err?.code !== 'STEP_ALREADY_ACCEPTED') {
-        alert('Step 생성에 실패했어요. 다시 시도해주세요.')
-        return
-      }
+      const msg =
+        err?.code === 'INVALID_ROLLBACK_TARGET'
+          ? '자식 Step이 있는 노드는 롤백할 수 없어요.\n마지막 Step을 선택해주세요.'
+          : '롤백에 실패했어요. 다시 시도해주세요.'
+      alert(msg)
+      return
     }
+  }
 
-    if (acceptResult?.is_current_required_step_completed) {
-      const requiredNode = selectedStep.type === 'requiredStepNode'
+  let acceptResult
+  try {
+    acceptResult = await acceptStep(selectedStep.id)
+  } catch (err) {
+    if (err?.code !== 'STEP_ALREADY_ACCEPTED') {
+      alert('Step 생성에 실패했어요. 다시 시도해주세요.')
+      return
+    }
+  }
+
+  if (acceptResult?.is_current_required_step_completed) {
+    const requiredNode =
+      selectedStep.type === 'requiredStepNode'
         ? selectedStep
         : findRequiredStep(selectedStep.id)
-      const name = requiredNode?.data?.label
-      if (name) {
-        const isStageComplete = acceptResult?.is_current_stage_completed
-        const message = isStageComplete
-          ? `✅ ${name}이(가) 종료됐어요. 이제 다음 스테이지로 이동할 수 있어요.`
-          : `✅ ${name}이(가) 종료됐어요!`
-        if (timerRef.current) clearTimeout(timerRef.current)
-        setToast(message)
-        setToastVisible(true)
-        timerRef.current = setTimeout(() => setToastVisible(false), 3000)
-        if (isStageComplete) {
-          getStages(projectId).then((data) => {
-            const list = data.stages ?? []
-            setStages(list)
-            const active = list.find(s => s.is_active)
-            if (active) setCurrentStageSequence(active.stage_sequence)
-          })
-        }
-      }
-    }
 
-    if (selectedStep.type === 'requiredStepNode') {
-      currentRequiredStepName.current = selectedStep.data.label
+    const name = requiredNode?.data?.label
+    if (name) {
+      const isStageComplete = acceptResult?.is_current_stage_completed
+      const message = isStageComplete
+        ? `✅ ${name}이(가) 종료됐어요. 이제 다음 스테이지로 이동할 수 있어요.`
+        : `✅ ${name}이(가) 종료됐어요!`
+
       if (timerRef.current) clearTimeout(timerRef.current)
-      setToast(`📌 ${selectedStep.data.label}이(가) 시작됐어요!`)
+      setToast(message)
       setToastVisible(true)
       timerRef.current = setTimeout(() => setToastVisible(false), 3000)
-    }
 
-    await fetchAndRenderTree(selectedStageId)
-    setSelectedStep(null)
-    setStepDetail(null)
+      if (isStageComplete) {
+        getStages(projectId).then((data) => {
+          const list = data.stages ?? []
+          setStages(list)
+          const active = list.find((s) => s.is_active)
+          if (active) setCurrentStageSequence(active.stage_sequence)
+        })
+      }
+    }
   }
+
+  if (selectedStep.type === 'requiredStepNode') {
+    currentRequiredStepName.current = selectedStep.data.label
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setToast(`📌 ${selectedStep.data.label}이(가) 시작됐어요!`)
+    setToastVisible(true)
+    timerRef.current = setTimeout(() => setToastVisible(false), 3000)
+  }
+
+  await fetchAndRenderTree(selectedStageId)
+  setSelectedStep(null)
+  setStepDetail(null)
+}
+
 
   function handleNodeContextMenu(event, node) {
     event.preventDefault()
@@ -293,7 +336,7 @@ export default function CanvasPage() {
     setStepDetail(null)
   }
 
-  const selectedHasChildren = edges.some(e => e.source === selectedStep?.id)
+  const selectedHasChildren = edges.some((e) => e.source === selectedStep?.id)
 
   return (
     <div className={styles.layout}>
@@ -323,7 +366,8 @@ export default function CanvasPage() {
             const next = !navCollapsed
             setNavCollapsed(next)
             localStorage.setItem('navCollapsed', next)
-          }}        />
+          }}
+        />
 
         <div className={styles.canvasWrapper}>
           <ToastAlarm
@@ -383,15 +427,15 @@ export default function CanvasPage() {
         )}
 
         {rollbackModal && (
-          <div className={styles.overlay} onClick={() => setRollbackModal(null)}>
-            <div className={styles.modal} onClick={e => e.stopPropagation()}>
+          <div className={styles.overlay} onClick={() => setRollbackModal(false)}>
+            <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
               <div className={styles.iconWrap}>⚠️</div>
-              <p className={styles.title}>선택한 Step으로 돌아가시겠습니까?</p>
+              <p className={styles.title}>이전 Stage로 돌아가시겠습니까?</p>
               <p className={styles.desc}>
-                stage {stagesToClear}의 모든 진행 내역이 삭제됩니다. 계속 하시겠습니까?
+                이후 Stage의 진행 내역이 삭제될 수 있습니다. 계속 하시겠습니까?
               </p>
               <div className={styles.actions}>
-                <button className={styles.cancelBtn} onClick={() => setRollbackModal(null)}>
+                <button className={styles.cancelBtn} onClick={() => setRollbackModal(false)}>
                   취소
                 </button>
                 <button className={styles.rollbackBtn} onClick={handleRollbackConfirm}>

--- a/frontend/src/utils/canvasUtils.js
+++ b/frontend/src/utils/canvasUtils.js
@@ -75,3 +75,23 @@ export function flattenTree(steps, stageSequence) {
 
   return { nodes, edges }
 }
+
+export function getStageProgressFromTree(nodes, edges) {
+  const firstRequired = nodes.find(
+    (node) =>
+      node.type === 'requiredStepNode' &&
+      !edges.some((edge) => edge.target === node.id)
+  )
+  return firstRequired
+    ? edges.some((edge) => edge.source === firstRequired.id)
+    : false
+}
+
+export function findRequiredStep(nodeId, nodes, edges) {
+  const parentEdge = edges.find((e) => e.target === nodeId)
+  if (!parentEdge) return null
+  const parentNode = nodes.find((n) => n.id === parentEdge.source)
+  if (!parentNode) return null
+  if (parentNode.type === 'requiredStepNode') return parentNode
+  return findRequiredStep(parentNode.id, nodes, edges)
+}


### PR DESCRIPTION
## PR 요약
- 캔버스 페이지 전반의 UX 안정성 개선 및 리팩토링
- 
## 변경 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링

## 변경 사항
- Accept 버튼 중복 클릭 방지 (isAccepting 상태 추가, finally로 안정화)
- 노드 클릭 시 race condition 방지 (requestId 패턴 적용)
- 사이드패널 자동 오픈 조건 개선 — 이미 진행된 스테이지 재진입 시 자동 오픈 안 함
- 롤백 모달 조건 개선 — completed 스테이지는 무조건 모달, active 스테이지는 progress 확인 후 모달
- `canvasUtils.js`에 `getStageProgressFromTree`, `findRequiredStep` 분리

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영