### PR TITLE
[#149][FE] SidePanel 스트리밍·로딩 뷰 개선

### DIFF
--- a/frontend/src/components/canvas/SidePanel.jsx
+++ b/frontend/src/components/canvas/SidePanel.jsx
@@ -409,61 +409,59 @@ export default function SidePanel({ step, detail, streamingText, isOpen, onClose
         ))}
       </div>
 
-      <div className={styles.content}>
-        {activeTab === 'mentoring' && (
-          <MentoringContent raw={mentoring} isLoading={!detail} streamingText={streamingText} isRequired={isRequired} />
-        )}
+      <div style={{ display: activeTab === 'mentoring' ? 'block' : 'none' }}>
+        <MentoringContent raw={mentoring} isLoading={!detail} streamingText={streamingText} isRequired={isRequired} />
+      </div>
 
-        {activeTab === 'dictionary' && (
-          <div className={styles.dictionaryList}>
-            {!detail
-              ? [...Array(3)].map((_, i) => (
-                  <div key={i} className={styles.dictionaryItem}>
-                    <div className={styles.skeletonTitle} />
-                    <div className={styles.skeletonLine} />
-                  </div>
-                ))
-              : dictionary.map((item, i) => (
-                  <div key={i} className={styles.dictionaryItem}>
-                    <p className={styles.dictionaryTerm}>{item.term}</p>
-                    <p className={styles.dictionaryDefinition}>{item.definition}</p>
-                  </div>
-                ))
-            }
-          </div>
-        )}
-
-        {activeTab === 'template' && (
-          <div className={styles.templateTab}>
-            <p className={styles.templateIntro}>
-              이 단계의 산출물인 템플릿이 준비되어 있어요.<br />
-              Notion에서 바로 작성을 시작할 수 있어요.
-            </p>
-            {artifact ? (
-              <div className={styles.templateCard}>
-                <div className={styles.templateCardTop}>
-                  <span>📄</span>
-                  <span className={styles.templateCardTitle}>{name}</span>
+      <div style={{ display: activeTab === 'dictionary' ? 'block' : 'none' }}>
+        <div className={styles.dictionaryList}>
+          {!detail
+            ? [...Array(3)].map((_, i) => (
+                <div key={i} className={styles.dictionaryItem}>
+                  <div className={styles.skeletonTitle} />
+                  <div className={styles.skeletonLine} />
                 </div>
-                <a
-                  href={artifact.notion_template_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={styles.notionBtn}
-                >
-                  <NotionIcon size={16} />
-                  Notion에서 템플릿 열기
-                </a>
-                <p className={styles.templateHint}>
-                  작성한 내용을 Poco에 제출할 필요는 없어요.<br />
-                  Notion에서 복제 후 자유롭게 활용하세요!
-                </p>
+              ))
+            : dictionary.map((item, i) => (
+                <div key={i} className={styles.dictionaryItem}>
+                  <p className={styles.dictionaryTerm}>{item.term}</p>
+                  <p className={styles.dictionaryDefinition}>{item.definition}</p>
+                </div>
+              ))
+          }
+        </div>
+      </div>
+
+      <div style={{ display: activeTab === 'template' ? 'block' : 'none' }}>
+        <div className={styles.templateTab}>
+          <p className={styles.templateIntro}>
+            이 단계의 산출물인 템플릿이 준비되어 있어요.<br />
+            Notion에서 바로 작성을 시작할 수 있어요.
+          </p>
+          {artifact ? (
+            <div className={styles.templateCard}>
+              <div className={styles.templateCardTop}>
+                <span>📄</span>
+                <span className={styles.templateCardTitle}>{name}</span>
               </div>
-            ) : (
-              <DotsLoading />
-            )}
-          </div>
-        )}
+              <a
+                href={artifact.notion_template_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.notionBtn}
+              >
+                <NotionIcon size={16} />
+                Notion에서 템플릿 열기
+              </a>
+              <p className={styles.templateHint}>
+                작성한 내용을 Poco에 제출할 필요는 없어요.<br />
+                Notion에서 복제 후 자유롭게 활용하세요!
+              </p>
+            </div>
+          ) : (
+            <DotsLoading />
+          )}
+        </div>
       </div>
 
       <div className={styles.footer}>

--- a/frontend/src/components/canvas/SidePanel.jsx
+++ b/frontend/src/components/canvas/SidePanel.jsx
@@ -11,17 +11,6 @@ function NotionIcon({ size = 18 }) {
   )
 }
 
