### PR TITLE
[#193][BE] design-export SSE 엔드포인트 추가 — 선택된 RS의 사고 궤적을 .md 파일로 export

### DIFF
--- a/backend/app/ai/main.py
+++ b/backend/app/ai/main.py
@@ -2,7 +2,7 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from mangum import Mangum
 
-from app.ai.routers import steps
+from app.ai.routers import steps, projects
 from app.core import exception_handlers
 from app.core.auth.csrf import verify_csrf
 from app.core.auth.dependencies import get_current_user_id
@@ -30,6 +30,11 @@ app.include_router(
     dependencies=[Depends(get_current_user_id), Depends(verify_csrf)],
 )
 
+app.include_router(
+    projects.router,
+    tags=["ai"],
+    dependencies=[Depends(get_current_user_id), Depends(verify_csrf)],
+)
 
 @app.get("/health")
 def health() -> HealthResponse:

--- a/backend/app/ai/routers/projects.py
+++ b/backend/app/ai/routers/projects.py
@@ -1,0 +1,72 @@
+"""design-export SSE 엔드포인트."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import Depends
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ai.exceptions import BedrockAPIError, AIGenerationFailedError, OutputViolatesHonestyGuardError
+from app.ai.services import orchestrator
+from app.ai.services import design_export_service, design_export_renderer
+from app.core.api.route import EnvelopeRouter
+from app.core.database import get_db
+from app.core.exceptions import (
+    DesignExportEmptySelectionError,
+    DesignExportInactiveStepError,
+    DesignExportInvalidStepIdError,
+    DesignExportRateLimitError,
+    ProjectNotFoundError,
+)
+from app.business.services import project_service
+
+router = EnvelopeRouter()
+
+
+class DesignExportRequest(BaseModel):
+    selected_step_ids: list[UUID]
+
+
+@router.post("/projects/{project_id}/design-export")
+async def design_export_stream(
+    project_id: UUID,
+    payload: DesignExportRequest,
+    db: Session = Depends(get_db),
+):
+    # SSE 시작 전 검증 — 여기서 raise하면 HTTP 상태코드 정상 반환
+    project_service.get_project_or_raise(db, project_id)
+    design_export_service.check_rate_limit(project_id)
+    input_data = design_export_service.build_input(
+        db, project_id, payload.selected_step_ids
+    )
+
+    async def event_generator():
+        async def call_ai():
+            return await orchestrator.call_design_export(input_data)
+
+        ai_task = asyncio.create_task(call_ai())
+
+        while not ai_task.done():
+            yield "event: keepalive\ndata: {}\n\n"
+            await asyncio.sleep(10)
+
+        try:
+            ai_output = ai_task.result()
+        except (BedrockAPIError, AIGenerationFailedError):
+            yield f"event: error\ndata: {json.dumps({'code': 'DESIGN_EXPORT_AI_FAILED'})}\n\n"
+            return
+        except OutputViolatesHonestyGuardError:
+            yield f"event: error\ndata: {json.dumps({'code': 'DESIGN_EXPORT_INVALID_OUTPUT'})}\n\n"
+            return
+
+        md = design_export_renderer.render(input_data, ai_output)
+        filename = f"design_{datetime.now(timezone.utc):%Y-%m-%d}.md"
+        yield f"event: complete\ndata: {json.dumps({'markdown': md, 'filename': filename}, ensure_ascii=False)}\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/backend/app/ai/routers/projects.py
+++ b/backend/app/ai/routers/projects.py
@@ -42,7 +42,7 @@ async def design_export_stream(
     # SSE 시작 전 검증 — 여기서 raise하면 HTTP 상태코드 정상 반환
     project_service.get_project_or_raise(db, project_id)
     design_export_service.check_rate_limit(project_id)
-    input_data, stage_seq_to_name = design_export_service.build_input(
+    input_data = design_export_service.build_input(
         db, project_id, payload.selected_step_ids
     )
 
@@ -65,7 +65,7 @@ async def design_export_stream(
             yield f"event: error\ndata: {json.dumps({'code': 'DESIGN_EXPORT_INVALID_OUTPUT'})}\n\n"
             return
 
-        md = design_export_renderer.render(input_data, ai_output, stage_seq_to_name)
+        md = design_export_renderer.render(input_data, ai_output)
         filename = f"design_{datetime.now(timezone.utc):%Y-%m-%d}.md"
         yield f"event: complete\ndata: {json.dumps({'markdown': md, 'filename': filename}, ensure_ascii=False)}\n\n"
 

--- a/backend/app/ai/routers/projects.py
+++ b/backend/app/ai/routers/projects.py
@@ -42,7 +42,7 @@ async def design_export_stream(
     # SSE 시작 전 검증 — 여기서 raise하면 HTTP 상태코드 정상 반환
     project_service.get_project_or_raise(db, project_id)
     design_export_service.check_rate_limit(project_id)
-    input_data = design_export_service.build_input(
+    input_data, stage_seq_to_name = design_export_service.build_input(
         db, project_id, payload.selected_step_ids
     )
 
@@ -65,7 +65,7 @@ async def design_export_stream(
             yield f"event: error\ndata: {json.dumps({'code': 'DESIGN_EXPORT_INVALID_OUTPUT'})}\n\n"
             return
 
-        md = design_export_renderer.render(input_data, ai_output)
+        md = design_export_renderer.render(input_data, ai_output, stage_seq_to_name)
         filename = f"design_{datetime.now(timezone.utc):%Y-%m-%d}.md"
         yield f"event: complete\ndata: {json.dumps({'markdown': md, 'filename': filename}, ensure_ascii=False)}\n\n"
 

--- a/backend/app/ai/services/design_export_renderer.py
+++ b/backend/app/ai/services/design_export_renderer.py
@@ -1,0 +1,105 @@
+"""design-export 렌더러 — .md 골격 렌더링."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from ai.schemas.design_export import DesignExportInput, DesignExportOutput, RSQuestions
+
+
+def render(
+    input_data: DesignExportInput,
+    ai_output: DesignExportOutput,
+) -> str:
+    ctx = input_data.project_context
+    constraints_str = (
+        ", ".join(ctx.constraints) if ctx.constraints else "(미입력)"
+    )
+
+    rs_q_map: dict[str, RSQuestions] = {
+        rs_q.required_step_id: rs_q
+        for rs_q in ai_output.questions_per_rs
+    }
+
+    seen_stage_seqs: list[int] = []
+    stage_rs_map: dict[int, list] = {}
+    for rs in input_data.selected_required_steps:
+        seq = int(rs.required_step_id.split("-")[0])
+        if seq not in seen_stage_seqs:
+            seen_stage_seqs.append(seq)
+            stage_rs_map[seq] = []
+        stage_rs_map[seq].append(rs)
+
+    lines: list[str] = []
+
+    lines.append(f"# {ctx.name or '(이름 미설정)'} — 사고 궤적 문서")
+    lines.append("")
+    lines.append("> **이 문서는 Poco가 생성한 What·Why 사고 궤적 문서입니다.**")
+    lines.append(">")
+    lines.append("> Poco는 검증된 소프트웨어 개발 방법론(미국 법무부 SDLC 기반)을 따라")
+    lines.append("> 사용자가 *\"무엇을·왜 만들지\"* 를 단계별로 결정하도록 돕는 AI 멘토링 도구입니다.")
+    lines.append("> 사용자는 6단계 흐름(아이디어 구체화 → 프로젝트 계획 → 요구사항 정의 → 설계 → 개발 → 테스트 및 검증)으로 사고를 진행합니다.")
+    lines.append(">")
+    lines.append("> **이 문서의 활용 방법**:")
+    lines.append("> 이 문서를 컨텍스트로 삼아 사용자가 요청하는 다음 작업(구현·작성·검토 등 How)을 진행해주세요.")
+    lines.append("> 사용자는 What·Why를 거쳐 여기에 도착한 상태입니다.")
+    lines.append("> 사용자가 *\"답을 적어둔 상태\"* 가 아니라 *\"질문을 인지한 상태\"* 일 수 있으니,")
+    lines.append("> 답 디테일이 필요하면 사용자에게 직접 보충 질문해주세요.")
+    lines.append(">")
+    lines.append("> **답변을 마무리할 때**: *\"어느 쪽을 원하시나요?\"*, *\"더 깊게 파고들고 싶은 게 있으신가요?\"* 같이")
+    lines.append("> 사용자에게 다시 공을 넘기는 막연한 질문으로 끝내지 마세요.")
+    lines.append("> 대신 이 문서의 What·Why 맥락에 비춰 사용자가 의도한 다음 한 걸음을")
+    lines.append("> *\"이 맥락에서는 ~를 ~ 방식으로 시작/구현해보면 어떨까요?\"* 형태로 **구체적이고 개인 맞춤형으로 제안**해주세요.")
+    lines.append("> 제안한 방향이 사용자 의도와 맞는지는 한 줄로 확인하되, 그 자체가 답변의 마무리가 되어서는 안 됩니다.")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("## 프로젝트 컨텍스트")
+    lines.append("")
+    lines.append(f"- 프로젝트 이름: {ctx.name or '(미입력)'}")
+    lines.append(f"- 인원·기간: {ctx.member_count}명 / {ctx.duration_months}개월")
+    lines.append(f"- 제약사항: {constraints_str}")
+    lines.append(f"- 초기 아이디어: {ctx.initial_prompt}")
+    lines.append("")
+    lines.append("## 사용자가 거쳐온 사고 궤적")
+    lines.append("")
+
+    for stage_seq in seen_stage_seqs:
+        lines.append(f"### Stage {stage_seq}")
+        lines.append("")
+        for rs in stage_rs_map[stage_seq]:
+            lines.append(f"#### {rs.required_step_id} {rs.required_step_name}")
+            lines.append("")
+            lines.append(f"**목표**: {rs.goal}")
+            lines.append("")
+            lines.append("**충족 기준**:")
+            for criterion in rs.fulfillment_criteria:
+                lines.append(f"- {criterion}")
+            lines.append("")
+            lines.append("**진행한 결정** (사용자 클릭 순서):")
+            if rs.accepted_general_steps:
+                for i, step in enumerate(rs.accepted_general_steps, start=1):
+                    lines.append(f"{i}. {step.name}")
+            else:
+                lines.append("(아직 없음)")
+            lines.append("")
+            lines.append("**이 단계에서 인지한 What·Why 질문**:")
+            rs_q = rs_q_map.get(rs.required_step_id)
+            if rs_q:
+                for q in rs_q.questions:
+                    lines.append(f"- {q}")
+            else:
+                lines.append("- (질문 생성 실패)")
+            lines.append("")
+
+    lines.append("## 핵심 What·Why 정리")
+    lines.append("")
+    for item in ai_output.core_summary:
+        lines.append(f"- {item}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    generated_at = datetime.now(timezone.utc)
+    lines.append(f"생성: {generated_at:%Y-%m-%d %H:%M} (KST) / 도구: Poco")
+
+    return "\n".join(lines)

--- a/backend/app/ai/services/design_export_renderer.py
+++ b/backend/app/ai/services/design_export_renderer.py
@@ -10,6 +10,7 @@ from ai.schemas.design_export import DesignExportInput, DesignExportOutput, RSQu
 def render(
     input_data: DesignExportInput,
     ai_output: DesignExportOutput,
+    stage_seq_to_name: dict[int, str],
 ) -> str:
     ctx = input_data.project_context
     constraints_str = (
@@ -65,7 +66,8 @@ def render(
     lines.append("")
 
     for stage_seq in seen_stage_seqs:
-        lines.append(f"### Stage {stage_seq}")
+        stage_name = stage_seq_to_name.get(stage_seq, "")
+        lines.append(f"### Stage {stage_seq} — {stage_name}")
         lines.append("")
         for rs in stage_rs_map[stage_seq]:
             lines.append(f"#### {rs.required_step_id} {rs.required_step_name}")

--- a/backend/app/ai/services/design_export_renderer.py
+++ b/backend/app/ai/services/design_export_renderer.py
@@ -6,11 +6,19 @@ from datetime import datetime, timezone
 
 from ai.schemas.design_export import DesignExportInput, DesignExportOutput, RSQuestions
 
+_STAGE_SEQ_TO_NAME: dict[int, str] = {
+    1: "아이디어 구체화",
+    2: "프로젝트 계획",
+    3: "요구사항 정의",
+    4: "설계",
+    5: "개발",
+    6: "테스트 및 검증",
+}
+
 
 def render(
     input_data: DesignExportInput,
     ai_output: DesignExportOutput,
-    stage_seq_to_name: dict[int, str],
 ) -> str:
     ctx = input_data.project_context
     constraints_str = (
@@ -66,7 +74,7 @@ def render(
     lines.append("")
 
     for stage_seq in seen_stage_seqs:
-        stage_name = stage_seq_to_name.get(stage_seq, "")
+        stage_name = _STAGE_SEQ_TO_NAME.get(stage_seq, "")
         lines.append(f"### Stage {stage_seq} — {stage_name}")
         lines.append("")
         for rs in stage_rs_map[stage_seq]:

--- a/backend/app/ai/services/design_export_service.py
+++ b/backend/app/ai/services/design_export_service.py
@@ -41,7 +41,7 @@ def build_input(
     db: Session,
     project_id: UUID,
     selected_step_ids: list[UUID],
-) -> DesignExportInput:
+) -> tuple[DesignExportInput, dict[int, str]]:
 
     if not selected_step_ids:
         raise DesignExportEmptySelectionError()
@@ -123,7 +123,9 @@ def build_input(
             )
         )
 
+    stage_seq_to_name = {s.stage.sequence: s.stage.name for s in steps_sorted}
+
     return DesignExportInput(
         project_context=project_context,
         selected_required_steps=selected_required_steps,
-    )
+    ), stage_seq_to_name

--- a/backend/app/ai/services/design_export_service.py
+++ b/backend/app/ai/services/design_export_service.py
@@ -41,7 +41,7 @@ def build_input(
     db: Session,
     project_id: UUID,
     selected_step_ids: list[UUID],
-) -> tuple[DesignExportInput, dict[int, str]]:
+) -> DesignExportInput:
 
     if not selected_step_ids:
         raise DesignExportEmptySelectionError()
@@ -123,9 +123,7 @@ def build_input(
             )
         )
 
-    stage_seq_to_name = {s.stage.sequence: s.stage.name for s in steps_sorted}
-
     return DesignExportInput(
         project_context=project_context,
         selected_required_steps=selected_required_steps,
-    ), stage_seq_to_name
+    )

