### PR TITLE
[#164][BE] decision history 전체 프로젝트 범위 확장 및 stage_sequence 추가

### DIFF
--- a/backend/app/ai/services/step_service.py
+++ b/backend/app/ai/services/step_service.py
@@ -382,6 +382,7 @@ def _build_generate_request(db: Session, parent_step: StepModel) -> GenerateRequ
 
     accepted_steps = (
         db.query(StepModel)
+        .join(StageModel, StepModel.stage_id == StageModel.id)
         .filter(
             StepModel.project_id == parent_step.project_id,
             StepModel.status == StepStatus.ACCEPTED,

--- a/backend/app/ai/services/step_service.py
+++ b/backend/app/ai/services/step_service.py
@@ -384,9 +384,9 @@ def _build_generate_request(db: Session, parent_step: StepModel) -> GenerateRequ
         db.query(StepModel)
         .filter(
             StepModel.project_id == parent_step.project_id,
-            StepModel.stage_id == parent_step.stage_id,
             StepModel.status == StepStatus.ACCEPTED,
         )
+        .order_by(StageModel.sequence, StepModel.created_at)
         .all()
     )
 
@@ -399,7 +399,12 @@ def _build_generate_request(db: Session, parent_step: StepModel) -> GenerateRequ
             db, parent_step.stage_id, fulfilled_ids
         ),
         decision_history=[
-            DecisionHistoryItem(step_id=s.id, name=s.name, status=s.status)
+            DecisionHistoryItem(
+                step_id=s.id,
+                name=s.name,
+                status=s.status,
+                stage_sequence=s.stage.sequence,
+                )
             for s in accepted_steps
         ],
         current_step=AcceptedStepItem(step_id=parent_step.id, name=parent_step.name),

--- a/backend/app/core/schemas/step.py
+++ b/backend/app/core/schemas/step.py
@@ -104,6 +104,7 @@ class DecisionHistoryItem(BaseModel):
     step_id: UUID
     name: str
     status: str
+    stage_sequence: int
 
 
 class TargetStep(BaseModel):


### PR DESCRIPTION
## PR 요약
- generate 요청 시 decision history에 현재 스테이지의 accepted step만 포함되던 것을
전체 프로젝트의 accepted step을 포함하도록 변경합니다.

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `_build_generate_request`의 쿼리에서 `stage_id` 필터 제거
- `StageModel` join 추가 및 `stage_sequence` 오름차순, `created_at` 오름차순 정렬
- `DecisionHistoryItem` 스키마에 `stage_sequence: int` 필드 추가

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
