### PR TITLE
[#173][AI] ProjectInfo.constraints 타입 전환 — str → list[str]

### DIFF
--- a/ai/cli_simulator.py
+++ b/ai/cli_simulator.py
@@ -135,7 +135,12 @@ def _build_project_info() -> ProjectInfo:
     member_count = _input_int("프로젝트 인원 (명): ", minimum=1)
     name = _input_optional("프로젝트 이름 (선택, 엔터=스킵): ")
     description = _input_optional("프로젝트 설명 (선택, 엔터=스킵): ")
-    constraints = _input_optional("제약사항 (선택, 엔터=스킵): ")
+    _constraints_raw = _input_optional("제약사항 (선택, 콤마 구분 또는 엔터=스킵): ")
+    constraints = (
+        [c.strip() for c in _constraints_raw.split(",") if c.strip()]
+        if _constraints_raw
+        else None
+    )
 
     return ProjectInfo(
         project_id=str(uuid.uuid4()),

--- a/ai/latency_simulator.py
+++ b/ai/latency_simulator.py
@@ -70,7 +70,7 @@ def _build_fixture_project() -> ProjectInfo:
         duration_months=3,
         member_count=4,
         description="레이턴시 측정용 고정 프로젝트",
-        constraints="기술 스택은 React + FastAPI로 제한",
+        constraints=["기술 스택은 React + FastAPI로 제한"],
         initial_prompt=(
             "배달 라이더들이 경로를 비효율적으로 다니는 문제를 AI로 해결하고 싶어요"
         ),

--- a/ai/schemas/common.py
+++ b/ai/schemas/common.py
@@ -16,7 +16,7 @@ class ProjectInfo(BaseModel):
     duration_months: int
     member_count: int
     description: Optional[str] = None
-    constraints: Optional[str] = None
+    constraints: Optional[list[str]] = None
     initial_prompt: str
 
 

--- a/ai/services/side_panel_generator.py
+++ b/ai/services/side_panel_generator.py
@@ -52,6 +52,13 @@ def _coerce(value: Any, default: str = _NONE_LABEL) -> str:
     return str(value)
 
 
+def _format_constraints(constraints: Optional[list[str]]) -> str:
+    """list[str] 제약사항을 프롬프트용 들여쓰기 리스트로 포맷팅."""
+    if not constraints:
+        return _NONE_LABEL
+    return "\n".join(f"  - {c}" for c in constraints)
+
+
 class SidePanelGenerator:
     """side_panel 시나리오 — 일반 Step 사이드패널 콘텐츠 동적 생성."""
 
@@ -98,7 +105,7 @@ class SidePanelGenerator:
             duration_months=str(project.duration_months),
             member_count=str(project.member_count),
             description=_coerce(project.description),
-            constraints=_coerce(project.constraints),
+            constraints=_format_constraints(project.constraints),
             initial_prompt=project.initial_prompt,
             stage_sequence=str(stage.stage_sequence),
             stage_name=stage.name,

--- a/ai/services/side_panel_generator.py
+++ b/ai/services/side_panel_generator.py
@@ -53,10 +53,15 @@ def _coerce(value: Any, default: str = _NONE_LABEL) -> str:
 
 
 def _format_constraints(constraints: Optional[list[str]]) -> str:
-    """list[str] 제약사항을 프롬프트용 들여쓰기 리스트로 포맷팅."""
+    """list[str] 제약사항을 프롬프트용 들여쓰기 리스트로 포맷팅.
+
+    선두에 줄바꿈을 두어 템플릿의 라벨(`- 제약사항: {constraints}`) 뒤에
+    첫 항목이 한 줄로 붙는 것을 방지한다. 모든 항목이 동일하게
+    `  - {item}` 형태로 들여쓰기되어 시각적·LLM 인식 일관성을 갖는다.
+    """
     if not constraints:
         return _NONE_LABEL
-    return "\n".join(f"  - {c}" for c in constraints)
+    return "\n" + "\n".join(f"  - {c}" for c in constraints)
 
 
 class SidePanelGenerator:

--- a/ai/services/step_generator.py
+++ b/ai/services/step_generator.py
@@ -37,10 +37,15 @@ def _coerce(value: Any, default: str = "") -> str:
 
 
 def _format_constraints(constraints: Optional[list[str]]) -> str:
-    """list[str] 제약사항을 프롬프트용 들여쓰기 리스트로 포맷팅."""
+    """list[str] 제약사항을 프롬프트용 들여쓰기 리스트로 포맷팅.
+
+    선두에 줄바꿈을 두어 템플릿의 라벨(`- 제약사항: {constraints}`) 뒤에
+    첫 항목이 한 줄로 붙는 것을 방지한다. 모든 항목이 동일하게
+    `  - {item}` 형태로 들여쓰기되어 시각적·LLM 인식 일관성을 갖는다.
+    """
     if not constraints:
         return _NONE_LABEL
-    return "\n".join(f"  - {c}" for c in constraints)
+    return "\n" + "\n".join(f"  - {c}" for c in constraints)
 
 
 class StepGenerator:

--- a/ai/services/step_generator.py
+++ b/ai/services/step_generator.py
@@ -36,6 +36,13 @@ def _coerce(value: Any, default: str = "") -> str:
     return str(value)
 
 
+def _format_constraints(constraints: Optional[list[str]]) -> str:
+    """list[str] 제약사항을 프롬프트용 들여쓰기 리스트로 포맷팅."""
+    if not constraints:
+        return _NONE_LABEL
+    return "\n".join(f"  - {c}" for c in constraints)
+
+
 class StepGenerator:
     """generate 시나리오 — 일반 Step 3개 동적 생성."""
 
@@ -88,7 +95,7 @@ class StepGenerator:
             duration_months=str(project.duration_months),
             member_count=str(project.member_count),
             description=_coerce(project.description, _NONE_LABEL),
-            constraints=_coerce(project.constraints, _NONE_LABEL),
+            constraints=_format_constraints(project.constraints),
             initial_prompt=project.initial_prompt,
             stage_sequence=str(stage.stage_sequence),
             stage_name=stage.name,

--- a/ai/tests/test_orchestrator.py
+++ b/ai/tests/test_orchestrator.py
@@ -47,7 +47,7 @@ def _project() -> ProjectInfo:
         duration_months=3,
         member_count=4,
         description="설명",
-        constraints="React + FastAPI",
+        constraints=["React + FastAPI"],
         initial_prompt="초기 아이디어",
     )
 

--- a/ai/tests/test_required_step_judge.py
+++ b/ai/tests/test_required_step_judge.py
@@ -30,7 +30,7 @@ def _project() -> ProjectInfo:
         duration_months=3,
         member_count=4,
         description="대학생용 스터디 매칭",
-        constraints="React + FastAPI",
+        constraints=["React + FastAPI"],
         initial_prompt="스터디 메이트 매칭 서비스를 만들고 싶음",
     )
 