--- a/backend/app/ai/services/design_export_service.py
+++ b/backend/app/ai/services/design_export_service.py
@@ -1,0 +1,129 @@
+"""design-export 서비스 — DB 데이터 조립 + 검증 + rate limit."""
+
+from __future__ import annotations
+
+import json
+import time
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ai.schemas.common import MentoringContent
+from ai.schemas.design_export import (
+    AcceptedStepForAI,
+    DesignExportInput,
+    ProjectContextForAI,
+    RequiredStepForAI,
+)
+from app.core.exceptions import (
+    DesignExportEmptySelectionError,
+    DesignExportInactiveStepError,
+    DesignExportInvalidStepIdError,
+    DesignExportRateLimitError,
+    ProjectNotFoundError,
+)
+from app.core.repositories import project as project_repo
+from app.core.repositories import step as step_repo
+
+_rate_limit_store: dict[str, float] = {}
+_RATE_LIMIT_SECONDS = 10
+
+
+def check_rate_limit(project_id: UUID) -> None:
+    key = str(project_id)
+    now = time.time()
+    if now - _rate_limit_store.get(key, 0) < _RATE_LIMIT_SECONDS:
+        raise DesignExportRateLimitError()
+    _rate_limit_store[key] = now
+
+
+def build_input(
+    db: Session,
+    project_id: UUID,
+    selected_step_ids: list[UUID],
+) -> DesignExportInput:
+
+    if not selected_step_ids:
+        raise DesignExportEmptySelectionError()
+
+    project = project_repo.get_active_project_by_id(db, project_id)
+    if not project:
+        raise ProjectNotFoundError()
+
+    steps = step_repo.get_steps_by_ids(db, selected_step_ids)
+    if len(steps) != len(selected_step_ids):
+        raise DesignExportInvalidStepIdError()
+
+    for s in steps:
+        if s.project_id != project_id or s.required_step_id is None:
+            raise DesignExportInvalidStepIdError()
+
+    active_stage_ids = {
+        ps.stage_id
+        for ps, _ in project_repo.get_project_stages_with_stage(db, project_id)
+        if ps.is_active
+    }
+    for s in steps:
+        if s.stage_id not in active_stage_ids:
+            raise DesignExportInactiveStepError()
+
+    steps_sorted = sorted(
+        steps,
+        key=lambda s: (s.stage.sequence, s.required_step.sequence),
+    )
+
+    project_context = ProjectContextForAI(
+        name=project.name,
+        description=project.description,
+        duration_months=project.duration_month or 1,
+        member_count=project.member_count or 1,
+        constraints=project.constraints,
+        initial_prompt=project.prompt or "",
+    )
+
+    selected_required_steps: list[RequiredStepForAI] = []
+    for s in steps_sorted:
+        rs = s.required_step
+
+        accepted_steps = step_repo.get_accepted_steps_in_required(
+            db, project_id, rs.id
+        )
+        accepted_steps_sorted = sorted(accepted_steps, key=lambda a: a.created_at)
+
+        accepted_for_ai: list[AcceptedStepForAI] = []
+        for a in accepted_steps_sorted:
+            mentoring = None
+            if a.content and a.content.mentoring:
+                raw = json.loads(a.content.mentoring)
+                description = raw["description"]
+                try:
+                    mentoring = MentoringContent(**raw)
+                except Exception:
+                    mentoring = None
+            else:
+                description = a.name
+
+            accepted_for_ai.append(
+                AcceptedStepForAI(
+                    name=a.name,
+                    description=description,
+                    sidepanel_mentoring=mentoring,
+                )
+            )
+
+        rs_id_str = f"{s.stage.sequence}-R{rs.sequence}"
+
+        selected_required_steps.append(
+            RequiredStepForAI(
+                required_step_id=rs_id_str,
+                required_step_name=rs.name,
+                goal=rs.goal,
+                fulfillment_criteria=rs.fulfillment_criteria,
+                accepted_general_steps=accepted_for_ai,
+            )
+        )
+
+    return DesignExportInput(
+        project_context=project_context,
+        selected_required_steps=selected_required_steps,
+    )

