### PR TITLE
[#145][FE]  Step 롤백 대상 노드 버그 수정

### DIFF
--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -393,6 +393,8 @@ export default function CanvasPage() {
       const status = selectedStep.data?.status
 
       const parentEdge = edges.find((e) => e.target === selectedStep.id)
+      const parentNode = parentEdge ? nodes.find((n) => n.id === parentEdge.source) : null
+      const parentStatus = parentNode?.data?.status
 
       const siblings = parentEdge
         ? nodes.filter(
@@ -410,7 +412,8 @@ export default function CanvasPage() {
 
       const needsRollback =
         status === 'CANCELED' ||
-        (status === 'READY' && !!acceptedSibling)
+        (status === 'READY' && !!acceptedSibling) ||
+        (status === 'READY' && !!parentNode && parentStatus !== 'ACCEPTED')
 
       if (!skipRollback && needsRollback) {
         try {


### PR DESCRIPTION
[#145][FE] 부모 노드 상태 기반 롤백 조건 추가
## PR 요약
- 부모 노드가 ACCEPTED가 아닌 경우 롤백 API를 호출하도록 조건 추가

## 변경 유형
- [x] 버그 수정

## 변경 사항
- `executeAccept` 내 rollback 판단 로직에 부모 노드 상태 체크 추가
- 부모가 ACCEPTED가 아닌 READY 노드 accept 시 rollback API 호출되도록 수정

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [x] 불필요한 코드 및 주석 제거

## 참고 사항
- 기존에는 형제 노드 중 ACCEPTED가 있는 경우만 롤백 처리했으나, 부모가 CANCELED인 경우 형제 탐색으로는 감지 불가라서 추가함