### PR TITLE
[#140][BE]READY 형제 노드 accept 시 rollback 실패 문제 수정

### DIFF
--- a/backend/app/business/services/step_service.py
+++ b/backend/app/business/services/step_service.py
@@ -3,7 +3,7 @@ import uuid
 from sqlalchemy.orm import Session
 
 from app.core.enums import StepStatus
-from app.core.exceptions import InvalidRollbackTargetError, StepNotFoundError
+from app.core.exceptions import StepNotFoundError
 from app.core.models.step import Step as StepModel
 from app.core.repositories import (
     project as project_repo,
@@ -34,10 +34,6 @@ def rollback_step(db: Session, step_id: uuid.UUID) -> None:
     step = step_repo.get_step(db, step_id)
     if step is None:
         raise StepNotFoundError()
-
-    # ① children 존재 여부 검사
-    if step_repo.has_children(db, step_id):
-        raise InvalidRollbackTargetError("자식 Step이 있는 Step은 롤백할 수 없습니다.")
 
     # ⓪ 롤백 대상이 현재 진행 Stage보다 낮은 Stage이면 윗 Stage 정리
     _wipe_upper_stages_if_needed(db, step)

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -43,15 +43,6 @@ class StepAlreadyAcceptedError(PocoError):
         )
 
 
-class InvalidRollbackTargetError(PocoError):
-    def __init__(self, message: str = "롤백할 수 없는 대상입니다."):
-        super().__init__(
-            code="INVALID_ROLLBACK_TARGET",
-            message=message,
-            status_code=http_status.HTTP_400_BAD_REQUEST,
-        )
-
-
 class ProjectNotFoundError(PocoError):
     def __init__(self, message: str = "프로젝트를 찾을 수 없습니다."):
         super().__init__(

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -362,11 +362,7 @@ export default function CanvasPage() {
     try {
       await rollbackStep(selectedStep.id)
     } catch (err) {
-      const msg =
-        err?.code === 'INVALID_ROLLBACK_TARGET'
-          ? '자식 Step이 있는 노드는 롤백할 수 없어요.\n마지막 Step을 선택해주세요.'
-          : '롤백에 실패했어요. 다시 시도해주세요.'
-      alert(msg)
+      alert('롤백에 실패했어요. 다시 시도해주세요.')
       return
     }
 
@@ -421,11 +417,7 @@ export default function CanvasPage() {
         try {
           await rollbackStep(nodeToRollback.id)
         } catch (err) {
-          const msg =
-            err?.code === 'INVALID_ROLLBACK_TARGET'
-              ? '자식 Step이 있는 노드는 롤백할 수 없어요.\n마지막 Step을 선택해주세요.'
-              : '롤백에 실패했어요. 다시 시도해주세요.'
-          alert(msg)
+          alert('롤백에 실패했어요. 다시 시도해주세요.')
           return
         }
       }


### PR DESCRIPTION
형제 노드 READY 유지 정책에서 ACCEPTED 형제를 rollback할 때
has_children 체크로 인해 INVALID_ROLLBACK_TARGET 오류 발생. 해당 체크는 형제 CANCELED 정책 기준으로 설계된 제약으로,
현재 정책과 맞지 않아 제거.

## PR 요약
- `business/services/step_service.py`: `rollback_step`에서 `has_children` 체크 제거

## 변경 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- 

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