-function SectionSkeleton() {
-  return (
-    <div className={styles.mentoringSection}>
-      <div className={styles.skeletonTitle} />
-      <div className={styles.skeletonLine} />
-      <div className={styles.skeletonLine} />
-      <div className={styles.skeletonLineShort} />
-    </div>
-  )
-}
-
 function TypewriterText({ text, className, speed = 12, onComplete }) {
   const [displayed, setDisplayed] = useState('')
   const indexRef = useRef(0)
@@ -438,59 +427,61 @@ export default function SidePanel({ step, detail, streamingText, isOpen, onClose
           </button>
         ))}
       </div>
-
-      <div style={{ display: activeTab === 'mentoring' ? 'block' : 'none' }}>
-        <MentoringContent raw={mentoring} isLoading={!detail} streamingText={streamingText} isRequired={isRequired} />
-      </div>
-
-      <div style={{ display: activeTab === 'dictionary' ? 'block' : 'none' }}>
-        <div className={styles.dictionaryList}>
-          {!detail
-            ? [...Array(3)].map((_, i) => (
-                <div key={i} className={styles.dictionaryItem}>
-                  <div className={styles.skeletonTitle} />
-                  <div className={styles.skeletonLine} />
-                </div>
-              ))
-            : dictionary.map((item, i) => (
-                <div key={i} className={styles.dictionaryItem}>
-                  <p className={styles.dictionaryTerm}>{item.term}</p>
-                  <p className={styles.dictionaryDefinition}>{item.definition}</p>
-                </div>
-              ))
-          }
+      
+      <div className={styles.content}>
+        <div style={{ display: activeTab === 'mentoring' ? 'block' : 'none' }}>
+          <MentoringContent raw={mentoring} isLoading={!detail} streamingText={streamingText} isRequired={isRequired} />
         </div>
-      </div>
 
-      <div style={{ display: activeTab === 'template' ? 'block' : 'none' }}>
-        <div className={styles.templateTab}>
-          <p className={styles.templateIntro}>
-            이 단계의 산출물인 템플릿이 준비되어 있어요.<br />
-            Notion에서 바로 작성을 시작할 수 있어요.
-          </p>
-          {artifact ? (
-            <div className={styles.templateCard}>
-              <div className={styles.templateCardTop}>
-                <span>📄</span>
-                <span className={styles.templateCardTitle}>{name}</span>
+        <div style={{ display: activeTab === 'dictionary' ? 'block' : 'none' }}>
+          <div className={styles.dictionaryList}>
+            {!detail
+              ? [...Array(3)].map((_, i) => (
+                  <div key={i} className={styles.dictionaryItem}>
+                    <div className={styles.skeletonTitle} />
+                    <div className={styles.skeletonLine} />
+                  </div>
+                ))
+              : dictionary.map((item, i) => (
+                  <div key={i} className={styles.dictionaryItem}>
+                    <p className={styles.dictionaryTerm}>{item.term}</p>
+                    <p className={styles.dictionaryDefinition}>{item.definition}</p>
+                  </div>
+                ))
+            }
+          </div>
+        </div>
+
+        <div style={{ display: activeTab === 'template' ? 'block' : 'none' }}>
+          <div className={styles.templateTab}>
+            <p className={styles.templateIntro}>
+              이 단계의 산출물인 템플릿이 준비되어 있어요.<br />
+              Notion에서 바로 작성을 시작할 수 있어요.
+            </p>
+            {artifact ? (
+              <div className={styles.templateCard}>
+                <div className={styles.templateCardTop}>
+                  <span>📄</span>
+                  <span className={styles.templateCardTitle}>{name}</span>
+                </div>
+                <a
+                  href={artifact.notion_template_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.notionBtn}
+                >
+                  <NotionIcon size={16} />
+                  Notion에서 템플릿 열기
+                </a>
+                <p className={styles.templateHint}>
+                  작성한 내용을 Poco에 제출할 필요는 없어요.<br />
+                  Notion에서 복제 후 자유롭게 활용하세요!
+                </p>
               </div>
-              <a
-                href={artifact.notion_template_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.notionBtn}
-              >
-                <NotionIcon size={16} />
-                Notion에서 템플릿 열기
-              </a>
-              <p className={styles.templateHint}>
-                작성한 내용을 Poco에 제출할 필요는 없어요.<br />
-                Notion에서 복제 후 자유롭게 활용하세요!
-              </p>
-            </div>
-          ) : (
-            <DotsLoading />
-          )}
+            ) : (
+              <DotsLoading />
+            )}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/canvas/SidePanel.jsx
+++ b/frontend/src/components/canvas/SidePanel.jsx
@@ -94,6 +94,19 @@ function parseStreamingMentoring(text) {
   return result
 }
 
