### PR TITLE
[#171][FE] toast alarm 버그 수정

### DIFF
--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -321,16 +321,6 @@ export default function CanvasPage() {
     lastToastByStageRef.current[selectedStageId] = { message, persistent: true }
     }
   }
-
-  // function showActiveStageToast(stageList) {
-  //   const list = stageList ?? stages
-  //   const active = getLatestActiveStage(list)
-  //   if (!active) return
-  //   const name = active.stage_name ?? STAGE_NAMES[active.stage_sequence]
-  //   if (!name) return
-  //   showTimedToast(`🤔 현재 ${name}${josa(name, '을/를')} 진행 중이에요!`, 5500)
-  }
-
   function enqueueTyping(newChars) {
     typingQueueRef.current += newChars
     if (typingTimerRef.current) return  // 이미 돌고 있으면 큐에만 쌓음

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -789,6 +789,26 @@ export default function CanvasPage() {
     if (latestActive) {
       setCurrentStageSequence(latestActive.stage_sequence)
       stageHasProgressRef.current[latestActive.stage_id] = false
+
+      const stageName = latestActive.stage_name ?? STAGE_NAMES[latestActive.stage_sequence]
+      
+      // selectedStep 기준으로 소속 RS 찾기
+      let rsName = null
+      if (selectedStep) {
+        if (selectedStep.type === 'requiredStepNode') {
+          rsName = selectedStep.data.label
+        } else {
+          const rs = findRequiredStep(selectedStep.id, nodes, edges)
+          rsName = rs?.data?.label
+        }
+      }
+      
+      if (stageName) {
+        const msg = rsName
+          ? `📌 ${stageName} 중 ${rsName}${josa(rsName, '(으)로')} 돌아왔어요!`
+          : `📌 ${stageName}${josa(stageName, '(으)로')} 돌아왔어요!`
+        showTimedToast(msg, 5500)
+      }
     }
 
     await executeAccept({ skipRollback: true })

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -317,6 +317,18 @@ export default function CanvasPage() {
     setToastPersistent(true)
     setToastVisible(true)
     persistentMsgRef.current = message
+    if (selectedStageId) {
+    lastToastByStageRef.current[selectedStageId] = { message, persistent: true }
+    }
+  }
+
+  // function showActiveStageToast(stageList) {
+  //   const list = stageList ?? stages
+  //   const active = getLatestActiveStage(list)
+  //   if (!active) return
+  //   const name = active.stage_name ?? STAGE_NAMES[active.stage_sequence]
+  //   if (!name) return
+  //   showTimedToast(`🤔 현재 ${name}${josa(name, '을/를')} 진행 중이에요!`, 5500)
   }
 
   function enqueueTyping(newChars) {

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -180,6 +180,7 @@ export default function CanvasPage() {
   const shownToastsRef = useRef(new Set())
   const persistentMsgRef = useRef(null)
   const justCompletedRSRef = useRef(null)
+  const lastToastByStageRef = useRef({})  // { stageId: { message, persistent } }
 
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
@@ -305,6 +306,9 @@ export default function CanvasPage() {
     setToastPersistent(false)
     setToastVisible(true)
     timerRef.current = setTimeout(() => setToastVisible(false), duration)
+    if (selectedStageId) {
+      lastToastByStageRef.current[selectedStageId] = { message, persistent: false }
+    }
   }
 
   function showPersistentToast(message) {
@@ -574,7 +578,9 @@ export default function CanvasPage() {
     }
     setToastVisible(false)
     setToastPersistent(false)
-    persistentMsgRef.current = null
+    // 이전 stage 기억된 토스트 → persistentMsgRef 복원 
+    const remembered = lastToastByStageRef.current[selectedStageId]
+    persistentMsgRef.current = remembered?.persistent ? remembered.message : null
     currentRequiredStepName.current = null
     lastCompletedRequiredStepRef.current = null
     shownToastsRef.current.clear()

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -28,7 +28,7 @@ import { BsLink45Deg, BsCheck } from 'react-icons/bs'
 import { 
   REQUIRED_STEPS_BY_STAGE, STAGE_NAMES,
   STAGE_ENGLISH, X_GAP, Y_GAP, flattenTree, 
-  getStageProgressFromTree, findRequiredStep, 
+  getStageProgressFromTree, findRequiredStep, findAcceptedLeaf, 
   getLatestActiveStage, predictGhostPositions
 } from '../utils/canvasUtils'
 
@@ -457,12 +457,17 @@ export default function CanvasPage() {
       }
     })
 
-    const acceptedRequiredNode = n.find(
-      (node) => node.type === 'requiredStepNode' && node.data.status === 'ACCEPTED'
-    )
-    if (acceptedRequiredNode) {
-      currentRequiredStepName.current = acceptedRequiredNode.data.label
+    // 현재 진행 경로의 leaf로부터 소속 RS를 추적
+    const leafAccepted = findAcceptedLeaf(n, e)
+    let activeRS = null
+    if (leafAccepted) {
+      if (leafAccepted.type === 'requiredStepNode') {
+        activeRS = leafAccepted
+      } else {
+        activeRS = findRequiredStep(leafAccepted.id, n, e)
+      }
     }
+    currentRequiredStepName.current = activeRS?.data?.label ?? null
 
     if (animateNew) {
       n.filter((node) =>

--- a/frontend/src/utils/canvasUtils.js
+++ b/frontend/src/utils/canvasUtils.js
@@ -193,6 +193,14 @@ export function getStageProgressFromTree(nodes, edges) {
     : false
 }
 
+export function findAcceptedLeaf(nodes, edges) {
+  const acceptedNodes = nodes.filter((n) => n.data?.status === 'ACCEPTED')
+  const acceptedIds = new Set(acceptedNodes.map((n) => n.id))
+  const hasAcceptedChild = (parentId) =>
+    edges.some((e) => e.source === parentId && acceptedIds.has(e.target))
+  return acceptedNodes.find((n) => !hasAcceptedChild(n.id)) ?? null
+}
+
 export function findRequiredStep(nodeId, nodes, edges) {
   const parentEdge = edges.find((e) => e.target === nodeId)
   if (!parentEdge) return null


### PR DESCRIPTION
## PR 요약
- 스테이지 이동 시 토스트가 통째로 초기화돼서 이전 안내가 사라지던 문제 해결
- 각 스테이지의 마지막 토스트를 ref에 저장하고, 재진입 시 복원
- 롤백 시 진행 중이던 필수 step 구하는 로직 수정

## 변경 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `lastToastByStageRef` ref 추가: `{ stageId: { message, persistent } }`
- `showTimedToast` / `showPersistentToast`에서 현재 stage 기준으로 메시지 저장
- 스테이지 변경 useEffect에서 기억된 persistent 토스트로 `persistentMsgRef` 복원 → 토글 버튼으로 마지막 안내 재표시 가능
- 현재 진행 경로의 leaf에서 RS를 추적하도록 `findAcceptedLeaf` 헬퍼 사용 (canvasUtils 변경 포함)

## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- 여러 번 테스트하며 검토 필요
