### PR TITLE
[#200] S3 + Lambda 인프라 배포를 위한 cross-origin 문제 해결

### DIFF
--- a/backend/app/ai/main.py
+++ b/backend/app/ai/main.py
@@ -1,12 +1,10 @@
 from fastapi import Depends, FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 from mangum import Mangum
 
 from app.ai.routers import steps, projects
 from app.core import exception_handlers
 from app.core.auth.csrf import verify_csrf
 from app.core.auth.dependencies import get_current_user_id
-from app.core.config import settings
 from app.core.logging import setup_logging
 from app.core.schemas.health import HealthResponse
 
@@ -14,13 +12,8 @@ setup_logging()
 
 app = FastAPI(title="Poco AI Orchestrator")
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=settings.CORS_ALLOWED_ORIGINS,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# CORS 는 Function URL 의 CORS 설정으로 edge 에서 처리.
+# FastAPI CORSMiddleware 를 켜면 헤더가 중복되어 브라우저가 거부함.
 
 exception_handlers.register(app)
 

--- a/backend/app/ai/main.py
+++ b/backend/app/ai/main.py
@@ -24,17 +24,14 @@ app.add_middleware(
 
 exception_handlers.register(app)
 
+_protected = [Depends(get_current_user_id), Depends(verify_csrf)]
 app.include_router(
-    steps.router,
-    tags=["ai"],
-    dependencies=[Depends(get_current_user_id), Depends(verify_csrf)],
+    steps.router, prefix="/steps", tags=["ai"], dependencies=_protected
+)
+app.include_router(
+    projects.router, prefix="/projects", tags=["ai"], dependencies=_protected
 )
 
-app.include_router(
-    projects.router,
-    tags=["ai"],
-    dependencies=[Depends(get_current_user_id), Depends(verify_csrf)],
-)
 
 @app.get("/health")
 def health() -> HealthResponse:

--- a/backend/app/ai/routers/projects.py
+++ b/backend/app/ai/routers/projects.py
@@ -35,7 +35,7 @@ class DesignExportRequest(BaseModel):
     selected_step_ids: list[UUID]
 
 
-@router.post("/projects/{project_id}/design-export")
+@router.post("/{project_id}/design-export")
 async def design_export_stream(
     project_id: UUID,
     payload: DesignExportRequest,

--- a/backend/app/ai/routers/steps.py
+++ b/backend/app/ai/routers/steps.py
@@ -17,19 +17,19 @@ from app.core.schemas.step import (
 router = EnvelopeRouter()
 
 
-@router.post("/steps/{step_id}/accept", status_code=http_status.HTTP_200_OK)
+@router.post("/{step_id}/accept", status_code=http_status.HTTP_200_OK)
 async def accept_step(
     step_id: UUID, db: Session = Depends(get_db)
 ) -> StepAcceptResponse:
     return await step_service.accept_step(db, step_id)
 
 
-@router.get("/steps/{step_id}", status_code=http_status.HTTP_200_OK)
+@router.get("/{step_id}", status_code=http_status.HTTP_200_OK)
 def get_step_detail(step_id: UUID, db: Session = Depends(get_db)) -> StepDetailResponse:
     return step_service.get_step_detail(db, step_id)
 
 
-@router.get("/steps/{step_id}/sidepanel-stream")
+@router.get("/{step_id}/sidepanel-stream")
 async def sidepanel_stream(step_id: UUID, db: Session = Depends(get_db)):
     """사이드패널 콘텐츠를 SSE 스트림으로 반환.
 

--- a/backend/app/business/routers/auth.py
+++ b/backend/app/business/routers/auth.py
@@ -62,7 +62,8 @@ def refresh_token(
     """Refresh Token 쿠키로 Access Token 갱신. 응답 쿠키도 모두 갱신.
 
     cross-site 셋업에서 프론트 JS가 쿠키를 읽을 수 없으므로,
-    새 csrf_token 값을 body로도 함께 반환한다.
+    새 csrf_token + access_token 값을 body로도 함께 반환한다.
+    access_token 은 AI Lambda Function URL 호출 시 Bearer 헤더로 사용.
     """
     if not refresh_token:
         raise InvalidTokenError("Refresh Token 쿠키가 없습니다.")
@@ -75,7 +76,7 @@ def refresh_token(
         refresh_token=tokens.refresh_token,
         csrf_token=csrf,
     )
-    return CsrfTokenResponse(csrf_token=csrf)
+    return CsrfTokenResponse(csrf_token=csrf, access_token=tokens.access_token)
 
 
 @router.post("/logout", status_code=http_status.HTTP_200_OK)
@@ -90,6 +91,9 @@ def logout(
 @router.get("/me", status_code=http_status.HTTP_200_OK)
 def get_me(
     user: AppUserModel = Depends(get_current_user),
+    access_token_cookie: str | None = Cookie(
+        default=None, alias=settings.ACCESS_COOKIE_NAME
+    ),
     csrf_cookie: str | None = Cookie(
         default=None, alias=settings.CSRF_COOKIE_NAME
     ),
@@ -97,9 +101,11 @@ def get_me(
 ) -> UserProfileResponse:
     """현재 로그인 사용자 정보.
 
-    cross-site 셋업에서 프론트가 쿠키를 직접 읽지 못하므로 csrf_token 값을
-    body 에도 실어 보낸다. 이미 발급되어 있는 값을 그대로 노출 (재발급 X).
+    cross-site 셋업에서 프론트가 쿠키를 직접 읽지 못하므로
+    csrf_token, access_token 을 body 에도 실어 보낸다.
+    access_token 은 AI Lambda Function URL 호출 시 Bearer 헤더로 사용.
     """
     profile = auth_service.get_user_profile(db, user)
     profile.csrf_token = csrf_cookie
+    profile.access_token = access_token_cookie
     return profile

--- a/backend/app/business/routers/auth.py
+++ b/backend/app/business/routers/auth.py
@@ -15,7 +15,7 @@ from app.core.auth.dependencies import get_current_user
 from app.core.config import settings
 from app.core.exceptions import InvalidTokenError
 from app.core.models.app_user import AppUser as AppUserModel
-from app.core.schemas.auth import UserProfileResponse
+from app.core.schemas.auth import CsrfTokenResponse, UserProfileResponse
 
 router = EnvelopeRouter()
 
@@ -58,8 +58,12 @@ def refresh_token(
     refresh_token: str | None = Cookie(
         default=None, alias=settings.REFRESH_COOKIE_NAME
     ),
-) -> None:
-    """Refresh Token 쿠키로 Access Token 갱신. 응답 쿠키도 모두 갱신."""
+) -> CsrfTokenResponse:
+    """Refresh Token 쿠키로 Access Token 갱신. 응답 쿠키도 모두 갱신.
+
+    cross-site 셋업에서 프론트 JS가 쿠키를 읽을 수 없으므로,
+    새 csrf_token 값을 body로도 함께 반환한다.
+    """
     if not refresh_token:
         raise InvalidTokenError("Refresh Token 쿠키가 없습니다.")
 
@@ -71,7 +75,7 @@ def refresh_token(
         refresh_token=tokens.refresh_token,
         csrf_token=csrf,
     )
-    return None
+    return CsrfTokenResponse(csrf_token=csrf)
 
 
 @router.post("/logout", status_code=http_status.HTTP_200_OK)
@@ -86,7 +90,16 @@ def logout(
 @router.get("/me", status_code=http_status.HTTP_200_OK)
 def get_me(
     user: AppUserModel = Depends(get_current_user),
+    csrf_cookie: str | None = Cookie(
+        default=None, alias=settings.CSRF_COOKIE_NAME
+    ),
     db: Session = Depends(get_db),
 ) -> UserProfileResponse:
-    """현재 로그인 사용자 정보."""
-    return auth_service.get_user_profile(db, user)
+    """현재 로그인 사용자 정보.
+
+    cross-site 셋업에서 프론트가 쿠키를 직접 읽지 못하므로 csrf_token 값을
+    body 에도 실어 보낸다. 이미 발급되어 있는 값을 그대로 노출 (재발급 X).
+    """
+    profile = auth_service.get_user_profile(db, user)
+    profile.csrf_token = csrf_cookie
+    return profile

--- a/backend/app/core/auth/csrf.py
+++ b/backend/app/core/auth/csrf.py
@@ -1,9 +1,16 @@
 """CSRF Double Submit Cookie 검증 의존성.
 
 원리:
-- 로그인 시 csrf_token을 쿠키(NON-HttpOnly)와 함께 발급
-- 프론트엔드는 mutating 요청 시 쿠키에서 csrf_token을 읽어 X-CSRF-Token 헤더에 첨부
+- 로그인 시 csrf_token 을 쿠키(NON-HttpOnly)와 함께 발급
+- 프론트엔드는 mutating 요청 시 쿠키에서 csrf_token 을 읽어 X-CSRF-Token 헤더에 첨부
 - 다른 사이트는 우리 도메인 쿠키를 JS로 읽지 못하므로 헤더 위조 불가 → CSRF 차단
+
+예외 — Bearer 헤더 인증:
+- AI Lambda Function URL 처럼 별도 도메인 호출은 쿠키가 안 가므로
+  Authorization: Bearer <token> 으로 인증한다.
+- 이 경우 브라우저가 자동 첨부하는 자격증명이 없어 CSRF 공격 자체가 성립 불가
+  (공격자가 sessionStorage 의 access_token 을 못 훔치는 한).
+- 따라서 Bearer 인증 요청은 CSRF 검증을 생략한다.
 """
 
 import secrets
@@ -20,10 +27,16 @@ def verify_csrf(
     request: Request,
     csrf_cookie: str | None = Cookie(default=None, alias=settings.CSRF_COOKIE_NAME),
     csrf_header: str | None = Header(default=None, alias=settings.CSRF_HEADER_NAME),
+    authorization: str | None = Header(default=None),
 ) -> None:
     """state-changing 메서드(POST/PUT/PATCH/DELETE)에서만 검증.
-    GET/HEAD/OPTIONS는 부수효과가 없으므로 검증 생략."""
+    GET/HEAD/OPTIONS는 부수효과가 없으므로 검증 생략.
+
+    Bearer 헤더로 인증한 요청은 CSRF 공격 불가능하므로 검증 생략.
+    """
     if request.method not in _MUTATING_METHODS:
+        return
+    if authorization and authorization.lower().startswith("bearer "):
         return
     if not csrf_cookie or not csrf_header:
         raise InvalidTokenError("CSRF 토큰이 누락되었습니다.")

--- a/backend/app/core/auth/dependencies.py
+++ b/backend/app/core/auth/dependencies.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from fastapi import Cookie, Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
 from app.core.auth.jwt import ACCESS_TOKEN_TYPE, decode_token
@@ -10,15 +11,25 @@ from app.core.exceptions import InvalidTokenError, UserNotFoundError
 from app.core.models.app_user import AppUser as AppUserModel
 from app.core.repositories import user as user_repo
 
+# Swagger UI 의 Authorize 버튼 활성화용. auto_error=False 라서
+# 헤더 없으면 None 이 들어오고, 우리가 직접 쿠키 폴백 처리.
+_bearer_scheme = HTTPBearer(auto_error=False)
+
 
 def get_current_user_id(
     access_token: str | None = Cookie(default=None, alias=settings.ACCESS_COOKIE_NAME),
+    bearer: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
 ) -> UUID:
-    """access_token 쿠키를 검증하고 user_id만 추출.
-    DB 조회가 필요 없는 경우(AI Lambda 등) 사용."""
-    if not access_token:
-        raise InvalidTokenError("Access Token 쿠키가 없습니다.")
-    return decode_token(access_token, expected_type=ACCESS_TOKEN_TYPE)
+    """access_token 을 검증하고 user_id만 추출.
+
+    우선순위: Cookie → Authorization Bearer 헤더.
+    AI Lambda 는 Function URL (별도 도메인) 으로 호출되어 쿠키가 안 가므로
+    프론트가 Bearer 헤더로 폴백한다.
+    """
+    token = access_token or (bearer.credentials if bearer else None)
+    if not token:
+        raise InvalidTokenError("Access Token 이 없습니다.")
+    return decode_token(token, expected_type=ACCESS_TOKEN_TYPE)
 
 
 def get_current_user(

--- a/backend/app/core/schemas/auth.py
+++ b/backend/app/core/schemas/auth.py
@@ -16,10 +16,14 @@ class UserProfileResponse(BaseModel):
     nickname: str
     provider: str
     csrf_token: str | None = None
+    # AI Lambda 의 Function URL 호출용 — 별도 도메인이라 쿠키가 안 가서
+    # 프론트가 Authorization: Bearer 로 보낼 수 있도록 body 로도 노출.
+    access_token: str | None = None
 
 
 class CsrfTokenResponse(BaseModel):
     csrf_token: str
+    access_token: str | None = None
 
 
 class OAuthUserInfo(BaseModel):

--- a/backend/app/core/schemas/auth.py
+++ b/backend/app/core/schemas/auth.py
@@ -15,6 +15,11 @@ class UserProfileResponse(BaseModel):
     email: str
     nickname: str
     provider: str
+    csrf_token: str | None = None
+
+
+class CsrfTokenResponse(BaseModel):
+    csrf_token: str
 
 
 class OAuthUserInfo(BaseModel):

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
-# 로컬 개발 시에는 비워두면 Vite proxy가 동작 (/api, /ai)
-# 배포 시 API Gateway URL을 설정
-VITE_API_URL=
-VITE_AI_URL=
+# Business 서버 base URL (미입력 시 http://localhost:8000)
+VITE_BUSINESS_SERVER_URL=
+# AI 서버 base URL (미입력 시 http://localhost:8001)
+VITE_AI_SERVER_URL=

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1185,9 +1185,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.10.30",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+      "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1266,9 +1266,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -1662,9 +1662,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.356",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
-      "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
+      "version": "1.5.357",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
       "dev": true,
       "license": "ISC"
     },

--- a/frontend/src/api/_client.js
+++ b/frontend/src/api/_client.js
@@ -27,10 +27,13 @@ const AI_ROUTES = [
   { method: 'POST', pattern: new RegExp(`^/projects/${UUID}/design-export$`) },
 ]
 
-function pickBaseUrl(method, path) {
+function isAiRoute(method, path) {
   const m = (method || 'GET').toUpperCase()
-  const isAi = AI_ROUTES.some((r) => r.method === m && r.pattern.test(path))
-  return isAi ? AI_BASE : BUSINESS_BASE
+  return AI_ROUTES.some((r) => r.method === m && r.pattern.test(path))
+}
+
+function pickBaseUrl(method, path) {
+  return isAiRoute(method, path) ? AI_BASE : BUSINESS_BASE
 }
 
 // path 를 절대 URL 로 변환. fetch (SSE 등) 직접 호출에 사용.
@@ -38,10 +41,15 @@ export function resolveApiUrl(method, path) {
   return `${pickBaseUrl(method, path)}${path}`
 }
 
-// cross-site 셋업에서 JS 가 csrf 쿠키를 읽을 수 없으므로,
-// 백엔드가 /auth/me, /auth/refresh 응답 body 로 내려준 값을
+// cross-site 셋업에서 JS 가 쿠키를 직접 읽을 수 없으므로,
+// 백엔드가 /auth/me, /auth/refresh 응답 body 로 내려준 토큰들을
 // sessionStorage 에 보관해 헤더로 부착한다.
+//
+// - csrf_token : 모든 mutating 요청의 X-CSRF-Token 헤더
+// - access_token: AI Lambda Function URL 호출 시 Authorization 헤더
+//                 (Function URL 은 별도 도메인이라 쿠키가 안 감)
 const CSRF_STORAGE_KEY = 'csrf_token'
+const ACCESS_TOKEN_STORAGE_KEY = 'access_token'
 
 export function getCsrfToken() {
   try {
@@ -60,13 +68,34 @@ export function setCsrfToken(token) {
   }
 }
 
-export function clearCsrfToken() {
+export function getAccessToken() {
   try {
-    sessionStorage.removeItem(CSRF_STORAGE_KEY)
+    return sessionStorage.getItem(ACCESS_TOKEN_STORAGE_KEY) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function setAccessToken(token) {
+  if (!token) return
+  try {
+    sessionStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, token)
   } catch {
     /* */
   }
 }
+
+export function clearAuthTokens() {
+  try {
+    sessionStorage.removeItem(CSRF_STORAGE_KEY)
+    sessionStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY)
+  } catch {
+    /* */
+  }
+}
+
+// 후위 호환을 위해 유지 (auth.js 의 logout 에서 사용)
+export const clearCsrfToken = clearAuthTokens
 
 // 동시 다발의 401 을 한 번의 refresh 로 합치기 위한 단일 promise.
 let refreshPromise = null
@@ -76,9 +105,10 @@ function refreshTokens() {
     refreshPromise = axios
       .post(`${BUSINESS_BASE}/auth/refresh`, null, { withCredentials: true })
       .then((res) => {
-        // 새 csrf_token 을 응답 body 에서 받아 sessionStorage 갱신
-        const newCsrf = res?.data?.data?.csrf_token
-        if (newCsrf) setCsrfToken(newCsrf)
+        // 새 csrf_token / access_token 을 응답 body 에서 받아 sessionStorage 갱신
+        const data = res?.data?.data
+        if (data?.csrf_token) setCsrfToken(data.csrf_token)
+        if (data?.access_token) setAccessToken(data.access_token)
         return res
       })
       .finally(() => {
@@ -107,16 +137,22 @@ export function createApi() {
 
   attachRouting(instance)
 
-  // CSRF 헤더 부착
+  // CSRF + Authorization Bearer 헤더 부착
   instance.interceptors.request.use((config) => {
+    config.headers = config.headers ?? {}
+
     const mutating = ['post', 'put', 'patch', 'delete']
     if (mutating.includes(config.method?.toLowerCase())) {
       const csrf = getCsrfToken()
-      if (csrf) {
-        config.headers = config.headers ?? {}
-        config.headers['X-CSRF-Token'] = csrf
-      }
+      if (csrf) config.headers['X-CSRF-Token'] = csrf
     }
+
+    // AI 라우트는 별도 도메인이라 쿠키가 안 가므로 Bearer 헤더로 폴백
+    if (isAiRoute(config.method, config.url)) {
+      const accessToken = getAccessToken()
+      if (accessToken) config.headers['Authorization'] = `Bearer ${accessToken}`
+    }
+
     return config
   })
 
@@ -124,9 +160,10 @@ export function createApi() {
   instance.interceptors.response.use(
     (res) => {
       const data = res.data?.data
-      // /auth/me 응답에 포함된 csrf_token 을 자동으로 sessionStorage 에 저장
-      if (data && typeof data === 'object' && data.csrf_token) {
-        setCsrfToken(data.csrf_token)
+      // /auth/me, /auth/refresh 등의 응답에 토큰이 포함되면 sessionStorage 갱신
+      if (data && typeof data === 'object') {
+        if (data.csrf_token) setCsrfToken(data.csrf_token)
+        if (data.access_token) setAccessToken(data.access_token)
       }
       return data
     },
@@ -145,9 +182,13 @@ export function createApi() {
         original._retry = true
         try {
           await refreshTokens()
+          // refresh 로 갱신된 새 토큰들로 헤더 교체
+          original.headers = original.headers ?? {}
           const newCsrf = getCsrfToken()
-          if (newCsrf && original.headers) {
-            original.headers['X-CSRF-Token'] = newCsrf
+          if (newCsrf) original.headers['X-CSRF-Token'] = newCsrf
+          if (isAiRoute(original.method, original.url)) {
+            const newAccess = getAccessToken()
+            if (newAccess) original.headers['Authorization'] = `Bearer ${newAccess}`
           }
           return instance(original)
         } catch (refreshErr) {

--- a/frontend/src/api/_client.js
+++ b/frontend/src/api/_client.js
@@ -1,16 +1,42 @@
 import axios from 'axios'
 
 // ─────────────────────────────────────────────────────────────
-// 공통 axios 클라이언트 팩토리
-// - withCredentials (HttpOnly 쿠키 자동 전송)
-// - 변경 요청에 X-CSRF-Token 헤더 부착
-// - 응답 envelope 자동 unwrap (res.data.data)
-// - 401 응답 시 자동으로 /auth/refresh 후 원래 요청 재시도
-// - refresh 가 동시 다발로 호출되지 않도록 단일 promise 큐
-// - refresh 자체가 실패하면 /login 으로 리다이렉트
+// 통합 axios 클라이언트
+//
+// - 호출부는 백엔드 path 를 그대로 쓴다 (예: '/projects', '/steps/tree').
+//   ai/business 구분은 이 파일이 path 패턴으로 자동 분기한다.
+// - 서버 주소는 환경변수 VITE_BUSINESS_SERVER_URL / VITE_AI_SERVER_URL
+//   에서 받고, 미설정 시 localhost 기본값을 사용한다.
+// - 동시 다발의 401 은 단일 refresh promise 로 합치고, refresh 자체가
+//   실패하면 /login 으로 보낸다.
 // ─────────────────────────────────────────────────────────────
 
-const BASE_URL = import.meta.env.VITE_API_URL || '/api'
+const BUSINESS_BASE =
+  import.meta.env.VITE_BUSINESS_SERVER_URL || 'http://localhost:8000'
+const AI_BASE =
+  import.meta.env.VITE_AI_SERVER_URL || 'http://localhost:8001'
+
+const UUID =
+  '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+
+// AI 서버로 보낼 (method, path) 패턴. 그 외는 전부 business.
+const AI_ROUTES = [
+  { method: 'POST', pattern: new RegExp(`^/steps/${UUID}/accept$`) },
+  { method: 'GET', pattern: new RegExp(`^/steps/${UUID}/sidepanel-stream$`) },
+  { method: 'GET', pattern: new RegExp(`^/steps/${UUID}$`) },
+  { method: 'POST', pattern: new RegExp(`^/projects/${UUID}/design-export$`) },
+]
+
+function pickBaseUrl(method, path) {
+  const m = (method || 'GET').toUpperCase()
+  const isAi = AI_ROUTES.some((r) => r.method === m && r.pattern.test(path))
+  return isAi ? AI_BASE : BUSINESS_BASE
+}
+
+// path 를 절대 URL 로 변환. fetch (SSE 등) 직접 호출에 사용.
+export function resolveApiUrl(method, path) {
+  return `${pickBaseUrl(method, path)}${path}`
+}
 
 function getCsrfToken() {
   return document.cookie
@@ -24,11 +50,9 @@ let refreshPromise = null
 
 function refreshTokens() {
   if (!refreshPromise) {
-    // 별도 axios 인스턴스로 호출 — 글로벌 instance 의 인터셉터를 거치지 않음(무한 루프 방지)
     refreshPromise = axios
-      .post(`${BASE_URL}/auth/refresh`, null, { withCredentials: true })
+      .post(`${BUSINESS_BASE}/auth/refresh`, null, { withCredentials: true })
       .finally(() => {
-        // 다음 만료 시 새 promise 생성될 수 있도록 비움
         refreshPromise = null
       })
   }
@@ -37,14 +61,22 @@ function refreshTokens() {
 
 function redirectToLogin() {
   if (typeof window === 'undefined') return
-  // 이미 로그인 페이지에 있으면 무한 루프 방지
   const path = window.location.pathname
   if (path === '/login' || path === '/' || path.startsWith('/shared/')) return
   window.location.href = '/login'
 }
 
-export function createApi(baseURL = BASE_URL) {
-  const instance = axios.create({ baseURL, withCredentials: true })
+function attachRouting(instance) {
+  instance.interceptors.request.use((config) => {
+    config.baseURL = pickBaseUrl(config.method, config.url)
+    return config
+  })
+}
+
+export function createApi() {
+  const instance = axios.create({ withCredentials: true })
+
+  attachRouting(instance)
 
   // CSRF 헤더 부착
   instance.interceptors.request.use((config) => {
@@ -66,18 +98,17 @@ export function createApi(baseURL = BASE_URL) {
       const original = err.config
       const status = err.response?.status
 
-      // 1) refresh 자체가 실패한 경우 — 무한 루프 방지
+      // refresh 자체가 실패 — 무한 루프 방지
       if (original?.url?.endsWith('/auth/refresh')) {
         redirectToLogin()
         return Promise.reject(err.response?.data?.error ?? err)
       }
 
-      // 2) 401 응답 — refresh 후 원래 요청 재시도 (한 번만)
+      // 401 응답 — refresh 후 원래 요청 한 번 재시도
       if (status === 401 && original && !original._retry) {
         original._retry = true
         try {
           await refreshTokens()
-          // refresh 성공 시 새 csrf 토큰이 쿠키로 내려왔으므로 헤더 갱신
           const newCsrf = getCsrfToken()
           if (newCsrf && original.headers) {
             original.headers['X-CSRF-Token'] = newCsrf
@@ -97,8 +128,9 @@ export function createApi(baseURL = BASE_URL) {
 }
 
 // 인증 없이 동작하는 read-only 클라이언트 (share 페이지용)
-export function createPublicApi(baseURL = BASE_URL) {
-  const instance = axios.create({ baseURL, withCredentials: true })
+export function createPublicApi() {
+  const instance = axios.create({ withCredentials: true })
+  attachRouting(instance)
   instance.interceptors.response.use(
     (res) => res.data?.data,
     (err) => Promise.reject(err.response?.data?.error ?? err)

--- a/frontend/src/api/_client.js
+++ b/frontend/src/api/_client.js
@@ -38,11 +38,34 @@ export function resolveApiUrl(method, path) {
   return `${pickBaseUrl(method, path)}${path}`
 }
 
-function getCsrfToken() {
-  return document.cookie
-    .split('; ')
-    .find((row) => row.startsWith('csrf_token='))
-    ?.split('=')[1]
+// cross-site 셋업에서 JS 가 csrf 쿠키를 읽을 수 없으므로,
+// 백엔드가 /auth/me, /auth/refresh 응답 body 로 내려준 값을
+// sessionStorage 에 보관해 헤더로 부착한다.
+const CSRF_STORAGE_KEY = 'csrf_token'
+
+export function getCsrfToken() {
+  try {
+    return sessionStorage.getItem(CSRF_STORAGE_KEY) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function setCsrfToken(token) {
+  if (!token) return
+  try {
+    sessionStorage.setItem(CSRF_STORAGE_KEY, token)
+  } catch {
+    /* sessionStorage 불가 환경 — 무시 */
+  }
+}
+
+export function clearCsrfToken() {
+  try {
+    sessionStorage.removeItem(CSRF_STORAGE_KEY)
+  } catch {
+    /* */
+  }
 }
 
 // 동시 다발의 401 을 한 번의 refresh 로 합치기 위한 단일 promise.
@@ -52,6 +75,12 @@ function refreshTokens() {
   if (!refreshPromise) {
     refreshPromise = axios
       .post(`${BUSINESS_BASE}/auth/refresh`, null, { withCredentials: true })
+      .then((res) => {
+        // 새 csrf_token 을 응답 body 에서 받아 sessionStorage 갱신
+        const newCsrf = res?.data?.data?.csrf_token
+        if (newCsrf) setCsrfToken(newCsrf)
+        return res
+      })
       .finally(() => {
         refreshPromise = null
       })
@@ -93,7 +122,14 @@ export function createApi() {
 
   // 응답: envelope unwrap + 401 자동 refresh & retry
   instance.interceptors.response.use(
-    (res) => res.data?.data,
+    (res) => {
+      const data = res.data?.data
+      // /auth/me 응답에 포함된 csrf_token 을 자동으로 sessionStorage 에 저장
+      if (data && typeof data === 'object' && data.csrf_token) {
+        setCsrfToken(data.csrf_token)
+      }
+      return data
+    },
     async (err) => {
       const original = err.config
       const status = err.response?.status

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,6 +1,13 @@
-import { createApi } from './_client'
+import { clearCsrfToken, createApi } from './_client'
 
 const api = createApi()
 
 export const getMe = () => api.get('/auth/me')
-export const logout = () => api.post('/auth/logout')
+
+export const logout = async () => {
+  try {
+    return await api.post('/auth/logout')
+  } finally {
+    clearCsrfToken()
+  }
+}

--- a/frontend/src/api/exports.js
+++ b/frontend/src/api/exports.js
@@ -1,4 +1,4 @@
-import { createApi, getCsrfToken, resolveApiUrl } from './_client'
+import { createApi, getAccessToken, getCsrfToken, resolveApiUrl } from './_client'
 
 const api = createApi()
 
@@ -17,6 +17,7 @@ export function createDesignExportStream(projectId, selectedStepIds) {
       ;(async () => {
         try {
           const csrf = getCsrfToken()
+          const accessToken = getAccessToken()
           const url = resolveApiUrl('POST', `/projects/${projectId}/design-export`)
           const res = await fetch(url, {
             method: 'POST',
@@ -25,6 +26,7 @@ export function createDesignExportStream(projectId, selectedStepIds) {
               'Content-Type': 'application/json',
               Accept: 'text/event-stream',
               ...(csrf ? { 'X-CSRF-Token': csrf } : {}),
+              ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
             },
             body: JSON.stringify({ selected_step_ids: selectedStepIds }),
             signal: abortController.signal,

--- a/frontend/src/api/exports.js
+++ b/frontend/src/api/exports.js
@@ -1,13 +1,6 @@
-import { createApi, resolveApiUrl } from './_client'
+import { createApi, getCsrfToken, resolveApiUrl } from './_client'
 
 const api = createApi()
-
-function getCsrfToken() {
-  return document.cookie
-    .split('; ')
-    .find((row) => row.startsWith('csrf_token='))
-    ?.split('=')[1]
-}
 
 // 1) 사전 조회 — accept된 RS 목록
 export const getAcceptedRequiredSteps = (projectId) =>

--- a/frontend/src/api/exports.js
+++ b/frontend/src/api/exports.js
@@ -1,19 +1,17 @@
-import { createApi } from './_client'
+import { createApi, resolveApiUrl } from './_client'
 
-const api = createApi()                                          // Business (/api)
-const AI_BASE = import.meta.env.VITE_AI_URL || '/ai'
+const api = createApi()
 
 function getCsrfToken() {
   return document.cookie
     .split('; ')
-    .find(row => row.startsWith('csrf_token='))
+    .find((row) => row.startsWith('csrf_token='))
     ?.split('=')[1]
 }
 
 // 1) 사전 조회 — accept된 RS 목록
 export const getAcceptedRequiredSteps = (projectId) =>
   api.get(`/projects/${projectId}/accepted-required-steps`)
-  // 응답 envelope unwrap 후: { required_steps: [{ step_id, name, stage_sequence }, ...] }
 
 // 2) design-export SSE
 export function createDesignExportStream(projectId, selectedStepIds) {
@@ -26,12 +24,13 @@ export function createDesignExportStream(projectId, selectedStepIds) {
       ;(async () => {
         try {
           const csrf = getCsrfToken()
-          const res = await fetch(`${AI_BASE}/projects/${projectId}/design-export`, {
+          const url = resolveApiUrl('POST', `/projects/${projectId}/design-export`)
+          const res = await fetch(url, {
             method: 'POST',
             credentials: 'include',
             headers: {
               'Content-Type': 'application/json',
-              'Accept': 'text/event-stream',
+              Accept: 'text/event-stream',
               ...(csrf ? { 'X-CSRF-Token': csrf } : {}),
             },
             body: JSON.stringify({ selected_step_ids: selectedStepIds }),
@@ -43,7 +42,9 @@ export function createDesignExportStream(projectId, selectedStepIds) {
             try {
               const body = await res.json()
               code = body?.error?.code ?? body?.code ?? code
-            } catch { /* */ }
+            } catch {
+              /* */
+            }
             onError?.({ code, status: res.status })
             return
           }
@@ -73,7 +74,11 @@ export function createDesignExportStream(projectId, selectedStepIds) {
                 }
 
                 let data
-                try { data = JSON.parse(dataStr) } catch { data = null }
+                try {
+                  data = JSON.parse(dataStr)
+                } catch {
+                  data = null
+                }
 
                 if (currentEvent === 'complete') {
                   onComplete?.(data)

--- a/frontend/src/api/shared.js
+++ b/frontend/src/api/shared.js
@@ -1,6 +1,5 @@
 import { createPublicApi } from './_client'
 
-// 공유 토큰 기반 read-only API — 인증 불필요, refresh 로직 불필요
 const api = createPublicApi()
 
 export const getSharedProject = (shareToken) =>

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -1,4 +1,4 @@
-import { createApi, resolveApiUrl } from './_client'
+import { createApi, getAccessToken, resolveApiUrl } from './_client'
 
 const api = createApi()
 
@@ -30,10 +30,12 @@ export function createSidePanelStream(stepId) {
       ;(async () => {
         try {
           const url = resolveApiUrl('GET', `/steps/${stepId}/sidepanel-stream`)
+          const accessToken = getAccessToken()
           const response = await fetch(url, {
             method: 'GET',
             headers: {
               Accept: 'text/event-stream',
+              ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
             },
             credentials: 'include',
             signal: abortController.signal,

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -1,7 +1,6 @@
-import { createApi } from './_client'
+import { createApi, resolveApiUrl } from './_client'
 
-const api = createApi() // Business Lambda (/api)
-const aiApi = createApi(import.meta.env.VITE_AI_URL || '/ai') // AI Lambda (/ai)
+const api = createApi()
 
 export const getStepTree = (projectId, stageId) =>
   api.get('/steps/tree', { params: { project_id: projectId, stage_id: stageId } })
@@ -10,10 +9,10 @@ export const getStepTreeBySequence = (projectId, stageSequence) =>
   api.get('/steps/tree', { params: { project_id: projectId, stage_sequence: stageSequence } })
 
 export const acceptStep = (stepId) =>
-  aiApi.post(`/steps/${stepId}/accept`)
+  api.post(`/steps/${stepId}/accept`)
 
 export const getStepDetail = (stepId) =>
-  aiApi.get(`/steps/${stepId}`)
+  api.get(`/steps/${stepId}`)
 
 export const rollbackStep = (stepId) =>
   api.post(`/steps/${stepId}/rollback`)
@@ -30,7 +29,8 @@ export function createSidePanelStream(stepId) {
 
       ;(async () => {
         try {
-          const response = await fetch(`${import.meta.env.VITE_AI_URL || '/ai'}/steps/${stepId}/sidepanel-stream`, {
+          const url = resolveApiUrl('GET', `/steps/${stepId}/sidepanel-stream`)
+          const response = await fetch(url, {
             method: 'GET',
             headers: {
               Accept: 'text/event-stream',

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,10 +1,11 @@
 import styles from './LoginPage.module.css'
 import { SiGoogle, SiNaver } from 'react-icons/si'
+import { resolveApiUrl } from '../api/_client'
 
 
 export default function LoginPage() {
   function handleLogin(provider) {
-    window.location.href = `${import.meta.env.VITE_API_URL || '/api'}/auth/${provider}/login`
+    window.location.href = resolveApiUrl('GET', `/auth/${provider}/login`)
   }
 
   return (


### PR DESCRIPTION
## Summary

S3 (프론트) + Lambda (백엔드) 배포 과정에서 cross-origin 환경 때문에 발생한 인증·CORS·스트리밍 이슈를 해결하기 위한 일련의 수정.

## 변경 내용

### 1. AI Lambda 의 business 의존성 제거
`app/ai/routers/projects.py` 가 `app.business.services.project_service` 를 import 하던 부분 제거. `app.core.repositories.project.get_active_project_by_id` 로 대체하여 Lambda_B 가 business 코드 없이 독립적으로 동작 가능해짐.

### 2. CSRF 토큰을 cross-site 환경에서 읽을 수 있도록 수정
csrf_token 쿠키가 API Gateway 도메인에 묶여 있어 S3 프론트엔드 JS 의 `document.cookie` 로 읽을 수 없는 문제. `/auth/me`, `/auth/refresh` 응답 body 에 `csrf_token` 을 함께 내려보내고, 프론트 `_client.js` 가 sessionStorage 에서 읽어 X-CSRF-Token 헤더에 자동 부착하도록 변경.

### 3. 프론트엔드 환경변수 분리
`VITE_API_URL` / `VITE_AI_URL` → `VITE_BUSINESS_SERVER_URL` / `VITE_AI_SERVER_URL` 로 변경. AI 서버를 Function URL (별도 도메인) 로 분리하면서 business / AI 가 완전히 다른 서버 주소를 갖게 됨에 따라, 변수명도 "서버 주소" 임을 명확히 드러내도록 통일.

### 4. AI Lambda 응답 스트리밍 활성화
API Gateway 는 응답 스트리밍을 지원하지 않아 SSE (sidepanel-stream, design-export) 가 한 번에 받아지는 문제.
- AI Lambda 를 **Lambda Web Adapter + Function URL response streaming** 모드로 전환
- `build/lambda-b-run.sh` 신규 — uvicorn 진입 스크립트 + PYTHONPATH 설정
- `build/build.sh` 의 lambda-b 빌드에 `run.sh` 포함 + 실행 권한 부여

### 5. Function URL 전환에 따른 인증 / CORS / CSRF 정비
AI Lambda 가 Function URL (`*.lambda-url.*.on.aws`) 로 옮겨가면서 business 도메인과 origin 이 분리됨. 그에 따른 세 가지 후속 조치:

**5-1. 쿠키 인증 → Bearer 헤더 인증 (AI 한정)**
쿠키는 발급된 도메인에만 묶여서 다른 도메인으로 자동 전송되지 않고, 두 도메인이 공유 가능한 상위 도메인도 없음 (`on.aws` 가 public suffix). AI 호출은 쿠키 대신 `Authorization: Bearer <access_token>` 헤더로 인증하도록 변경.
- `get_current_user_id`: Cookie 우선, 없으면 Bearer 헤더 폴백 (HTTPBearer 보안 스키마 사용 — Swagger UI 의 Authorize 버튼 호환)
- `/auth/me`, `/auth/refresh` 응답 body 에 `access_token` 포함 → 프론트가 sessionStorage 보관 후 AI 호출 시 자동 부착

**5-2. CORS 헤더 중복 제거**
Function URL CORS 설정 + FastAPI CORSMiddleware 가 둘 다 Access-Control-* 헤더를 추가해 브라우저가 중복 헤더로 거부. AI Lambda 의 `CORSMiddleware` 제거하고 Function URL edge 에서만 처리.

**5-3. Bearer 인증 시 CSRF 검증 우회**
`verify_csrf` 가 쿠키+헤더 일치를 요구하는데 Function URL 호출은 쿠키 없음. Bearer 헤더는 브라우저가 자동 첨부하지 않고 JS 가 명시 부착해야 하므로 CSRF 공격이 성립 불가 → Bearer 인증 요청은 CSRF 검증 생략.

## 변경 파일

**Backend**
- `build/build.sh`, `build/lambda-b-run.sh` (신규)
- `backend/app/ai/main.py`, `backend/app/ai/routers/{projects,steps}.py`
- `backend/app/business/routers/auth.py`
- `backend/app/core/auth/{csrf,dependencies}.py`
- `backend/app/core/schemas/auth.py`

**Frontend**
- `frontend/src/api/_client.js` (전면 재작성)
- `frontend/src/api/{auth,projects,stage,shared,step,exports}.js`
- `frontend/src/pages/LoginPage.jsx`
- `frontend/.env.example`

## Test plan

- [ ] Lambda_A (business) ZIP 빌드 & 업로드 후 동작 확인
- [ ] Lambda_B (ai) ZIP 빌드 & Function URL response streaming 모드로 동작 확인
- [ ] 프론트엔드 빌드 & S3 sync 후 로그인 정상
- [ ] AI 라우트 호출 시 Authorization Bearer 헤더가 자동 부착되는지 (DevTools Network)
- [ ] sidepanel-stream / design-export SSE 가 chunk 단위로 도착하는지
- [x] accept 등 mutating AI 요청이 CSRF 검증 통과하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)