--- a/backend/app/ai/services/orchestrator.py
+++ b/backend/app/ai/services/orchestrator.py
@@ -3,7 +3,7 @@ from typing import AsyncIterator
 
 from app.core.config import settings
 from app.core.logging import get_logger
-from ai import generate_steps, judge_required_step, generate_side_panel, generate_side_panel_stream
+from ai import generate_steps, judge_required_step, generate_side_panel, generate_side_panel_stream, generate_design_export
 from ai.clients.llm import LLMClient
 from ai.clients.rag import RAGClient
 
@@ -68,3 +68,17 @@ async def call_side_panel_stream(input_data) -> AsyncIterator[str]:
         custom_data_source_id=settings.BEDROCK_CUSTOM_DATA_SOURCE_ID or None,
     ):
         yield chunk
+
+
+
+async def call_design_export(input_data):
+    logger.debug("ai: invoking generate_design_export")
+    try:
+        return await generate_design_export(
+            input_data,
+            bedrock_runtime,
+            settings.BEDROCK_MODEL_ID,
+        )
+    except Exception:
+        logger.error("ai: design_export invocation failed", exc_info=True)
+        raise

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -174,3 +174,35 @@ class ConstraintsLimitError(PocoError):
             message=message,
             status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
         )
+
+class DesignExportEmptySelectionError(PocoError):
+    def __init__(self, message: str = "선택된 Required Step이 없습니다."):
+        super().__init__(
+            code="DESIGN_EXPORT_EMPTY_SELECTION",
+            message=message,
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+        )
+
+class DesignExportInactiveStepError(PocoError):
+    def __init__(self, message: str = "비활성 Required Step이 포함되어 있습니다."):
+        super().__init__(
+            code="DESIGN_EXPORT_INACTIVE_STEP_SELECTED",
+            message=message,
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+        )
+
+class DesignExportInvalidStepIdError(PocoError):
+    def __init__(self, message: str = "잘못된 Required Step ID가 포함되어 있습니다."):
+        super().__init__(
+            code="DESIGN_EXPORT_INVALID_STEP_ID",
+            message=message,
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+        )
+
+class DesignExportRateLimitError(PocoError):
+    def __init__(self, message: str = "요청이 너무 잦습니다. 10초 후 다시 시도해주세요."):
+        super().__init__(
+            code="DESIGN_EXPORT_RATE_LIMITED",
+            message=message,
+            status_code=http_status.HTTP_429_TOO_MANY_REQUESTS,
+        )