--- a/ai/tests/test_schemas.py
+++ b/ai/tests/test_schemas.py
@@ -65,7 +65,7 @@ class TestProjectInfo:
         assert m.name is None
 
     def test_optional_fields_accepted(self):
-        m = ProjectInfo(**PROJECT_INFO, name="Poco", description="설명", constraints="제약")
+        m = ProjectInfo(**PROJECT_INFO, name="Poco", description="설명", constraints=["제약"])
         assert m.name == "Poco"
 
     @pytest.mark.parametrize("missing", ["project_id", "duration_months", "member_count", "initial_prompt"])

--- a/ai/tests/test_side_panel_generator.py
+++ b/ai/tests/test_side_panel_generator.py
@@ -35,7 +35,7 @@ def _project() -> ProjectInfo:
         duration_months=3,
         member_count=4,
         description="배달 라이더 경로 비효율 문제 해결",
-        constraints="React + FastAPI",
+        constraints=["React + FastAPI"],
         initial_prompt="배달 라이더 경로 최적화 서비스를 만들고 싶음",
     )
 

--- a/ai/tests/test_side_panel_generator_stream.py
+++ b/ai/tests/test_side_panel_generator_stream.py
@@ -34,7 +34,7 @@ def _project() -> ProjectInfo:
         duration_months=3,
         member_count=4,
         description="배달 라이더 경로 비효율 문제 해결",
