### PR TITLE
[#80][FE] step 생성 UI 개선

### DIFF
--- a/frontend/src/components/canvas/GhostEdge.jsx
+++ b/frontend/src/components/canvas/GhostEdge.jsx
@@ -1,0 +1,24 @@
+import { getBezierPath } from '@xyflow/react'
+import { motion } from 'framer-motion'
+
+export default function GhostEdge({
+  sourceX, sourceY, targetX, targetY,
+  sourcePosition, targetPosition,
+}) {
+  const [edgePath] = getBezierPath({
+    sourceX, sourceY, sourcePosition,
+    targetX, targetY, targetPosition,
+  })
+
+  return (
+    <motion.path
+      d={edgePath}
+      fill="none"
+      stroke="#C5BDFB"
+      strokeWidth={1.5}
+      initial={{ pathLength: 0, opacity: 0 }}
+      animate={{ pathLength: 1, opacity: 1 }}
+      transition={{ duration: 0.7, ease: 'easeOut' }}
+    />
+  )
+}

--- a/frontend/src/components/canvas/GhostNode.jsx
+++ b/frontend/src/components/canvas/GhostNode.jsx
@@ -1,0 +1,25 @@
+import { Handle, Position } from '@xyflow/react'
+import { motion } from 'framer-motion'
+import styles from './GhostNode.module.css'
+
+export default function GhostNode({ data }) {
+  const { isExiting = false } = data
+
+  return (
+    <motion.div
+      className={styles.wrapper}
+      initial={{ opacity: 0 }}
+      animate={isExiting ? { opacity: 0 } : { opacity: 1 }}
+      transition={{ duration: 0.25, delay: 0.5 }}
+    >
+      <div className={styles.stageRow}>
+        <div className={styles.stageSkeletonLine} />
+      </div>
+      <div className={styles.node}>
+        <Handle type="target" position={Position.Left} style={{ opacity: 0, left: 3, top: '60%' }} />
+        <div className={styles.skeletonLine} />
+        <Handle type="source" position={Position.Right} style={{ opacity: 0, right: 3, top: '60%' }} />
+      </div>
+    </motion.div>
+  )
+}

--- a/frontend/src/components/canvas/GhostNode.jsx
+++ b/frontend/src/components/canvas/GhostNode.jsx
@@ -10,7 +10,7 @@ export default function GhostNode({ data }) {
       className={styles.wrapper}
       initial={{ opacity: 0 }}
       animate={isExiting ? { opacity: 0 } : { opacity: 1 }}
-      transition={{ duration: 0.25, delay: 0.5 }}
+      transition={{ duration: 0.25, delay: 0.6 }}
     >
       <div className={styles.stageRow}>
         <div className={styles.stageSkeletonLine} />

--- a/frontend/src/components/canvas/GhostNode.module.css
+++ b/frontend/src/components/canvas/GhostNode.module.css
@@ -1,0 +1,49 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.node {
+  width: 180px;
+  min-height: 70px;
+  background: #FFFFFF;
+  border: 1.5px solid #E2DFFE;
+  border-left: 4px solid #9092B8;
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(92, 69, 232, 0.06);
+}
+
+.skeletonLine {
+  height: 18px;
+  width: 75%;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #E2DFFE 25%, #C5BDFB 50%, #E2DFFE 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.8s infinite;
+}
+
+@keyframes shimmer {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
+
+.stageRow {
+  font-size: 20px;  /* stageNumber랑 동일하게 → 높이 자동 일치 */
+  padding-left: 9px;
+  padding-bottom: 4px;
+}
+
+.stageSkeletonLine {
+  height: 11px;
+  width: 40px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #E2DFFE 25%, #C5BDFB 50%, #E2DFFE 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s infinite 0.1s;
+}

--- a/frontend/src/components/canvas/NewEdge.jsx
+++ b/frontend/src/components/canvas/NewEdge.jsx
@@ -1,0 +1,26 @@
+import { getBezierPath } from '@xyflow/react'
+import { motion } from 'framer-motion'
+
+export default function NewEdge({
+  sourceX, sourceY, targetX, targetY,
+  sourcePosition, targetPosition,
+  style = {},
+}) {
+  const [edgePath] = getBezierPath({
+    sourceX, sourceY, sourcePosition,
+    targetX, targetY, targetPosition,
+  })
+
+  return (
+    <motion.path
+      d={edgePath}
+      fill="none"
+      stroke={style.stroke ?? '#291C80'}
+      strokeWidth={style.strokeWidth ?? 1.5}
+      strokeDasharray={style.strokeDasharray}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.35, ease: 'easeOut' }}
+    />
+  )
+}

--- a/frontend/src/components/canvas/RequiredStepNode.jsx
+++ b/frontend/src/components/canvas/RequiredStepNode.jsx
@@ -1,17 +1,23 @@
 import { Handle, Position } from '@xyflow/react'
+import { motion } from 'framer-motion'
 import styles from './RequiredStepNode.module.css'
 
 export default function RequiredStepNode({ data }) {
-  const { label, status } = data
+  const { label, status, isNew = false } = data
 
   return (
-    <div className={styles.wrapper}>
+    <motion.div
+      className={styles.wrapper}
+      initial={isNew ? { opacity: 0, scale: 1.0 } : false}
+      animate={isNew ? { opacity: [0, 1, 1], scale: [1.0, 1.1, 1.0] } : { opacity: 1, scale: 1.0 }}
+      transition={{ duration: 0.45, times: [0, 0.5, 1], ease: 'easeOut' }}
+    >
       <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
       <div className={styles.diamondWrap}>
         <div className={`${styles.diamond} ${status === 'ACCEPTED' ? styles.accepted : ''}`} />
       </div>
       <span className={styles.label}>{label}</span>
       <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/components/canvas/StepNode.jsx
+++ b/frontend/src/components/canvas/StepNode.jsx
@@ -1,15 +1,12 @@
 import { Handle, Position } from '@xyflow/react'
+import { motion } from 'framer-motion'
 import styles from './StepNode.module.css'
 
 export default function StepNode({ data }) {
-  const { label, status = 'READY', stageNumber, keep = false } = data
+  const { label, status = 'READY', stageNumber, keep = false, isNew = false } = data
 
   return (
-    <div className={[
-      styles.wrapper,
-      styles[status.toLowerCase()],
-      keep ? styles.keep : '',
-    ].join(' ')}>
+    <div className={[styles.wrapper, styles[status.toLowerCase()], keep ? styles.keep : ''].join(' ')}>
       <Handle type="target" position={Position.Left} style={{ opacity: 0, left: 3, top: '60%' }} />
       {status === 'ACCEPTED' && <div className={styles.dot} />}
       <span className={styles.stageNumber}>stage {stageNumber}</span>

--- a/frontend/src/components/canvas/StepNode.module.css
+++ b/frontend/src/components/canvas/StepNode.module.css
@@ -9,6 +9,7 @@
   color: #9092B8;
   font-weight: 450;
   padding-left: 9px;
+  transition: color 0.3s ease;
 }
 
 .node {
@@ -22,6 +23,7 @@
   align-items: center;
   cursor: pointer;
   box-shadow: 0 2px 8px rgba(92, 69, 232, 0.06);
+  transition: background 0.3s ease, border-color 0.3s ease, border-left-color 0.3s ease;
 }
 
 .label {
@@ -31,6 +33,7 @@
   margin: 0;
   line-height: 1.4;
   word-break: keep-all;
+  transition: color 0.3s ease;
 }
 
 /* READY */

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -12,13 +12,16 @@ import ToastAlarm from '../components/canvas/ToastAlarm'
 import ContextMenu from '../components/canvas/onNodeContext'
 import StepNode from '../components/canvas/StepNode'
 import RequiredStepNode from '../components/canvas/RequiredStepNode'
+import GhostNode from '../components/canvas/GhostNode'
+import GhostEdge from '../components/canvas/GhostEdge'
+import NewEdge from '../components/canvas/NewEdge'
 
 import { getStages } from '../api/stage'
 import { getStepTree, getStepDetail, acceptStep, rollbackStep, createSidePanelStream } from '../api/step'
 import { createShare, deleteShare } from '../api/projects'
 import { BsLink45Deg, BsCheck } from 'react-icons/bs'
 
-import { STAGE_ENGLISH, flattenTree, getStageProgressFromTree, findRequiredStep, getLatestActiveStage } from '../utils/canvasUtils'
+import { STAGE_ENGLISH, X_GAP, Y_GAP, flattenTree, getStageProgressFromTree, findRequiredStep, getLatestActiveStage } from '../utils/canvasUtils'
 
 import styles from './CanvasPage.module.css'
 import { HiOutlineUser } from 'react-icons/hi'
@@ -26,6 +29,12 @@ import { HiOutlineUser } from 'react-icons/hi'
 const nodeTypes = {
   stepNode: StepNode,
   requiredStepNode: RequiredStepNode,
+  ghostNode: GhostNode,
+}
+
+const edgeTypes = {
+  newEdge: NewEdge,
+  ghostEdge: GhostEdge,
 }
 
 export default function CanvasPage() {
@@ -78,6 +87,43 @@ export default function CanvasPage() {
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
 
   const onConnect = (params) => setEdges((eds) => addEdge(params, eds))
+
+  function addGhostNodes(acceptedNode) {
+    const { id, position } = acceptedNode
+    const ghostX = position.x + X_GAP
+    const offsets = [-Y_GAP * 0.6, 0, Y_GAP * 0.6]
+
+    const ghostNodes = offsets.map((dy, i) => ({
+      id: `ghost-${i}`,
+      type: 'ghostNode',
+      position: { x: ghostX, y: position.y + dy + 3 },
+      data: {},
+      selectable: false,
+      draggable: false,
+    }))
+
+    const ghostEdges = offsets.map((_, i) => ({
+      id: `ghost-edge-${i}`,
+      source: id,
+      target: `ghost-${i}`,
+      type: 'ghostEdge',
+    }))
+
+    setNodes(nds => [...nds, ...ghostNodes])
+    setEdges(eds => [...eds, ...ghostEdges])
+  }
+
+  function removeGhostNodes() {
+    setNodes(nds => nds.map(n =>
+      n.type === 'ghostNode'
+        ? { ...n, data: { ...n.data, isExiting: true } }
+        : n
+    ))
+    setTimeout(() => {
+      setNodes(nds => nds.filter(n => n.type !== 'ghostNode'))
+      setEdges(eds => eds.filter(e => e.type !== 'ghostEdge'))
+    }, 300)
+  }
 
   function josa(word, form) {
     const code = word.charCodeAt(word.length - 1)
@@ -189,16 +235,37 @@ export default function CanvasPage() {
     })
   }, [projectId])
 
-  async function fetchAndRenderTree(stageId) {
+  async function fetchAndRenderTree(stageId, { animateNew = false } = {}) {
     const treeData = await getStepTree(projectId, stageId)
     const stage = stages.find((s) => s.stage_id === stageId)
+    
+    const existingIds = animateNew
+      ? new Set(nodes.filter(n => n.type !== 'ghostNode').map(n => n.id))
+      : null
+    
     const { nodes: n, edges: e } = flattenTree(treeData.steps ?? [], stage?.stage_sequence)
 
     const hasProgress = getStageProgressFromTree(n, e)
     stageHasProgressRef.current[stageId] = hasProgress
 
-    setNodes(n)
-    setEdges(e)
+    const processedNodes = animateNew
+      ? n.map(node => ({
+          ...node,
+          data: { ...node.data, isNew: !existingIds.has(node.id) }
+        }))
+      : n
+
+    setNodes(processedNodes)
+    const processedEdges = animateNew
+      ? e.map(edge =>
+          !existingIds.has(edge.target)
+            ? { ...edge, type: 'newEdge' }
+            : edge
+        )
+      : e
+
+    setEdges(processedEdges)
+
 
     const newNodeIds = new Set(n.map((node) => node.id))
     streamBuffers.current.forEach((buf, id) => {
@@ -325,6 +392,7 @@ export default function CanvasPage() {
   }))
 
   async function handleNodeClick(event, node) {
+    if (node.type === 'ghostNode') return
     if (selectedStep?.id === node.id) return
     clearStreamCallbacks()
     setSelectedStep(node)
@@ -500,103 +568,107 @@ export default function CanvasPage() {
         }
       }
 
+      addGhostNodes(selectedStep)
+
       let acceptResult
       try {
         acceptResult = await acceptStep(selectedStep.id)
       } catch (err) {
         if (err?.code !== 'STEP_ALREADY_ACCEPTED') {
+          removeGhostNodes()
           alert('Step 생성에 실패했어요. 다시 시도해주세요.')
           return
         }
       }
 
-        const isRSComplete = acceptResult?.is_current_required_step_completed
-        const isStageComplete = acceptResult?.is_current_stage_completed
 
-        const prevRSName = currentRequiredStepName.current
+      const isRSComplete = acceptResult?.is_current_required_step_completed
+      const isStageComplete = acceptResult?.is_current_stage_completed
 
-        if (selectedStep.type === 'requiredStepNode') {
-          const stepName = selectedStep.data.label
-          currentRequiredStepName.current = stepName
-          lastCompletedRequiredStepRef.current = null
+      const prevRSName = currentRequiredStepName.current
 
-          const key = `enter_${selectedStep.id}`
-          const overridePersistent = toastPersistent
-          if (!shownToastsRef.current.has(key) || overridePersistent) {
-            shownToastsRef.current.add(key)
-            if (justCompletedRSRef.current?.nextMsgTimer) {
-              clearTimeout(justCompletedRSRef.current.nextMsgTimer)
-              justCompletedRSRef.current = null
-            }
-            persistentMsgRef.current = `🤔 ${stepName}${josa(stepName, '을/를')} 진행 중이에요!`
+      if (selectedStep.type === 'requiredStepNode') {
+        const stepName = selectedStep.data.label
+        currentRequiredStepName.current = stepName
+        lastCompletedRequiredStepRef.current = null
 
-            showTimedToast(`📌 ${stepName}${josa(stepName, '이/가')} 시작됐어요!`, 5500)
+        const key = `enter_${selectedStep.id}`
+        const overridePersistent = toastPersistent
+        if (!shownToastsRef.current.has(key) || overridePersistent) {
+          shownToastsRef.current.add(key)
+          if (justCompletedRSRef.current?.nextMsgTimer) {
+            clearTimeout(justCompletedRSRef.current.nextMsgTimer)
+            justCompletedRSRef.current = null
           }
+          persistentMsgRef.current = `🤔 ${stepName}${josa(stepName, '을/를')} 진행 중이에요!`
+
+          showTimedToast(`📌 ${stepName}${josa(stepName, '이/가')} 시작됐어요!`, 5500)
         }
+      }
 
-        clearStreamCallbacks()
-        setStreamingText(null)
+      clearStreamCallbacks()
+      setStreamingText(null)
 
-        const { nextRequiredStepName } = await fetchAndRenderTree(selectedStageId)
+      const { nextRequiredStepName } = await fetchAndRenderTree(selectedStageId, { animateNew: true })
+      
+      if (isStageComplete) {
+        const key = `stage_complete_${selectedStageId}`
+        if (!shownToastsRef.current.has(key)) {
+          shownToastsRef.current.add(key)
+          persistentMsgRef.current = `이제 다음 Stage로 이동할 수 있어요!`
+          showPersistentToast(`🎉 Stage가 종료됐어요! 이제 다음 Stage로 이동할 수 있어요!`)
+        }
+        currentRequiredStepName.current = null
+        getStages(projectId).then((data) => {
+          const list = data.stages ?? []
+          setStages(list)
+          const latestActive = getLatestActiveStage(list)
+          if (latestActive) setCurrentStageSequence(latestActive.stage_sequence)
+        })
 
-        if (isStageComplete) {
-          const key = `stage_complete_${selectedStageId}`
+      } else if (isRSComplete) {
+        const name = (() => {
+          if (selectedStep.type === 'requiredStepNode') return selectedStep.data.label
+          const req = findRequiredStep(selectedStep.id, nodes, edges)
+          return req?.data?.label
+        })()
+
+        if (name && name !== lastCompletedRequiredStepRef.current) {
+          lastCompletedRequiredStepRef.current = name
+          const key = `complete_${name}`
           if (!shownToastsRef.current.has(key)) {
             shownToastsRef.current.add(key)
-            persistentMsgRef.current = `이제 다음 Stage로 이동할 수 있어요!`
-            showPersistentToast(`🎉 Stage가 종료됐어요! 이제 다음 Stage로 이동할 수 있어요!`)
-          }
-          currentRequiredStepName.current = null
-          getStages(projectId).then((data) => {
-            const list = data.stages ?? []
-            setStages(list)
-            const latestActive = getLatestActiveStage(list)
-            if (latestActive) setCurrentStageSequence(latestActive.stage_sequence)
-          })
+            const nextMsg = nextRequiredStepName
+              ? `다음 단계인 ${nextRequiredStepName}${josa(nextRequiredStepName, '(으)로')} 이동할 수 있어요!`
+              : `다음 필수 단계로 이동할 수 있어요!`
+            persistentMsgRef.current = nextMsg
 
-        } else if (isRSComplete) {
-          const name = (() => {
-            if (selectedStep.type === 'requiredStepNode') return selectedStep.data.label
-            const req = findRequiredStep(selectedStep.id, nodes, edges)
-            return req?.data?.label
-          })()
-
-          if (name && name !== lastCompletedRequiredStepRef.current) {
-            lastCompletedRequiredStepRef.current = name
-            const key = `complete_${name}`
-            if (!shownToastsRef.current.has(key)) {
-              shownToastsRef.current.add(key)
-              const nextMsg = nextRequiredStepName
-                ? `다음 단계인 ${nextRequiredStepName}${josa(nextRequiredStepName, '(으)로')} 이동할 수 있어요!`
-                : `다음 필수 단계로 이동할 수 있어요!`
-              persistentMsgRef.current = nextMsg
-
-              showTimedToast(`🎉 ${name}${josa(name, '이/가')} 종료됐어요!`, 3000)
-              const t = setTimeout(() => {
-                showPersistentToast(nextMsg)
-                justCompletedRSRef.current = null
-              }, 3000)
-              justCompletedRSRef.current = { name, nextMsgTimer: t }
-            }
-          }
-        }
-
-        if (skipRollback || needsRollback) {
-          if (!isStageComplete && !isRSComplete && selectedStep.type !== 'requiredStepNode') {
-            if (justCompletedRSRef.current?.nextMsgTimer) {
-              clearTimeout(justCompletedRSRef.current.nextMsgTimer)
+            showTimedToast(`🎉 ${name}${josa(name, '이/가')} 종료됐어요!`, 3000)
+            const t = setTimeout(() => {
+              showPersistentToast(nextMsg)
               justCompletedRSRef.current = null
-            }
-            lastCompletedRequiredStepRef.current = null
-
-            const newRSName = currentRequiredStepName.current
-            if (newRSName && newRSName !== prevRSName) {
-              persistentMsgRef.current = `🤔 ${newRSName}${josa(newRSName, '을/를')} 진행 중이에요!`
-              showTimedToast(`📌 ${newRSName}${josa(newRSName, '(으)로')} 돌아왔어요!`, 5500)
-            } else {
-              persistentMsgRef.current = null            }
+            }, 3000)
+            justCompletedRSRef.current = { name, nextMsgTimer: t }
           }
         }
+      }
+
+      if (skipRollback || needsRollback) {
+        if (!isStageComplete && !isRSComplete && selectedStep.type !== 'requiredStepNode') {
+          if (justCompletedRSRef.current?.nextMsgTimer) {
+            clearTimeout(justCompletedRSRef.current.nextMsgTimer)
+            justCompletedRSRef.current = null
+          }
+          lastCompletedRequiredStepRef.current = null
+
+          const newRSName = currentRequiredStepName.current
+          if (newRSName && newRSName !== prevRSName) {
+            persistentMsgRef.current = `🤔 ${newRSName}${josa(newRSName, '을/를')} 진행 중이에요!`
+            showTimedToast(`📌 ${newRSName}${josa(newRSName, '(으)로')} 돌아왔어요!`, 5500)
+          } else {
+            persistentMsgRef.current = null            }
+        }
+      }
 
       setSelectedStep(null)
       setStepDetail(null)
@@ -740,6 +812,7 @@ export default function CanvasPage() {
             onPaneClick={handlePaneClick}
             onNodeContextMenu={handleNodeContextMenu}
             nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes} 
             nodesDraggable={false}
             onInit={setRfInstance}
             defaultViewport={{ x: -10, y: 0, zoom: 1 }}

--- a/frontend/src/utils/canvasUtils.js
+++ b/frontend/src/utils/canvasUtils.js
@@ -18,9 +18,8 @@ export function makeEdge(sourceId, targetId, solid = false) {
     target: targetId,
     type: 'default',
     style: {
-      stroke: '#291C80',
-      strokeWidth: solid ?  1.5: 1.5,
-      strokeDasharray: solid ? undefined : '5,5',
+      stroke: solid ? '#3c2ab0' : '#C5BDFB',
+      strokeWidth: 1.5,
     },
   }
 }
@@ -56,16 +55,25 @@ export function flattenTree(steps, stageSequence) {
     const children = node.children ?? []
     if (children.length === 0) return
 
-    const sorted = [...children].sort((a, b) => (a.is_required ? 1 : 0) - (b.is_required ? 1 : 0))
-    const sizes = sorted.map(child => getSubtreeSize(child))
-    const totalLeaves = sizes.reduce((sum, s) => sum + s, 0)
-    const totalHeight = (totalLeaves - 1) * Y_GAP
+    const regularChildren = children.filter(c => !c.is_required)
+    const requiredChildren = children.filter(c => c.is_required)
 
+    const sizes = regularChildren.map(child => getSubtreeSize(child))
+    const totalLeaves = sizes.reduce((sum, s) => sum + s, 0)
+    const totalHeight = totalLeaves > 0 ? (totalLeaves - 1) * Y_GAP : 0
+
+    let lastRegularChildY = centerY
     let currentY = centerY - totalHeight / 2
-    sorted.forEach((child, index) => {
+
+    regularChildren.forEach((child, index) => {
       const childCenterY = currentY + (sizes[index] - 1) * Y_GAP / 2
       build(child, depth + 1, childCenterY)
+      lastRegularChildY = childCenterY
       currentY += sizes[index] * Y_GAP
+    })
+
+    requiredChildren.forEach((child) => {
+      build(child, depth + 1, lastRegularChildY + Y_GAP * 0.5)
     })
   }
 


### PR DESCRIPTION
## 요약
- Accept 시 Ghost 노드/엣지로 로딩 상태 시각화
- 신규 노드/엣지 등장 애니메이션 추가
- ACCEPTED 노드 클릭 시 사이드패널 미로드 버그 수정

## 변경 유형
- [x] 새로운 기능
- [x] 버그 수정

## 변경 사항
- `GhostNode`, `GhostEdge`, `NewEdge` 컴포넌트 추가
- Accept 시 ghost 노드 3개 생성 → 트리 갱신 후 제거
- 신규 노드는 `isNew` 플래그로 등장 애니메이션 적용
- Required Step 노드 레이아웃 Regular 노드 아래 고정 배치
- ACCEPTED 노드 클릭 시 스트림 버퍼 없는 경우 `getStepDetail` 미호출 버그 수정

## 체크리스트
- [x] 로컬 빌드 확인
- [x] 기존 기능 동작 확인 (Accept, 롤백, 사이드패널)

## 참고 사항
- Ghost 노드는 selectable/draggable 비활성화
- Ghost 노드 클릭 이벤트 차단 (`if (node.type === 'ghostNode') return`)