### PR DESCRIPTION
## PR 요약
- design-export SSE 엔드포인트 추가 — 선택된 RS의 사고 궤적을 .md 파일로 export

## 변경 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- app/core/exceptions.py — design-export 관련 에러 클래스 4개 추가 (DesignExportEmptySelectionError, DesignExportInactiveStepError, DesignExportInvalidStepIdError, DesignExportRateLimitError)
- app/ai/services/orchestrator.py — call_design_export() 추가
- app/ai/services/design_export_service.py — DB에서 DesignExportInput 조립, 입력 검증, rate limit 처리
- app/ai/services/design_export_renderer.py — DesignExportInput + DesignExportOutput → .md 렌더링
- app/ai/routers/projects.py — POST /projects/{project_id}/design-export SSE 엔드포인트
- app/ai/main.py — projects.router include 추가

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- AI 호출 최대 45초 소요 → Gateway 타임아웃 우회를 위해 SSE keepalive 10초 간격 전송
- Lambda timeout 180초 적용 필요 (콘솔에서 직접 설정)
- AI 모듈(generate_design_export)은 이미 머지된 PR 기준, RAG 미사용 동기 1회 호출
- .md 골격 렌더링은 백엔드 책임, AI는 질문 리스트 + 핵심 요약 JSON만 반환