+function DotsLoading({ text = '템플릿을 불러오는 중이에요' }) {
+  return (
+    <p className={styles.templateHint}>
+      {text}
+      <span className={styles.bounceDots}>
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+    </p>
+  )
+}
+
 function LoadingSpinner() {
   const [visible, setVisible] = useState(false)
 
@@ -425,7 +438,12 @@ export default function SidePanel({ step, detail, streamingText, isOpen, onClose
         {activeTab === 'dictionary' && (
           <div className={styles.dictionaryList}>
             {!detail
-              ? [...Array(4)].map((_, i) => <SectionSkeleton key={i} />)
+              ? [...Array(3)].map((_, i) => (
+                  <div key={i} className={styles.dictionaryItem}>
+                    <div className={styles.skeletonTitle} />
+                    <div className={styles.skeletonLine} />
+                  </div>
+                ))
               : dictionary.map((item, i) => (
                   <div key={i} className={styles.dictionaryItem}>
                     <p className={styles.dictionaryTerm}>{item.term}</p>

--- a/frontend/src/components/canvas/SidePanel.jsx
+++ b/frontend/src/components/canvas/SidePanel.jsx
@@ -82,7 +82,37 @@ function parseStreamingMentoring(text) {
       }
       i++
     }
-    return undefined
+    const items = []
+    let j = start + 1  // '[' 다음부터
+    while (j < text.length) {
+      while (j < text.length && /\s/.test(text[j])) j++
+      if (text[j] !== '{') break
+      let objDepth = 0, inStr = false, k = j
+      while (k < text.length) {
+        const ch = text[k]
+        if (inStr) {
+          if (ch === '\\') { k += 2; continue }
+          if (ch === '"') inStr = false
+        } else {
+          if (ch === '"') inStr = true
+          else if (ch === '{') objDepth++
+          else if (ch === '}') {
+            objDepth--
+            if (objDepth === 0) {
+              try {
+                items.push(JSON.parse(text.slice(j, k + 1)))
+                j = k + 1
+                while (j < text.length && /[\s,]/.test(text[j])) j++
+              } catch { return items.length > 0 ? items : undefined }
+              break
+            }
+          }
+        }
+        k++
+      }
+      if (objDepth > 0) break
+    }
+    return items.length > 0 ? items : undefined
   }
 
   result.description = extractString('description')

--- a/frontend/src/components/canvas/SidePanel.jsx
+++ b/frontend/src/components/canvas/SidePanel.jsx
@@ -107,27 +107,6 @@ function DotsLoading({ text = '템플릿을 불러오는 중이에요' }) {
   )
 }
 
-function LoadingSpinner() {
-  const [visible, setVisible] = useState(false)
-
-  useEffect(() => {
-    const timer = setTimeout(() => setVisible(true), 1000)
-    return () => clearTimeout(timer)
-  }, [])
-
-  return (
-    <div className={styles.spinnerWrap} style={{ opacity: visible ? 1 : 0, transition: 'opacity 0.5s ease' }}>
-      <svg className={styles.floatingIcon} width="26" height="23" viewBox="0 0 26 23" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M5.48038 9.06491C6.19361 10.6221 5.61325 12.4223 4.1841 13.0857C2.75495 13.7491 1.01822 13.0246 0.304985 11.4673C-0.408245 9.91013 0.172119 8.10994 1.60127 7.44653C3.03041 6.78311 4.76715 7.50769 5.48038 9.06491Z" fill="#4A35D0"/>
-        <path d="M20.5196 9.06491C19.8064 10.6221 20.3868 12.4223 21.8159 13.0857C23.245 13.7491 24.9818 13.0246 25.695 11.4673C26.4082 9.91013 25.8279 8.10994 24.3987 7.44653C22.9696 6.78311 21.2329 7.50769 20.5196 9.06491Z" fill="#4A35D0"/>
-        <path d="M13.7173 3.30832C13.3244 5.45563 14.5778 7.48791 16.517 7.84754C18.4562 8.20716 20.3467 6.75795 20.7396 4.61063C21.1325 2.46331 19.879 0.43103 17.9399 0.0714064C16.0007 -0.288217 14.1102 1.161 13.7173 3.30832Z" fill="#4A35D0"/>
-        <path d="M12.2447 3.29168C12.6376 5.439 11.3841 7.47128 9.44495 7.8309C7.50579 8.19052 5.61526 6.74131 5.22235 4.59399C4.82943 2.44667 6.08291 0.414392 8.02208 0.0547683C9.96125 -0.304855 11.8518 1.14436 12.2447 3.29168Z" fill="#4A35D0"/>
-        <path d="M20.029 22.0422C17.1938 24.3954 14.9862 21.6718 12.995 21.6718C11.0038 21.6718 8.92611 24.4608 5.85279 21.8679C1.74061 17.5319 7.82229 9.48651 12.9861 9.48651C18.1498 9.48651 24.2927 17.6845 20.029 22.0422Z" fill="#4A35D0"/>
-      </svg>
-    </div>
-  )
-}
-
 function MethodListTyping({ items }) {
   const [typingIndex, setTypingIndex] = useState(0)
   const [doneIndex, setDoneIndex] = useState(-1)
@@ -278,9 +257,9 @@ function AllSkeleton() {
   )
 }
 
-function MentoringContent({ raw, isLoading, streamingText, isRequired, isStreamMode }) {
+function MentoringContent({ raw, isLoading, streamingText, isRequired }) {
   if (isLoading && !streamingText) {
-    return isStreamMode ? <AllSkeleton /> : <LoadingSpinner />
+    return <AllSkeleton />
   }
 
   if (streamingText) {
@@ -371,7 +350,7 @@ function MentoringContent({ raw, isLoading, streamingText, isRequired, isStreamM
   )
 }
 
-export default function SidePanel({ step, detail, streamingText, isOpen, onClose, onAccept, hasChildren, isAccepting, isStreamMode }) {
+export default function SidePanel({ step, detail, streamingText, isOpen, onClose, onAccept, hasChildren, isAccepting }) {
   const [lastStep, setLastStep] = useState(step)
   const [activeTab, setActiveTab] = useState('mentoring')
   const [tabStepId, setTabStepId] = useState(step?.id)
@@ -432,7 +411,7 @@ export default function SidePanel({ step, detail, streamingText, isOpen, onClose
 
       <div className={styles.content}>
         {activeTab === 'mentoring' && (
-          <MentoringContent raw={mentoring} isLoading={!detail} streamingText={streamingText} isRequired={isRequired} isStreamMode={isStreamMode} />
+          <MentoringContent raw={mentoring} isLoading={!detail} streamingText={streamingText} isRequired={isRequired} />
         )}
 
         {activeTab === 'dictionary' && (

--- a/frontend/src/components/canvas/SidePanel.jsx
+++ b/frontend/src/components/canvas/SidePanel.jsx
@@ -359,8 +359,14 @@ function MentoringContent({ raw, isLoading, streamingText, isRequired, isStreamM
 }
 
 export default function SidePanel({ step, detail, streamingText, isOpen, onClose, onAccept, hasChildren, isAccepting, isStreamMode }) {
-  const [activeTab, setActiveTab] = useState('mentoring')
   const [lastStep, setLastStep] = useState(step)
+  const [activeTab, setActiveTab] = useState('mentoring')
+  const [tabStepId, setTabStepId] = useState(step?.id)
+
+  if (step?.id !== tabStepId) {
+    setTabStepId(step?.id)
+    setActiveTab('mentoring')
+  }
 
   useEffect(() => {
     if (step) setTimeout(() => setLastStep(step), 0)

--- a/frontend/src/components/canvas/SidePanel.jsx
+++ b/frontend/src/components/canvas/SidePanel.jsx
@@ -115,7 +115,7 @@ function parseStreamingMentoring(text) {
 
 function DotsLoading({ text = '템플릿을 불러오는 중이에요' }) {
   return (
-    <p className={styles.templateHint}>
+    <p className={styles.templateLoading}>
       {text}
       <span className={styles.bounceDots}>
         <span></span>
@@ -470,7 +470,7 @@ export default function SidePanel({ step, detail, streamingText, isOpen, onClose
                   rel="noopener noreferrer"
                   className={styles.notionBtn}
                 >
-                  <NotionIcon size={16} />
+                  <NotionIcon size={18} />
                   Notion에서 템플릿 열기
                 </a>
                 <p className={styles.templateHint}>

--- a/frontend/src/components/canvas/SidePanel.jsx
+++ b/frontend/src/components/canvas/SidePanel.jsx
@@ -460,7 +460,7 @@ export default function SidePanel({ step, detail, streamingText, isOpen, onClose
                 </p>
               </div>
             ) : (
-              <p className={styles.templateHint}>템플릿을 불러오는 중이에요.</p>
+              <DotsLoading />
             )}
           </div>
         )}

--- a/frontend/src/components/canvas/SidePanel.module.css
+++ b/frontend/src/components/canvas/SidePanel.module.css
@@ -380,9 +380,10 @@
   background: #191919;
   color: #fff;
   font-size: 13px;
-  font-weight: 700;
-  padding: 10px 16px;
-  border-radius: 8px;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: 10px;
   text-decoration: none;
   transition: opacity 0.15s;
 }
@@ -391,10 +392,24 @@
   opacity: 0.85;
 }
 
-.templateHint {
+.templateLoading {
   display: inline-flex;
   align-items: center;
+  font-size: 13px;
+  font-weight: 500;
+  color: #707097;
+  letter-spacing: 0.4px;
+  text-align: center;
   gap: 6px;
+}
+
+.templateHint {
+  font-size: 12px;
+  color: #9E99C0;
+  text-align: center;
+  line-height: 1.6;
+  letter-spacing: 0.2px;
+  margin: 0;
 }
 
 .bounceDots {
@@ -405,7 +420,7 @@
 .bounceDots span {
   width: 6px;
   height: 6px;
-  background-color: var(--color-primary);
+  background-color:#9b9bc4;
   border-radius: 50%;
   animation: bounce 1.4s infinite ease-in-out both;
 }
@@ -428,7 +443,7 @@
     opacity: 0.6;
   }
   40% {
-    transform: translateY(-6px);
+    transform: translateY(-3px);
     opacity: 1;
   }
 }

--- a/frontend/src/components/canvas/SidePanel.module.css
+++ b/frontend/src/components/canvas/SidePanel.module.css
@@ -392,14 +392,48 @@
 }
 
 .templateHint {
-  font-size: 12px;
-  color: #9E99C0;
-  text-align: center;
-  line-height: 1.6;
-  letter-spacing: 0.2px;
-  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
+.bounceDots {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.bounceDots span {
+  width: 6px;
+  height: 6px;
+  background-color: var(--color-primary);
+  border-radius: 50%;
+  animation: bounce 1.4s infinite ease-in-out both;
+}
+
+.bounceDots span:nth-child(1) {
+  animation-delay: -0.32s;
+}
+
+.bounceDots span:nth-child(2) {
+  animation-delay: -0.16s;
+}
+
+.bounceDots span:nth-child(3) {
+  animation-delay: 0s;
+}
+
+@keyframes bounce {
+  0%, 80%, 100% {
+    transform: translateY(0);
+    opacity: 0.6;
+  }
+  40% {
+    transform: translateY(-6px);
+    opacity: 1;
+  }
+}
+
+/* 하단 */
 .footer {
   padding: 14px 20px;
   border-top: 1px solid #EEEDF8;

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -516,8 +516,6 @@ export default function CanvasPage() {
       setStreamingText(null)
 
       await fetchAndRenderTree(selectedStageId)
-      setSelectedStep(null)
-      setStepDetail(null)
     } finally {
       setIsAccepting(false)
     }

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -286,6 +286,7 @@ export default function CanvasPage() {
   }))
 
   async function handleNodeClick(event, node) {
+    if (selectedStep?.id === node.id) return
     clearStreamCallbacks()
     setSelectedStep(node)
     setStepDetail(null)

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -67,6 +67,7 @@ export default function CanvasPage() {
   const enqueuedLenRef = useRef(0)
   const typingQueueRef = useRef('')
   const typingTimerRef = useRef(null)
+  const detailCacheRef = useRef({})
 
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
@@ -270,6 +271,7 @@ export default function CanvasPage() {
     autoOpenedStageRef.current = null
     streamBuffers.current.forEach((buf) => buf.stream?.abort())
     streamBuffers.current.clear()
+    detailCacheRef.current = {}
   }, [selectedStageId])
 
   const activeStage = getLatestActiveStage(stages)
@@ -289,23 +291,29 @@ export default function CanvasPage() {
     if (selectedStep?.id === node.id) return
     clearStreamCallbacks()
     setSelectedStep(node)
-    setStepDetail(null)
     setStreamingText(null)
+
+    if (detailCacheRef.current[node.id]) {
+      setStepDetail(detailCacheRef.current[node.id])
+    } else {
+      setStepDetail(null)
+    }
 
     const requestId = ++detailRequestRef.current
     const buf = streamBuffers.current.get(node.id)
 
     if (buf?.isDone) {
-      setIsStreamMode(false) 
+      setIsStreamMode(false)
       try {
         const detail = await getStepDetail(node.id)
         if (requestId !== detailRequestRef.current) return
         setStepDetail(detail)
+        detailCacheRef.current[node.id] = detail
       } catch {
         //
       }
     } else if (buf && !buf.isDone) {
-      setIsStreamMode(false) 
+      setIsStreamMode(false)
       clearTyping()
       const baseText = buf.text
       setStreamingText(baseText)
@@ -325,16 +333,18 @@ export default function CanvasPage() {
           if (requestId !== detailRequestRef.current) return
           setStepDetail(detail)
           setStreamingText(null)
+          detailCacheRef.current[node.id] = detail
         } catch {
           setStreamingText(null)
         }
       }
     } else {
-      setIsStreamMode(false) 
+      setIsStreamMode(false)
       try {
         const detail = await getStepDetail(node.id)
         if (requestId !== detailRequestRef.current) return
         setStepDetail(detail)
+        detailCacheRef.current[node.id] = detail
       } catch {
         //
       }

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -320,13 +320,13 @@ export default function CanvasPage() {
       }
       buf.onComplete = async () => {
         clearTyping()
-        setStreamingText(null)
         try {
           const detail = await getStepDetail(node.id)
           if (requestId !== detailRequestRef.current) return
           setStepDetail(detail)
+          setStreamingText(null)
         } catch {
-          //
+          setStreamingText(null)
         }
       }
     } else {


### PR DESCRIPTION
## PR 요약
- SidePanel 스트리밍/로딩/탭 상태 전반 UX 개선

## 변경 유형
- [x] 버그 수정
- [x] 리팩토링

## 변경 사항
- LoadingSpinner(발바닥) 제거 → AllSkeleton으로 통일
- 다른 노드 클릭 시 mentoring 탭으로 초기화
- Accept 후 사이드패널 유지 (닫히지 않음)
- 같은 노드 재클릭 방지
- 탭 전환 시 스트리밍 상태 유지 (조건부 렌더 → display:none)
- 스트리밍 완료 후 깜빡임 제거 (streamingText 초기화 순서 수정)
- 스트리밍 중 추천 방법 부분 파싱으로 끊김 개선
- 노드 클릭 시 detail 캐싱으로 빈화면 개선
- 딕셔너리 스켈레톤 간격 조정 (3개, term+definition 구조)
- 템플릿 로딩 중 DotsLoading 애니메이션 추가

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] 불필요한 코드 및 주석 제거

## 참고 사항
- isStreamMode prop 제거