-        constraints="React + FastAPI",
+        constraints=["React + FastAPI"],
         initial_prompt="배달 라이더 경로 최적화 서비스를 만들고 싶음",
     )
 

--- a/ai/tests/test_step_generator.py
+++ b/ai/tests/test_step_generator.py
@@ -32,7 +32,7 @@ def _project() -> ProjectInfo:
         duration_months=3,
         member_count=4,
         description="대학생용 스터디 매칭",
-        constraints="React + FastAPI",
+        constraints=["React + FastAPI"],
         initial_prompt="스터디 메이트 매칭 서비스를 만들고 싶음",
     )
 


### PR DESCRIPTION
## PR 요약
- 백엔드의 제약사항 입력 방식 변경(자유 텍스트 → 칩 + 추가 정책)에 맞춰 AI 모듈 스키마를 `Optional[str]` → `Optional[list[str]]`로 전환
- 3개 서비스의 프롬프트 렌더 헬퍼 추가 + 모든 fixture·테스트 데이터 일괄 업데이트
- CloudShell 실측: 리스트 입력으로 정상 응답 확인, 들여쓰기 일관성 보강

## 변경 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

**0c1f404 — constraints str → list[str] 전환**

| 영역 | 변경 |
|---|---|
| `ai/schemas/common.py` | `ProjectInfo.constraints: Optional[str]` → `Optional[list[str]]` |
| `ai/services/step_generator.py` | `_format_constraints()` 헬퍼 추가 + 렌더 호출 교체 |
| `ai/services/side_panel_generator.py` | 동일 패턴 |
| `ai/services/required_step_judge.py` | constraints 미사용 (수정 불필요) |
| `ai/cli_simulator.py` | 콤마 split으로 list 변환, 빈 입력 시 `None` |
| `ai/latency_simulator.py` | fixture `constraints=["..."]` |
| `ai/tests/*.py` (6개 파일) | 모든 fixture `constraints="..."` → `[...]` |

**3073272 — 들여쓰기 일관성 보강**
- `_format_constraints` 선두에 `\n` 추가 → 템플릿 라벨(`- 제약사항: {constraints}`) 뒤 첫 항목이 한 줄로 붙는 문제 해소
- 모든 항목이 동일하게 `  - {item}` 형태로 렌더되도록 통일

**테스트**
- `pytest ai/tests/ -q` → **288 passed** (회귀 없음)
- 두 커밋 모두 회귀 없음 검증 완료

**유지된 항목**
- 프롬프트 템플릿(`ai/prompts/*.txt`) 무변경
- JSON 출력 스키마 무변경
- 다른 ProjectInfo 필드(name, description, member_count, duration_months, initial_prompt) 무변경

## 실측 결과 (CloudShell, Haiku 4.5)

리스트 입력으로 호출 시 프롬프트 렌더 정상:

```
- 제약사항: 
  - 기술 스택은 React + FastAPI로 제한
  - AWS 크레딧 활용 가능
  - 외주 사용 불가
```

생성된 Step 3개 정상 (예시):
- 라이더 불편 상황 조사
- 기존 배달앱 경로 기능 분석
- 경로 최적화로 인한 효과 추정

JSON 파싱 에러 0건, 응답 시간 회귀 없음.

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항

- **백엔드 동기화 필요**: 백엔드도 `constraints` 필드 타입을 `list[str]`로 전환해야 함. 진행 중 호출에서는 *"기존 항목 변경/삭제 거부, 추가만 허용"* 정책 별도 구현 필요 (별도 이슈)
- **프론트 동기화 필요**: 생성 화면 칩 UI + 수정 모달 잠금/추가만 정책 (별도 이슈)
- 영향 범위: AI 모듈만. 공개 4개 함수의 시그니처는 그대로 (입력 타입만 list로 받음)
- Related:
  - PR #117, #118, #120, #125, #154, #163 (AI 모듈 누적 작업)