### PR TITLE
[#176][FE] 프로젝트 정보 입력 및 수정 화면 변경

### DIFF
--- a/frontend/src/pages/CreateProjectPage.jsx
+++ b/frontend/src/pages/CreateProjectPage.jsx
@@ -13,33 +13,41 @@ export default function CreateProjectPage() {
   const [name, setName] = useState('')
   const [memberCount, setMemberCount] = useState('')
   const [noDuration, setNoDuration] = useState(false)
+  const [durationMonth, setDurationMonth] = useState('')
   const [description, setDescription] = useState('')
-  const [constraint, setConstraint] = useState('')
+  const [constraints, setConstraints] = useState([])
+  const [constraintInput, setConstraintInput] = useState('')
   const [prompt, setPrompt] = useState('')
   const [loading, setLoading] = useState(false)
-  const [durationMonth, setDurationMonth] = useState('')
+  const [constraintError, setConstraintError] = useState('')
 
+  function handleAddConstraint() {
+    const trimmed = constraintInput.trim()
+    if (!trimmed || constraints.includes(trimmed)) return
+    if (trimmed.length > 50) { setConstraintError('제약 사항은 50자 이하로 입력해주세요.'); return }
+    if (constraints.length >= 10) { setConstraintError('제약 사항은 최대 10개까지 추가할 수 있어요.'); return }
+    setConstraints([...constraints, trimmed])
+    setConstraintInput('')
+    setConstraintError('')
+  }
+
+  function handleConstraintKeyDown(e) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleAddConstraint()
+    }
+  }
 
   function handleNext(e) {
     e.preventDefault()
-    if (!memberCount) {
-      alert('프로젝트 인원을 선택해주세요.')
-      return
-    }
-    if (!noDuration && !durationMonth) {
-      alert('프로젝트 기간을 선택해주세요.')
-      return
-    }
+    if (!memberCount) { alert('프로젝트 인원을 선택해주세요.'); return }
+    if (!noDuration && !durationMonth) { alert('프로젝트 기간을 선택해주세요.'); return }
     setStep(2)
   }
 
   async function handleSubmit(e) {
     e.preventDefault()
-    if (!prompt.trim()) {
-      alert('현재 상황을 입력해주세요.')
-      return
-      
-    }
+    if (!prompt.trim()) { alert('현재 상황을 입력해주세요.'); return }
     setLoading(true)
     try {
       const project = await createProject({
@@ -47,11 +55,10 @@ export default function CreateProjectPage() {
         member_count: Number(memberCount),
         duration_months: noDuration ? 0 : Number(durationMonth),
         description: description.trim() || null,
-        constraint: constraint.trim() || null,
+        constraint: constraints.length > 0 ? constraints : null,
         prompt: prompt.trim(),
       })
       navigate(`/canvas/${project.project_id}`, { state: { projectName: name.trim() || 'Project' } })
-
     } catch (err) {
       alert('생성 실패: ' + (err.message ?? '알 수 없는 오류'))
     } finally {
@@ -61,18 +68,14 @@ export default function CreateProjectPage() {
 
   const Logo = (
     <Link to="/projects">
-      <div className={styles.logo}>
-        <span>poco</span>
-      </div>
+      <div className={styles.logo}><span>poco</span></div>
     </Link>
   )
 
   if (step === 1) {
     return (
       <div className={styles.page}>
-        <nav className={styles.nav}>
-          {Logo}
-        </nav>
+        <nav className={styles.nav}>{Logo}</nav>
 
         <div className={styles.content}>
           <h1 className={styles.title}>
@@ -83,9 +86,14 @@ export default function CreateProjectPage() {
           </h1>
 
           <div className={styles.formWrapper}>
-            <p className={styles.subtitle}>프로젝트 정보(이름, 인원, 기간 등)를 적어주세요.</p>
+            <p className={styles.subtitle}>
+              프로젝트 정보를 적어주세요.
+              <br />
+              <span className={styles.subtitleWarn}>한 번 정한 이후엔 인원·기간·제약사항을 자유롭게 바꾸기 어려워요.</span>
+            </p>
 
             <form className={styles.form} onSubmit={handleNext}>
+              {/* 이름 */}
               <div className={styles.field}>
                 <label className={styles.label}>프로젝트 이름</label>
                 <input
@@ -98,29 +106,18 @@ export default function CreateProjectPage() {
                 />
               </div>
 
+              {/* 인원 */}
               <div className={styles.field}>
-                <label className={styles.label}>
-                  프로젝트 인원 <span className={styles.required}>*</span>
-                </label>
-                <select
-                  className={styles.select}
-                  required
-                  value={memberCount}
-                  onChange={(e) => setMemberCount(e.target.value)}
-                >
-                  <option value="" disabled>
-                    1 ~ 20명
-                  </option>
-                  {members.map((m) => (
-                    <option key={m} value={m}>{m}명</option>
-                  ))}
+                <label className={styles.label}>프로젝트 인원 <span className={styles.required}>*</span></label>
+                <select className={styles.select} required value={memberCount} onChange={(e) => setMemberCount(e.target.value)}>
+                  <option value="" disabled>1 ~ 20명</option>
+                  {members.map((m) => <option key={m} value={m}>{m}명</option>)}
                 </select>
               </div>
 
+              {/* 기간 */}
               <div className={styles.field}>
-                <label className={styles.label}>
-                  프로젝트 기간 <span className={styles.required}>*</span>
-                </label>
+                <label className={styles.label}>프로젝트 기간 <span className={styles.required}>*</span></label>
                 <div className={styles.durationRow}>
                   <select
                     className={styles.select}
@@ -128,49 +125,80 @@ export default function CreateProjectPage() {
                     value={durationMonth}
                     onChange={(e) => setDurationMonth(e.target.value)}
                   >
-                    <option value="" disabled>
-                      1 ~ 12개월
-                    </option>
-                    {durations.map((d) => (
-                      <option key={d} value={d}>{d}개월</option>
-                    ))}
+                    <option value="" disabled>1 ~ 12개월</option>
+                    {durations.map((d) => <option key={d} value={d}>{d}개월</option>)}
                   </select>
                   <label className={styles.checkboxLabel}>
                     <input
                       type="checkbox"
                       checked={noDuration}
-                      onChange={(e) => {
-                        setNoDuration(e.target.checked)
-                        if (e.target.checked) setDurationMonth('')
-                      }}
+                      onChange={(e) => { setNoDuration(e.target.checked); if (e.target.checked) setDurationMonth('') }}
                     />
                     기간 없음
                   </label>
                 </div>
               </div>
 
+              {/* 설명 */}
               <div className={styles.field}>
-                <label className={styles.label}>프로젝트 설명</label>
+                <div className={styles.labelRow}>
+                  <label className={styles.label}>프로젝트 설명</label>
+                  <span className={styles.charCount}>{description.length} / 100자</span>
+                </div>
                 <textarea
-                  className={styles.textarea}
+                  className={`${styles.input} ${styles.inputAutoResize}`}
+                  maxLength={100}
+                  placeholder="예: 배달 라이더의 경로 비효율을 해결하는 AI 모바일 앱"
                   value={description}
-                  onChange={(e) => setDescription(e.target.value)}
+                  onChange={(e) => {
+                    setDescription(e.target.value)
+                    e.target.style.height = 'auto'
+                    e.target.style.height = e.target.scrollHeight + 'px'
+                  }}
+                  rows={1}
                 />
+                <p className={styles.hint}>💡 한 줄로 짧게! 외부에 이 프로젝트를 소개할 때 쓰는 부제 같은 거예요.</p>
               </div>
 
+              {/* 제약 사항 */}
               <div className={styles.field}>
                 <label className={styles.label}>프로젝트 제약 사항</label>
-                <textarea
-                  className={styles.textarea}
-                  value={constraint}
-                  onChange={(e) => setConstraint(e.target.value)}
-                />
+                <div className={styles.chipInputRow}>
+                  <input
+                    className={styles.input}
+                    type="text"
+                    placeholder="제약 사항 입력 후 추가"
+                    value={constraintInput}
+                    onChange={(e) => setConstraintInput(e.target.value)}
+                    onKeyDown={handleConstraintKeyDown}
+                  />
+                  <button type="button" className={styles.addChipBtn} onClick={handleAddConstraint}>
+                    +
+                  </button>
+                </div>
+                {constraints.length > 0 && (
+                  <div className={styles.chipList}>
+                    {constraints.map((c, i) => (
+                      <span key={i} className={styles.chip}>
+                        {c}
+                        <button
+                          type="button"
+                          className={styles.chipRemove}
+                          onClick={() => setConstraints(constraints.filter((_, j) => j !== i))}
+                        >✕</button>
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {constraintError && <p className={styles.errorMsg}>{constraintError}</p>}
+                <p className={styles.hint}>
+                  💡 이 프로젝트의 한계나 제약을 적어주세요. 시작 후엔 추가만 가능해요!<br />
+                  예: "AWS ElastiCache 금지", "React로 제한", "AWS 크레딧 활용 가능"
+                </p>
               </div>
 
               <div className={styles.actions}>
-                <button type="submit" className={styles.btnPrimary}>
-                  다음으로 이동 →
-                </button>
+                <button type="submit" className={styles.btnPrimary}>다음으로 이동 →</button>
               </div>
             </form>
           </div>
@@ -183,13 +211,8 @@ export default function CreateProjectPage() {
     <div className={styles.page}>
       <nav className={styles.nav}>
         {Logo}
-        <button
-          type="button"
-          className={styles.btnBack}
-          onClick={() => setStep(1)}
-        >
-          
-          <span> {'<'} </span> 이전으로
+        <button type="button" className={styles.btnBack} onClick={() => setStep(1)}>
+          <span>{'<'}</span> 이전으로
         </button>
       </nav>
 
@@ -201,28 +224,39 @@ export default function CreateProjectPage() {
           <span className={styles.titleDark}>적어주세요!</span>
         </h1>
 
-        <p className={styles.subtitleCenter}>
-          상황에 맞춰 poco가 단계별 프로젝트를 설계해드릴게요.
-        </p>
+        <p className={styles.subtitleCenter}>상황에 맞춰 poco가 단계별 프로젝트를 설계해드릴게요.</p>
 
         <form className={styles.promptForm} onSubmit={handleSubmit}>
           <div className={styles.promptCard}>
             <textarea
               className={styles.promptTextarea}
               required
-              placeholder="예) 현재 팀원 3명이서 2개월 동안 캡스톤 프로젝트를 진행해야해. 주제는 아직 정하지 않았지만 대학생과 관련한 걸로 하고 싶어."
+              maxLength={500}
+              placeholder="여기에 자유롭게 적어주세요."
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
             />
             <div className={styles.promptActions}>
-              <button
-                type="submit"
-                className={styles.createBtn}
-                disabled={loading}
-              >
+              <span className={styles.promptCounter}>{prompt.length} / 500자</span>
+              <button type="submit" className={styles.createBtn} disabled={loading}>
                 {loading ? '생성 중...' : '프로젝트 생성 →'}
               </button>
             </div>
+          </div>
+
+          <div className={styles.promptExamples}>
+            <p className={styles.promptExampleItem}>
+              예 1) 배달 라이더의 경로 비효율 문제를 AI로 해결하는 앱을 만들고 싶어요. 아직 어떤 기술을 쓸지는 모르지만, 라이더의 시간 절약이 핵심이에요.<br />
+             
+            </p>
+            <p className={styles.promptExampleItem}>
+              예 2) 뭘 만들지 정하지 못했어요. 평소에 일정 관리가 어려워서 뭔가 도와주는 서비스가 있으면 좋겠다 정도? 친구들 4명이서 졸업작품으로 시작해보려고요.<br />
+              
+            </p>
+            <p className={styles.promptTip}>
+              💡 친구한테 "이런 거 만들어보려고…" 하고 얘기한다 생각하고 풀어보세요. 디테일은 poco와 진행하면서 단계별로 정리해 나가요!<br />
+              
+            </p>
           </div>
         </form>
       </div>

--- a/frontend/src/pages/CreateProjectPage.module.css
+++ b/frontend/src/pages/CreateProjectPage.module.css
@@ -241,7 +241,7 @@
   font-family: var(--font-family);
   font-size: 14px;
   color: var(--color-text);
-  line-height: 1.7;
+  line-height: 1.8;
   background: transparent;
 }
 
@@ -341,4 +341,129 @@
   font-weight: 700;
   color: var(--color-primary);
   cursor: default;
+}
+
+.subtitleWarn {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  font-weight: 400;
+}
+
+.inputAutoResize {
+  resize: none;
+  overflow: hidden;
+  line-height: 1.6;
+  min-height: 100px;
+}
+
+.labelRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.charCount {
+  font-size: 12px;
+  color: var(--color-text-disabled);
+}
+
+.hint {
+  font-size: 12px;
+  font-weight: 450;
+  color: var(--color-text-disabled);
+  line-height: 1.8;
+  margin-top: 4px;
+}
+
+.chipInputRow {
+  display: flex;
+  gap: 8px;
+}
+
+.chipInputRow .input {
+  flex: 1;
+}
+
+.addChipBtn {
+  padding: 5px 10px;
+  background: var(--color-primary-light);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: var(--font-family);
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s;
+}
+
+.addChipBtn:hover {
+  background: var(--color-primary-hover);
+}
+
+.chipList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  background: #e6e4ff;
+  color: var(--color-text);
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.chipRemove {
+  background: none;
+  border: none;
+  color: #B5B0D8;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.chipRemove:hover {
+  color: var(--color-error);
+}
+
+.promptCounter {
+  font-size: 12px;
+  color: var(--color-text-disabled);
+  margin-right: 4px;
+}
+
+.promptExamples {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 660px;
+  width: 100%;
+}
+
+.promptExampleItem {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.8;
+}
+
+.promptTip {
+  font-size: 12px;
+  color: var(--color-text-disabled);
+  line-height: 1.8;
+}
+
+.errorMsg {
+  font-size: 12px;
+  color: var(--color-error);
+  margin-top: 4px;
 }

--- a/frontend/src/pages/ProjectListPage.jsx
+++ b/frontend/src/pages/ProjectListPage.jsx
@@ -32,6 +32,9 @@ export default function ProjectListPage() {
   const [editData, setEditData] = useState({})
   const [deleteModal, setDeleteModal] = useState(null)
   const [toast, setToast] = useState(null)
+
+  const [constraintInput, setConstraintInput] = useState('')
+  const [editConstraints, setEditConstraints] = useState([])
   
   useEffect(() => {
     getProjects({ page, size, sort_by: sortBy, is_deleted: false }).then((data) => {
@@ -59,12 +62,30 @@ export default function ProjectListPage() {
     setOpenMenuId(null)
     setInfoModal(project)
     setIsEditing(false)
+    setConstraintInput('')
+    setEditConstraints(project.constraints ?? [])
     setEditData({
       name: project.name ?? '',
-      member_count: project.member_count ?? '',
-      duration_month: project.duration_month ?? '',
       description: project.description ?? '',
-      constraint: project.constraint ?? '',
+    })
+  }
+
+  function handleAddModalConstraint() {
+    const trimmed = constraintInput.trim()
+    if (!trimmed || editConstraints.includes(trimmed)) return
+    if (trimmed.length > 50) { showToast('제약 사항은 50자 이하로 입력해주세요.'); return }
+    if (editConstraints.length >= 10) { showToast('제약 사항은 최대 10개까지 추가할 수 있어요.'); return }
+    setEditConstraints([...editConstraints, trimmed])
+    setConstraintInput('')
+  }
+
+  function handleCancelEdit() {
+    setIsEditing(false)
+    setConstraintInput('')
+    setEditConstraints(infoModal.constraints ?? [])
+    setEditData({
+      name: infoModal.name ?? '',
+      description: infoModal.description ?? '',
     })
   }
 
@@ -80,16 +101,14 @@ export default function ProjectListPage() {
   }
 
   async function handleSaveInfo() {
-    const memberCount = Number(editData.member_count)
-    const durationMonth = Number(editData.duration_month)
-
     try {
+      const existingConstraints = infoModal.constraints ?? []
+      const added = editConstraints.filter((c) => !existingConstraints.includes(c))
+
       await updateProject(infoModal.project_id, {
         name: editData.name || null,
-        member_count: editData.member_count ? memberCount : null,
-        duration_months: editData.duration_month ? durationMonth : null,
         description: editData.description || null,
-        constraint: editData.constraint || null,
+        new_constraints: added.length > 0 ? added : null,
       })
     } catch {
       showToast('수정에 실패했어요. 다시 시도해주세요.')
@@ -98,11 +117,10 @@ export default function ProjectListPage() {
 
     setProjects(projects.map((p) =>
       p.project_id === infoModal.project_id
-        ? { ...p, ...editData, name: editData.name || null }
+        ? { ...p, name: editData.name || null, description: editData.description || null, constraints: editConstraints }
         : p
     ))
-
-    setInfoModal((prev) => ({ ...prev, ...editData, name: editData.name || null }))
+    setInfoModal((prev) => ({ ...prev, name: editData.name || null, description: editData.description || null, constraints: editConstraints }))
     setIsEditing(false)
   }
 
@@ -296,63 +314,114 @@ export default function ProjectListPage() {
             </div>
 
             <div className={styles.infoTable}>
-              {[
-                { label: '프로젝트 이름', key: 'name', type: 'input', maxLength: 20 },
-                { label: '프로젝트 인원', key: 'member_count', type: 'select', suffix: '명',
-                  options: Array.from({ length: 20 }, (_, i) => i + 1) },
-                { label: '프로젝트 기간', key: 'duration_month', type: 'select', suffix: '개월',
-                  options: Array.from({ length: 12 }, (_, i) => i + 1) },
-                { label: '프로젝트 설명', key: 'description', type: 'textarea' },
-                { label: '프로젝트 제약 사항', key: 'constraint', type: 'textarea' },
-              ].map(({ label, key, type, inputType, suffix, maxLength, options }) => (
-                <div key={key} className={styles.infoRow}>
-                  <span className={styles.infoLabel}>{label}</span>
-                  {isEditing ? (
-                    type === 'textarea' ? (
-                      <textarea
-                        className={styles.infoTextarea}
-                        value={editData[key] ?? ''}
-                        onChange={(e) => setEditData({ ...editData, [key]: e.target.value })}
-                      />
-                    ) : type === 'select' ? (
-                      <select
-                        className={styles.infoInput}
-                        value={editData[key] ?? ''}
-                        onChange={(e) => setEditData({ ...editData, [key]: e.target.value })}
-                      >
-                        <option value="">-</option>
-                        {options.map((o) => (
-                          <option key={o} value={o}>{o}{suffix}</option>
-                        ))}
-                      </select>
-                    ) : (
+              {/* 이름 */}
+              <div className={`${styles.infoRow} ${styles.infoRowTop}`}>
+                <span className={styles.infoLabel}>프로젝트 이름</span>
+                {isEditing ? (
+                  <div className={styles.infoEditCol}>
+                    <input
+                      className={styles.infoInput}
+                      type="text"
+                      maxLength={20}
+                      value={editData.name ?? ''}
+                      onChange={(e) => setEditData({ ...editData, name: e.target.value })}
+                    />
+                    <span className={styles.infoCharCount}>{(editData.name ?? '').length} / 20자</span>
+                  </div>
+                ) : (
+                  <span className={styles.infoValue}>{infoModal.name || '-'}</span>
+                )}
+              </div>
+
+              {/* 설명 */}
+              <div className={`${styles.infoRow} ${styles.infoRowTop}`}>
+                <span className={styles.infoLabel}>프로젝트 설명</span>
+                {isEditing ? (
+                  <div className={styles.infoEditCol}>
+                    <input
+                      className={styles.infoInput}
+                      type="text"
+                      maxLength={100}
+                      value={editData.description ?? ''}
+                      onChange={(e) => setEditData({ ...editData, description: e.target.value })}
+                    />
+                    <span className={styles.infoCharCount}>{(editData.description ?? '').length} / 100자</span>
+                  </div>
+                ) : (
+                  <span className={styles.infoValue}>{infoModal.description || '-'}</span>
+                )}
+              </div>
+
+              {/* 인원 - 잠김 */}
+              <div className={styles.infoRow}>
+                <span className={styles.infoLabel}>프로젝트 인원</span>
+                <span className={`${styles.infoValue} ${isEditing ? styles.infoLocked : ''}`}>
+                  {infoModal.member_count ? `${infoModal.member_count}명` : '-'}
+                  {isEditing && <span className={styles.lockBadge}>🔒</span>}
+                </span>
+              </div>
+
+              {/* 기간 - 잠김 */}
+              <div className={styles.infoRow}>
+                <span className={styles.infoLabel}>프로젝트 기간</span>
+                <span className={`${styles.infoValue} ${isEditing ? styles.infoLocked : ''}`}>
+                  {infoModal.duration_month === 0
+                    ? '기간 없음'
+                    : infoModal.duration_month
+                    ? `${infoModal.duration_month}개월`
+                    : '-'}
+                  {isEditing && <span className={styles.lockBadge}>🔒</span>}
+                </span>
+              </div>
+
+              {/* 제약 사항 */}
+              <div className={`${styles.infoRow} ${styles.infoRowTop}`}>
+                <span className={styles.infoLabel}>제약 사항</span>
+                <div className={styles.infoConstraintCol}>
+                  {isEditing && (
+                    <div className={styles.chipInputRow}>
                       <input
                         className={styles.infoInput}
-                        type={inputType ?? 'text'}
-                        value={editData[key] ?? ''}
-                        maxLength={maxLength}
-                        onChange={(e) => setEditData({ ...editData, [key]: e.target.value })}
+                        type="text"
+                        placeholder="제약 추가 후 Enter"
+                        value={constraintInput}
+                        onChange={(e) => setConstraintInput(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleAddModalConstraint() } }}
                       />
-                    )
-                  ) : (
-                    <span className={styles.infoValue}>
-                      {infoModal[key] ? `${infoModal[key]}${suffix ?? ''}` : '-'}
-                    </span>
+                      <button type="button" className={styles.addChipBtn} onClick={handleAddModalConstraint}>
+                        +
+                      </button>
+                    </div>
+                  )}
+                  {editConstraints.length > 0 && (
+                    <div className={styles.chipList}>
+                      {editConstraints.map((c, i) => (
+                        <span key={i} className={styles.chip}>{c}</span>
+                      ))}
+                    </div>
+                  )}
+                  {!isEditing && editConstraints.length === 0 && (
+                    <span className={styles.infoValue}>-</span>
                   )}
                 </div>
-              ))}
-            </div>
-
+              </div>
+            </div>     
             <div className={styles.promptSection}>
               <p className={styles.promptLabel}>프로젝트 프롬프트</p>
               <p className={styles.promptText}>{infoModal.prompt ?? '-'}</p>
             </div>
 
             {isEditing && (
-              <div className={styles.modalFooter}>
-                <button className={styles.cancelBtn} onClick={() => setIsEditing(false)}>취소</button>
-                <button className={styles.saveBtn} onClick={handleSaveInfo}>저장</button>
-              </div>
+              <>
+                <p className={styles.editInfoTip}>
+                  💡 수정한 내용은 즉시 반영돼서, 다음에 만들어지는 Step부터 새 정보를 기반으로 추천돼요.<br />
+                  이전에 진행한 결정들은 그대로 보존되니 걱정하지 않으셔도 돼요!
+                </p>
+                <div className={styles.modalFooter}>
+                  <button className={styles.cancelBtn} onClick={handleCancelEdit}>취소</button>
+                  <button className={styles.saveBtn} onClick={handleSaveInfo}>저장</button>
+                </div>
+              </>
             )}
           </div>
         </div>

--- a/frontend/src/pages/ProjectListPage.module.css
+++ b/frontend/src/pages/ProjectListPage.module.css
@@ -496,8 +496,8 @@
 
 .infoRow {
   display: grid;
-  grid-template-columns: 130px 1fr;
-  align-items: center;
+  grid-template-columns: 110px 1fr;
+  align-items: start;  /* center → start */
   padding: 12px 0;
   gap: 12px;
 }
@@ -506,6 +506,11 @@
   font-size: 13px;
   color: var(--color-text-secondary);
   flex-shrink: 0;
+}
+
+.infoRowTop {
+  padding-top: -10px;
+  align-items: start;
 }
 
 .infoValue {
@@ -664,4 +669,94 @@
   5%   { opacity: 1; transform: translateX(-50%) translateY(0); }
   82%  { opacity: 1; }
   100% { opacity: 0; }
+}
+
+.infoEditCol {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  width: 100%;
+}
+
+.infoCharCount {
+  font-size: 11px;
+  color: var(--color-text-disabled);
+  text-align: right;
+}
+
+.infoLocked {
+  color: var(--color-text-disabled);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.lockBadge {
+  font-size: 11px;
+  color: var(--color-text-disabled);
+  background: #F4F3FB;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.infoConstraintCol {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.chipInputRow {
+  display: flex;
+  gap: 6px;
+}
+
+.chipInputRow .infoInput {
+  flex: 1;
+}
+
+.addChipBtn {
+  padding: 0 12px;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 12px;
+  font-family: var(--font-family);
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s;
+}
+
+.addChipBtn:hover {
+  background: var(--color-primary-hover);
+}
+
+.chipList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  background: #EEEDF8;
+  color: var(--color-primary);
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.editInfoTip {
+  font-size: 12px;
+  color: var(--color-text-disabled);
+  line-height: 1.7;
+  padding: 12px 16px;
+  background: #F7F6FF;
+  border-radius: 8px;
+  margin: 0 0 4px;
 }


### PR DESCRIPTION
## 요약
- 프로젝트 생성 Step 1: 설명 필드 자동 높이 조절, 제약사항 칩 UI 적용, 자수 카운터 추가
- 프로젝트 생성 Step 2: 500자 카운터, 예시/팁 고정 표시
- 프로젝트 정보 수정 모달: 인원·기간 잠금, 제약사항 추가 전용 칩 UI, 자수 카운터, 하단 안내문
- 제약사항 50자 초과 / 10개 초과 에러 처리

## 변경 유형
- [x] 새로운 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 변경 사항
- `CreateProjectPage`: constraints string[] 전송, 제약사항 칩 UI
- `ProjectListPage`: 정보 수정 모달 인원·기간 잠금, 제약사항 추가만 가능, constraints 배열 대응

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영
