### PR TITLE
[#145][FE] Step 롤백 대상 노드 버그 수정

### DIFF
--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -361,7 +361,7 @@ export default function CanvasPage() {
 
     try {
       await rollbackStep(selectedStep.id)
-    } catch (err) {
+    } catch {
       alert('롤백에 실패했어요. 다시 시도해주세요.')
       return
     }
@@ -406,17 +406,9 @@ export default function CanvasPage() {
         (status === 'READY' && !!acceptedSibling)
 
       if (!skipRollback && needsRollback) {
-        const nodeToRollback =
-          status === 'CANCELED' ? selectedStep : acceptedSibling
-
-        if (!nodeToRollback) {
-          alert('롤백 대상을 찾지 못했어요. 다시 시도해주세요.')
-          return
-        }
-
         try {
-          await rollbackStep(nodeToRollback.id)
-        } catch (err) {
+          await rollbackStep(selectedStep.id)
+        } catch {
           alert('롤백에 실패했어요. 다시 시도해주세요.')
           return
         }

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -170,6 +170,13 @@ export default function CanvasPage() {
     setNodes(n)
     setEdges(e)
 
+    const acceptedRequiredNode = n.find(
+      (node) => node.type === 'requiredStepNode' && node.data.status === 'ACCEPTED'
+    )
+    if (acceptedRequiredNode) {
+      currentRequiredStepName.current = acceptedRequiredNode.data.label
+    }
+
     n.filter((node) =>
       node.data.status === 'READY' &&
       node.type !== 'requiredStepNode' &&


### PR DESCRIPTION
## PR 요약
- Step 롤백 시 대상 노드를 형제 노드(acceptedSibling)에서 선택한 노드(selectedStep)로 수정
- 미사용 `catch (err)` 바인딩 제거 (`catch`로 변경)
- 재진입 시 진행 중인 필수 Step의 toast 이름 복원

## 변경 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `executeAccept`: `rollbackStep(nodeToRollback.id)` → `rollbackStep(selectedStep.id)` (백엔드 계약: "내가 가고 싶은 노드 ID"를 전달)
- `handleRollbackConfirm`, `executeAccept`: 미사용 `catch (err)` → `catch`
- `fetchAndRenderTree`: ACCEPTED 상태의 requiredStepNode 감지 후 `currentRequiredStepName.current` 복원