### PR TITLE
[#202] Side Panel / Design Export 비동기 폴링 방식 전환

### DIFF
--- a/backend/alembic/versions/c3a91f4b27e0_add_side_panel_streaming_columns.py
+++ b/backend/alembic/versions/c3a91f4b27e0_add_side_panel_streaming_columns.py
@@ -1,0 +1,45 @@
+"""add side panel streaming columns to step_content
+
+비동기 폴링 방식의 side panel 생성 — chunk 도착마다 streaming_raw 누적,
+폴링 endpoint 가 streaming_status 와 함께 노출.
+
+Revision ID: c3a91f4b27e0
+Revises: 8d7474fd5838
+Create Date: 2026-05-18 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c3a91f4b27e0"
+down_revision: Union[str, None] = "8d7474fd5838"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "step_content",
+        sa.Column(
+            "streaming_status",
+            sa.String(length=16),
+            nullable=False,
+            server_default="idle",
+        ),
+    )
+    op.add_column(
+        "step_content",
+        sa.Column(
+            "streaming_raw",
+            sa.Text(),
+            nullable=False,
+            server_default="",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("step_content", "streaming_raw")
+    op.drop_column("step_content", "streaming_status")

--- a/backend/alembic/versions/d8e2c1a04b91_add_design_export_job_table.py
+++ b/backend/alembic/versions/d8e2c1a04b91_add_design_export_job_table.py
@@ -1,0 +1,63 @@
+"""add design_export_job table
+
+비동기 폴링 방식의 design-export — 작업별 row 생성 후 폴링으로 결과 조회.
+
+Revision ID: d8e2c1a04b91
+Revises: c3a91f4b27e0
+Create Date: 2026-05-18 00:01:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "d8e2c1a04b91"
+down_revision: Union[str, None] = "c3a91f4b27e0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "design_export_job",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "project_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("project.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("markdown", sa.Text(), nullable=True),
+        sa.Column("filename", sa.String(length=255), nullable=True),
+        sa.Column("error_code", sa.String(length=64), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_design_export_job_project_id",
+        "design_export_job",
+        ["project_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_design_export_job_project_id", table_name="design_export_job")
+    op.drop_table("design_export_job")

--- a/backend/app/ai/main.py
+++ b/backend/app/ai/main.py
@@ -24,17 +24,14 @@ app.add_middleware(
 
 exception_handlers.register(app)
 
+_protected = [Depends(get_current_user_id), Depends(verify_csrf)]
 app.include_router(
-    steps.router,
-    tags=["ai"],
-    dependencies=[Depends(get_current_user_id), Depends(verify_csrf)],
+    steps.router, prefix="/steps", tags=["ai"], dependencies=_protected
+)
+app.include_router(
+    projects.router, prefix="/projects", tags=["ai"], dependencies=_protected
 )
 
-app.include_router(
-    projects.router,
-    tags=["ai"],
-    dependencies=[Depends(get_current_user_id), Depends(verify_csrf)],
-)
 
 @app.get("/health")
 def health() -> HealthResponse:

--- a/backend/app/ai/routers/projects.py
+++ b/backend/app/ai/routers/projects.py
@@ -35,7 +35,7 @@ class DesignExportRequest(BaseModel):
     selected_step_ids: list[UUID]
 
 
-@router.post("/projects/{project_id}/design-export")
+@router.post("/{project_id}/design-export")
 async def design_export_stream(
     project_id: UUID,
     payload: DesignExportRequest,

--- a/backend/app/ai/routers/projects.py
+++ b/backend/app/ai/routers/projects.py
@@ -1,47 +1,56 @@
-"""design-export SSE 엔드포인트."""
+"""Design Export 비동기 폴링 시작 엔드포인트."""
 
 from __future__ import annotations
 
-import asyncio
-import json
 from datetime import datetime, timezone, timedelta
 
 KST = timezone(timedelta(hours=9))
 from uuid import UUID
 
 from fastapi import Depends
-from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from fastapi import status as http_status
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
-from ai.exceptions import BedrockAPIError, AIGenerationFailedError, OutputViolatesHonestyGuardError
-from app.ai.services import orchestrator
-from app.ai.services import design_export_service, design_export_renderer
+from ai.exceptions import (
+    AIGenerationFailedError,
+    BedrockAPIError,
+    OutputViolatesHonestyGuardError,
+)
+from app.ai.services import design_export_renderer, design_export_service, orchestrator
 from app.core.api.route import EnvelopeRouter
 from app.core.database import get_db
-from app.core.exceptions import (
-    DesignExportEmptySelectionError,
-    DesignExportInactiveStepError,
-    DesignExportInvalidStepIdError,
-    DesignExportRateLimitError,
-    ProjectNotFoundError,
-)
+from app.core.exceptions import ProjectNotFoundError
 from app.core.repositories import project as project_repo
+from app.core.schemas.project import (
+    DesignExportStartRequest,
+    DesignExportStartResponse,
+)
+from app.core.schemas.response import SuccessResponse
 
 router = EnvelopeRouter()
 
 
-class DesignExportRequest(BaseModel):
-    selected_step_ids: list[UUID]
-
-
-@router.post("/{project_id}/design-export")
-async def design_export_stream(
+@router.post(
+    "/{project_id}/design-export-start",
+    status_code=http_status.HTTP_202_ACCEPTED,
+)
+async def start_design_export(
     project_id: UUID,
-    payload: DesignExportRequest,
+    payload: DesignExportStartRequest,
     db: Session = Depends(get_db),
 ):
-    # SSE 시작 전 검증 — 여기서 raise하면 HTTP 상태코드 정상 반환
+    """Design Export 생성을 시작한다 (비동기 폴링 방식).
+
+    - 새로 시작: 202 Accepted + { job_id, status: 'pending' or 'done' or 'error' }
+      (실제로는 같은 invocation 내에서 LLM 까지 끝까지 실행하므로
+       응답 시점에 이미 done 또는 error 일 수 있음)
+    - 이미 완료된 job_id 재호출: 200 OK + { job_id, status: 'done' or 'error' }
+      (멱등 — 재실행 없이 기존 결과 신호)
+
+    클라이언트는 응답을 기다리지 않고 즉시 폴링을 시작하는 fire-and-forget 패턴.
+    """
+    # 사전 검증 — 잘못된 입력은 즉시 4xx
     project = project_repo.get_active_project_by_id(db, project_id)
     if not project:
         raise ProjectNotFoundError()
@@ -50,28 +59,38 @@ async def design_export_stream(
         db, project_id, payload.selected_step_ids
     )
 
-    async def event_generator():
-        async def call_ai():
-            return await orchestrator.call_design_export(input_data)
+    # 이미 종료된 job_id 가 들어오면 멱등 응답 (재실행 X)
+    from app.core.models.design_export_job import DesignExportJob
 
-        ai_task = asyncio.create_task(call_ai())
+    existing = db.get(DesignExportJob, payload.job_id)
+    if existing is not None and existing.status in ("done", "error"):
+        body = SuccessResponse(
+            data=DesignExportStartResponse(
+                job_id=payload.job_id, status=existing.status
+            )
+        ).model_dump(mode="json")
+        return JSONResponse(status_code=http_status.HTTP_200_OK, content=body)
 
-        while not ai_task.done():
-            yield "event: keepalive\ndata: {}\n\n"
-            await asyncio.sleep(10)
+    # job row 생성 (status=pending)
+    design_export_service.create_job(db, payload.job_id, project_id)
 
-        try:
-            ai_output = ai_task.result()
-        except (BedrockAPIError, AIGenerationFailedError):
-            yield f"event: error\ndata: {json.dumps({'code': 'DESIGN_EXPORT_AI_FAILED'})}\n\n"
-            return
-        except OutputViolatesHonestyGuardError:
-            yield f"event: error\ndata: {json.dumps({'code': 'DESIGN_EXPORT_INVALID_OUTPUT'})}\n\n"
-            return
+    # LLM 실행 — 같은 invocation 에서 끝까지 진행. Lambda timeout 까지 계속 실행.
+    try:
+        ai_output = await orchestrator.call_design_export(input_data)
+    except (BedrockAPIError, AIGenerationFailedError):
+        design_export_service.mark_job_error(
+            db, payload.job_id, "DESIGN_EXPORT_AI_FAILED"
+        )
+        return DesignExportStartResponse(job_id=payload.job_id, status="error")
+    except OutputViolatesHonestyGuardError:
+        design_export_service.mark_job_error(
+            db, payload.job_id, "DESIGN_EXPORT_INVALID_OUTPUT"
+        )
+        return DesignExportStartResponse(job_id=payload.job_id, status="error")
 
-        now_kst = datetime.now(KST)
-        md = design_export_renderer.render(input_data, ai_output)
-        filename = f"design_{now_kst:%Y-%m-%d_%H-%M}.md"
-        yield f"event: complete\ndata: {json.dumps({'markdown': md, 'filename': filename}, ensure_ascii=False)}\n\n"
+    now_kst = datetime.now(KST)
+    md = design_export_renderer.render(input_data, ai_output)
+    filename = f"design_{now_kst:%Y-%m-%d_%H-%M}.md"
+    design_export_service.mark_job_done(db, payload.job_id, md, filename)
 
-    return StreamingResponse(event_generator(), media_type="text/event-stream")
+    return DesignExportStartResponse(job_id=payload.job_id, status="done")

--- a/backend/app/ai/routers/steps.py
+++ b/backend/app/ai/routers/steps.py
@@ -1,3 +1,4 @@
+import asyncio
 from uuid import UUID
 
 from fastapi import Depends
@@ -8,6 +9,7 @@ from sqlalchemy.orm import Session
 from app.ai.services import step_service
 from app.core.api.route import EnvelopeRouter
 from app.core.database import get_db
+from app.core.logging import get_logger
 from app.core.models.step import StepContent as StepContentModel
 from app.core.schemas.response import SuccessResponse
 from app.core.schemas.step import (
@@ -15,6 +17,8 @@ from app.core.schemas.step import (
     StepAcceptResponse,
     StepDetailResponse,
 )
+
+logger = get_logger(__name__)
 
 router = EnvelopeRouter()
 
@@ -62,6 +66,26 @@ async def start_side_panel(step_id: UUID, db: Session = Depends(get_db)):
             step_id=step.id, status=content.streaming_status
         )
 
-    # 새로 시작 — 같은 invocation 에서 LLM 실행. Lambda timeout 까지 계속 진행.
-    await step_service.run_side_panel_generation(db, step_id)
+    # 새로 시작 — 같은 invocation 에서 LLM 실행.
+    # 클라이언트가 끊겨도(새로고침 등) LLM 스트림이 cancel 되지 않도록 shield 로 격리한다.
+    # 핸들러는 작업이 끝날 때까지 살아있어 Lambda invocation 도 종료되지 않는다.
+    task = asyncio.create_task(
+        step_service.run_side_panel_generation(db, step_id)
+    )
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            # 클라이언트 끊김으로 인한 핸들러 취소 — task 는 shield 로 보호되어 계속 실행.
+            # 다음 iteration 에서 task 가 끝날 때까지 계속 대기한다.
+            logger.info(
+                "ai: side_panel handler cancelled by client — task continues under shield",
+                extra={"step_id": str(step_id)},
+            )
+            continue
+
+    exc = task.exception()
+    if exc is not None:
+        raise exc
+
     return SidePanelStartResponse(step_id=step.id, status="done")

--- a/backend/app/ai/routers/steps.py
+++ b/backend/app/ai/routers/steps.py
@@ -17,19 +17,19 @@ from app.core.schemas.step import (
 router = EnvelopeRouter()
 
 
-@router.post("/steps/{step_id}/accept", status_code=http_status.HTTP_200_OK)
+@router.post("/{step_id}/accept", status_code=http_status.HTTP_200_OK)
 async def accept_step(
     step_id: UUID, db: Session = Depends(get_db)
 ) -> StepAcceptResponse:
     return await step_service.accept_step(db, step_id)
 
 
-@router.get("/steps/{step_id}", status_code=http_status.HTTP_200_OK)
+@router.get("/{step_id}", status_code=http_status.HTTP_200_OK)
 def get_step_detail(step_id: UUID, db: Session = Depends(get_db)) -> StepDetailResponse:
     return step_service.get_step_detail(db, step_id)
 
 
-@router.get("/steps/{step_id}/sidepanel-stream")
+@router.get("/{step_id}/sidepanel-stream")
 async def sidepanel_stream(step_id: UUID, db: Session = Depends(get_db)):
     """사이드패널 콘텐츠를 SSE 스트림으로 반환.
 

--- a/backend/app/ai/routers/steps.py
+++ b/backend/app/ai/routers/steps.py
@@ -1,15 +1,17 @@
-import json
 from uuid import UUID
 
 from fastapi import Depends
 from fastapi import status as http_status
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
-from app.ai.services import orchestrator, step_service
+from app.ai.services import step_service
 from app.core.api.route import EnvelopeRouter
 from app.core.database import get_db
+from app.core.models.step import StepContent as StepContentModel
+from app.core.schemas.response import SuccessResponse
 from app.core.schemas.step import (
+    SidePanelStartResponse,
     StepAcceptResponse,
     StepDetailResponse,
 )
@@ -29,25 +31,37 @@ def get_step_detail(step_id: UUID, db: Session = Depends(get_db)) -> StepDetailR
     return step_service.get_step_detail(db, step_id)
 
 
-@router.get("/{step_id}/sidepanel-stream")
-async def sidepanel_stream(step_id: UUID, db: Session = Depends(get_db)):
-    """사이드패널 콘텐츠를 SSE 스트림으로 반환.
+@router.post(
+    "/{step_id}/sidepanel-start",
+    status_code=http_status.HTTP_202_ACCEPTED,
+)
+async def start_side_panel(step_id: UUID, db: Session = Depends(get_db)):
+    """Side panel 생성을 시작한다 (비동기 폴링 방식).
 
-    Accept 직후 프론트가 노드별로 연결하며, 토큰이 도착할 때마다
-    data 이벤트로 push된다. 스트리밍 완료 시 DB 저장 후 done 이벤트 전송.
+    - 새로 시작 / 이미 진행 중 → 202 Accepted
+    - 이미 완료 (status=done) → 200 OK (재생성 안 함, 멱등)
+
+    클라이언트는 응답을 기다리지 않고 즉시 `/sidepanel-content` 를 폴링.
+    Lambda 는 클라이언트 끊김과 무관하게 자체 timeout 까지 실행되며
+    chunk 도착마다 DB 에 누적 저장한다.
     """
+    # 존재 확인 + 사전조건 검사
     step = step_service.get_step_for_stream(db, step_id)
-    request = step_service.build_side_panel_request(db, step)
+    content = db.get(StepContentModel, step_id)
 
-    async def event_generator():
-        accumulated: list[str] = []
-        try:
-            async for chunk in orchestrator.call_side_panel_stream(request):
-                accumulated.append(chunk)
-                yield f"data: {json.dumps({'delta': chunk}, ensure_ascii=False)}\n\n"
-            step_service.save_side_panel_content(db, step_id, "".join(accumulated))
-            yield "event: done\ndata: {}\n\n"
-        except Exception as e:
-            yield f"event: error\ndata: {json.dumps({'error': str(e)})}\n\n"
+    # 이미 완료 — 재생성 없이 200
+    if content is not None and content.streaming_status == "done":
+        body = SuccessResponse(
+            data=SidePanelStartResponse(step_id=step.id, status="done")
+        ).model_dump(mode="json")
+        return JSONResponse(status_code=http_status.HTTP_200_OK, content=body)
 
-    return StreamingResponse(event_generator(), media_type="text/event-stream")
+    # 이미 진행 중 — 새 작업 시작하지 않고 202 만 반환
+    if content is not None and content.streaming_status in ("pending", "streaming"):
+        return SidePanelStartResponse(
+            step_id=step.id, status=content.streaming_status
+        )
+
+    # 새로 시작 — 같은 invocation 에서 LLM 실행. Lambda timeout 까지 계속 진행.
+    await step_service.run_side_panel_generation(db, step_id)
+    return SidePanelStartResponse(step_id=step.id, status="done")

--- a/backend/app/ai/services/design_export_service.py
+++ b/backend/app/ai/services/design_export_service.py
@@ -22,11 +22,49 @@ from app.core.exceptions import (
     DesignExportRateLimitError,
     ProjectNotFoundError,
 )
+from app.core.models.design_export_job import DesignExportJob
 from app.core.repositories import project as project_repo
 from app.core.repositories import step as step_repo
 
 _rate_limit_store: dict[str, float] = {}
 _RATE_LIMIT_SECONDS = 10
+
+
+# ─────────────────────────────────────────────────────────────
+# 비동기 폴링 — Job 헬퍼
+# ─────────────────────────────────────────────────────────────
+
+
+def create_job(db: Session, job_id: UUID, project_id: UUID) -> DesignExportJob:
+    """클라이언트가 생성한 job_id 로 row 등록. 이미 존재하면 그대로 반환."""
+    existing = db.get(DesignExportJob, job_id)
+    if existing is not None:
+        return existing
+    job = DesignExportJob(id=job_id, project_id=project_id, status="pending")
+    db.add(job)
+    db.commit()
+    return job
+
+
+def mark_job_done(
+    db: Session, job_id: UUID, markdown: str, filename: str
+) -> None:
+    job = db.get(DesignExportJob, job_id)
+    if job is None:
+        return
+    job.status = "done"
+    job.markdown = markdown
+    job.filename = filename
+    db.commit()
+
+
+def mark_job_error(db: Session, job_id: UUID, error_code: str) -> None:
+    job = db.get(DesignExportJob, job_id)
+    if job is None:
+        return
+    job.status = "error"
+    job.error_code = error_code
+    db.commit()
 
 
 def check_rate_limit(project_id: UUID) -> None:

--- a/backend/app/ai/services/step_service.py
+++ b/backend/app/ai/services/step_service.py
@@ -591,7 +591,7 @@ def get_step_for_stream(db: Session, step_id: uuid.UUID) -> StepModel:
 
 
 def save_side_panel_content(db: Session, step_id: uuid.UUID, full_text: str) -> None:
-    """SSE 스트리밍 완료 후 누적 텍스트를 파싱해 DB에 저장."""
+    """누적 텍스트를 파싱해 mentoring/dictionary 컬럼에 영속화."""
     from pydantic import ValidationError
     from ai.schemas.side_panel import SidePanelOutput
 
@@ -622,3 +622,73 @@ def save_side_panel_content(db: Session, step_id: uuid.UUID, full_text: str) -> 
         "ai: side_panel content saved",
         extra={"step_id": str(step_id), "text_len": len(full_text)},
     )
+
+
+# ─────────────────────────────────────────────────────────────
+# Side panel — 비동기 폴링 방식
+# ─────────────────────────────────────────────────────────────
+
+
+def _ensure_step_content(db: Session, step_id: uuid.UUID) -> StepContentModel:
+    content = db.get(StepContentModel, step_id)
+    if content is None:
+        content = StepContentModel(step_id=step_id)
+        db.add(content)
+        db.flush()
+    return content
+
+
+def mark_side_panel_pending(db: Session, step_id: uuid.UUID) -> None:
+    """생성 시작 직전 — 누적 버퍼 초기화 + status='pending'."""
+    content = _ensure_step_content(db, step_id)
+    content.streaming_status = "pending"
+    content.streaming_raw = ""
+    db.commit()
+
+
+def append_side_panel_chunk(
+    db: Session, step_id: uuid.UUID, accumulated: str
+) -> None:
+    """chunk 도착마다 누적 텍스트 갱신 + status='streaming'."""
+    content = _ensure_step_content(db, step_id)
+    content.streaming_status = "streaming"
+    content.streaming_raw = accumulated
+    db.commit()
+
+
+def mark_side_panel_done(db: Session, step_id: uuid.UUID) -> None:
+    content = _ensure_step_content(db, step_id)
+    content.streaming_status = "done"
+    db.commit()
+
+
+def mark_side_panel_error(db: Session, step_id: uuid.UUID) -> None:
+    content = _ensure_step_content(db, step_id)
+    content.streaming_status = "error"
+    db.commit()
+
+
+async def run_side_panel_generation(db: Session, step_id: uuid.UUID) -> None:
+    """LLM 으로부터 chunk 를 받아 DB 에 누적 저장.
+
+    클라이언트 끊김 여부와 무관하게 Lambda 가 timeout 까지 실행되어
+    결과는 DB 에 보존된다.
+    """
+    step = get_step_for_stream(db, step_id)
+    request = build_side_panel_request(db, step)
+
+    mark_side_panel_pending(db, step_id)
+    accumulated: list[str] = []
+    try:
+        async for chunk in orchestrator.call_side_panel_stream(request):
+            accumulated.append(chunk)
+            append_side_panel_chunk(db, step_id, "".join(accumulated))
+        save_side_panel_content(db, step_id, "".join(accumulated))
+        mark_side_panel_done(db, step_id)
+    except Exception:
+        logger.exception(
+            "ai: side_panel generation failed",
+            extra={"step_id": str(step_id)},
+        )
+        mark_side_panel_error(db, step_id)
+        raise

--- a/backend/app/business/routers/auth.py
+++ b/backend/app/business/routers/auth.py
@@ -15,7 +15,7 @@ from app.core.auth.dependencies import get_current_user
 from app.core.config import settings
 from app.core.exceptions import InvalidTokenError
 from app.core.models.app_user import AppUser as AppUserModel
-from app.core.schemas.auth import UserProfileResponse
+from app.core.schemas.auth import CsrfTokenResponse, UserProfileResponse
 
 router = EnvelopeRouter()
 
@@ -58,8 +58,12 @@ def refresh_token(
     refresh_token: str | None = Cookie(
         default=None, alias=settings.REFRESH_COOKIE_NAME
     ),
-) -> None:
-    """Refresh Token 쿠키로 Access Token 갱신. 응답 쿠키도 모두 갱신."""
+) -> CsrfTokenResponse:
+    """Refresh Token 쿠키로 Access Token 갱신. 응답 쿠키도 모두 갱신.
+
+    cross-site 셋업에서 프론트 JS가 쿠키를 읽을 수 없으므로,
+    새 csrf_token 값을 body로도 함께 반환한다.
+    """
     if not refresh_token:
         raise InvalidTokenError("Refresh Token 쿠키가 없습니다.")
 
@@ -71,7 +75,7 @@ def refresh_token(
         refresh_token=tokens.refresh_token,
         csrf_token=csrf,
     )
-    return None
+    return CsrfTokenResponse(csrf_token=csrf)
 
 
 @router.post("/logout", status_code=http_status.HTTP_200_OK)
@@ -86,7 +90,16 @@ def logout(
 @router.get("/me", status_code=http_status.HTTP_200_OK)
 def get_me(
     user: AppUserModel = Depends(get_current_user),
+    csrf_cookie: str | None = Cookie(
+        default=None, alias=settings.CSRF_COOKIE_NAME
+    ),
     db: Session = Depends(get_db),
 ) -> UserProfileResponse:
-    """현재 로그인 사용자 정보."""
-    return auth_service.get_user_profile(db, user)
+    """현재 로그인 사용자 정보.
+
+    cross-site 셋업에서 프론트가 쿠키를 직접 읽지 못하므로 csrf_token 값을
+    body 에도 실어 보낸다. 이미 발급되어 있는 값을 그대로 노출 (재발급 X).
+    """
+    profile = auth_service.get_user_profile(db, user)
+    profile.csrf_token = csrf_cookie
+    return profile

--- a/backend/app/business/routers/projects.py
+++ b/backend/app/business/routers/projects.py
@@ -11,7 +11,9 @@ from app.core.api.route import EnvelopeRouter
 from app.core.auth.dependencies import get_current_user
 from app.core.models.app_user import AppUser as AppUserModel
 from app.core.models.project import Project as ProjectModel
+from app.core.models.design_export_job import DesignExportJob as DesignExportJobModel
 from app.core.schemas.project import (
+    DesignExportJobResponse,
     ProjectCreateRequest,
     ProjectListResponse,
     ProjectResponse,
@@ -98,3 +100,31 @@ def get_accepted_required_steps(
     project: ProjectModel = Depends(get_owned_project),
 ) -> AcceptedRequiredStepListResponse:
     return step_service.get_accepted_required_steps(db, project.id)
+
+
+@router.get(
+    "/{project_id}/design-export-jobs/{job_id}",
+    status_code=http_status.HTTP_200_OK,
+)
+def get_design_export_job(
+    job_id: UUID,
+    db: Session = Depends(get_db),
+    project: ProjectModel = Depends(get_owned_project),
+) -> DesignExportJobResponse:
+    """Design Export 진행 상태 폴링.
+
+    매 호출 200 OK + body 의 status 필드로 상태 전달.
+    project 소유권은 get_owned_project 가 검증.
+    """
+    job = db.get(DesignExportJobModel, job_id)
+    if job is None or job.project_id != project.id:
+        return DesignExportJobResponse(
+            status="pending", is_complete=False
+        )
+    return DesignExportJobResponse(
+        status=job.status,
+        markdown=job.markdown,
+        filename=job.filename,
+        error_code=job.error_code,
+        is_complete=job.status in ("done", "error"),
+    )

--- a/backend/app/business/routers/steps.py
+++ b/backend/app/business/routers/steps.py
@@ -8,8 +8,10 @@ from app.business.dependencies import get_owned_project, get_owned_step
 from app.core.api.route import EnvelopeRouter
 from app.core.models.project import Project as ProjectModel
 from app.core.models.step import Step as StepModel
+from app.core.models.step import StepContent as StepContentModel
 from app.core.schemas.step import (
     RequiredStepListResponse,
+    SidePanelContentResponse,
     StepKeepResponse,
     StepKeepUpdateRequest,
     StepTreeResponse,
@@ -60,3 +62,26 @@ def update_step_keep(
 ) -> StepKeepResponse:
     """Step.is_keep 값을 변경한다."""
     return step_service.update_step_keep(db, step.id, payload.is_keep)
+
+
+@router.get(
+    "/{step_id}/sidepanel-content",
+    status_code=http_status.HTTP_200_OK,
+)
+def get_side_panel_content(
+    db: Session = Depends(get_db),
+    step: StepModel = Depends(get_owned_step),
+) -> SidePanelContentResponse:
+    """Side panel 생성 진행 상태 폴링.
+
+    POST /steps/{step_id}/sidepanel-start 로 시작된 작업의 누적 raw text 와
+    상태를 반환. 매 호출 200 OK + body 의 status 필드로 상태 전달.
+    """
+    content = db.get(StepContentModel, step.id)
+    if content is None:
+        return SidePanelContentResponse(status="idle", content="", is_complete=False)
+    return SidePanelContentResponse(
+        status=content.streaming_status,
+        content=content.streaming_raw or "",
+        is_complete=content.streaming_status in ("done", "error"),
+    )

--- a/backend/app/core/models/__init__.py
+++ b/backend/app/core/models/__init__.py
@@ -1,4 +1,5 @@
 from app.core.models.app_user import AppUser
+from app.core.models.design_export_job import DesignExportJob
 from app.core.models.oauth_account import OAuthAccount
 from app.core.models.project import Project, ProjectStage
 from app.core.models.project_required_step_status import ProjectRequiredStepStatus
@@ -8,6 +9,7 @@ from app.core.models.step import Step, StepContent, StepTree
 
 __all__ = [
     "AppUser",
+    "DesignExportJob",
     "OAuthAccount",
     "Project",
     "ProjectRequiredStepStatus",

--- a/backend/app/core/models/design_export_job.py
+++ b/backend/app/core/models/design_export_job.py
@@ -1,0 +1,47 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class DesignExportJob(Base):
+    """Design Export 비동기 폴링용 job 레코드.
+
+    POST /projects/{project_id}/design-export-start 에서 row 생성 후
+    AI Lambda 가 LLM 작업을 수행하며 status / markdown / filename 을 채운다.
+    프론트는 GET /projects/{project_id}/design-export-jobs/{job_id} 로 폴링.
+
+    클라이언트 끊김 시 결과는 휘발성으로 처리 — 별도 cleanup 정책으로 오래된 row 정리.
+    """
+
+    __tablename__ = "design_export_job"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("project.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # pending / done / error
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default="pending"
+    )
+    markdown: Mapped[str | None] = mapped_column(Text, nullable=True)
+    filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/backend/app/core/models/step.py
+++ b/backend/app/core/models/step.py
@@ -74,6 +74,16 @@ class StepContent(Base):
     dictionary: Mapped[str | None] = mapped_column(Text, nullable=True)
     mentoring: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Side panel 비동기 폴링 상태.
+    # streaming_status: idle / pending / streaming / done / error
+    # streaming_raw   : 생성 중 누적되는 raw LLM 응답 (폴링으로 실시간 노출)
+    streaming_status: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default="idle"
+    )
+    streaming_raw: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=""
+    )
+
     step: Mapped["Step"] = relationship(back_populates="content")
 
 

--- a/backend/app/core/schemas/auth.py
+++ b/backend/app/core/schemas/auth.py
@@ -15,6 +15,11 @@ class UserProfileResponse(BaseModel):
     email: str
     nickname: str
     provider: str
+    csrf_token: str | None = None
+
+
+class CsrfTokenResponse(BaseModel):
+    csrf_token: str
 
 
 class OAuthUserInfo(BaseModel):

--- a/backend/app/core/schemas/project.py
+++ b/backend/app/core/schemas/project.py
@@ -49,3 +49,24 @@ class ProjectListResponse(BaseModel):
     total_count: int
     page: int
     size: int
+
+
+class DesignExportStartRequest(BaseModel):
+    """POST /projects/{project_id}/design-export-start 요청."""
+    job_id: UUID  # 클라이언트가 생성 — 응답 안 기다리고 곧장 폴링 가능
+    selected_step_ids: list[UUID]
+
+
+class DesignExportStartResponse(BaseModel):
+    """POST /projects/{project_id}/design-export-start 응답."""
+    job_id: UUID
+    status: str  # pending / done / error
+
+
+class DesignExportJobResponse(BaseModel):
+    """GET /projects/{project_id}/design-export-jobs/{job_id} 폴링 응답."""
+    status: str  # pending / done / error
+    markdown: str | None = None
+    filename: str | None = None
+    error_code: str | None = None
+    is_complete: bool

--- a/backend/app/core/schemas/step.py
+++ b/backend/app/core/schemas/step.py
@@ -74,6 +74,19 @@ class NotionTemplateResponse(BaseModel):
     notion_page_url: str
 
 
+class SidePanelStartResponse(BaseModel):
+    """POST /steps/{step_id}/sidepanel-start 응답."""
+    step_id: UUID
+    status: str  # pending / streaming / done
+
+
+class SidePanelContentResponse(BaseModel):
+    """GET /steps/{step_id}/sidepanel-content 폴링 응답."""
+    status: str  # idle / pending / streaming / done / error
+    content: str  # 누적 raw text (생성 중에도 부분 노출)
+    is_complete: bool
+
+
 class ProjectInfo(BaseModel):
     project_id: UUID
     name: str

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
-# 로컬 개발 시에는 비워두면 Vite proxy가 동작 (/api, /ai)
-# 배포 시 API Gateway URL을 설정
-VITE_API_URL=
-VITE_AI_URL=
+# Business 서버 base URL (미입력 시 http://localhost:8000)
+VITE_BUSINESS_SERVER_URL=
+# AI 서버 base URL (미입력 시 http://localhost:8001)
+VITE_AI_SERVER_URL=

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1185,9 +1185,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.10.30",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+      "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1266,9 +1266,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -1662,9 +1662,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.356",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
-      "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
+      "version": "1.5.357",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
       "dev": true,
       "license": "ISC"
     },

--- a/frontend/src/api/_client.js
+++ b/frontend/src/api/_client.js
@@ -20,12 +20,12 @@ const UUID =
   '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 
 // AI 서버로 보낼 (method, path) 패턴. 그 외는 전부 business.
-// 폴링 GET (sidepanel-content 등) 은 business 로 가야 하므로 여기 X.
+// 폴링 GET (sidepanel-content, design-export-jobs 등) 은 business 로 가야 하므로 여기 X.
 const AI_ROUTES = [
   { method: 'POST', pattern: new RegExp(`^/steps/${UUID}/accept$`) },
   { method: 'POST', pattern: new RegExp(`^/steps/${UUID}/sidepanel-start$`) },
   { method: 'GET', pattern: new RegExp(`^/steps/${UUID}$`) },
-  { method: 'POST', pattern: new RegExp(`^/projects/${UUID}/design-export$`) },
+  { method: 'POST', pattern: new RegExp(`^/projects/${UUID}/design-export-start$`) },
 ]
 
 function pickBaseUrl(method, path) {

--- a/frontend/src/api/_client.js
+++ b/frontend/src/api/_client.js
@@ -20,9 +20,10 @@ const UUID =
   '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 
 // AI 서버로 보낼 (method, path) 패턴. 그 외는 전부 business.
+// 폴링 GET (sidepanel-content 등) 은 business 로 가야 하므로 여기 X.
 const AI_ROUTES = [
   { method: 'POST', pattern: new RegExp(`^/steps/${UUID}/accept$`) },
-  { method: 'GET', pattern: new RegExp(`^/steps/${UUID}/sidepanel-stream$`) },
+  { method: 'POST', pattern: new RegExp(`^/steps/${UUID}/sidepanel-start$`) },
   { method: 'GET', pattern: new RegExp(`^/steps/${UUID}$`) },
   { method: 'POST', pattern: new RegExp(`^/projects/${UUID}/design-export$`) },
 ]

--- a/frontend/src/api/_client.js
+++ b/frontend/src/api/_client.js
@@ -1,16 +1,42 @@
 import axios from 'axios'
 
 // ─────────────────────────────────────────────────────────────
-// 공통 axios 클라이언트 팩토리
-// - withCredentials (HttpOnly 쿠키 자동 전송)
-// - 변경 요청에 X-CSRF-Token 헤더 부착
-// - 응답 envelope 자동 unwrap (res.data.data)
-// - 401 응답 시 자동으로 /auth/refresh 후 원래 요청 재시도
-// - refresh 가 동시 다발로 호출되지 않도록 단일 promise 큐
-// - refresh 자체가 실패하면 /login 으로 리다이렉트
+// 통합 axios 클라이언트
+//
+// - 호출부는 백엔드 path 를 그대로 쓴다 (예: '/projects', '/steps/tree').
+//   ai/business 구분은 이 파일이 path 패턴으로 자동 분기한다.
+// - 서버 주소는 환경변수 VITE_BUSINESS_SERVER_URL / VITE_AI_SERVER_URL
+//   에서 받고, 미설정 시 localhost 기본값을 사용한다.
+// - 동시 다발의 401 은 단일 refresh promise 로 합치고, refresh 자체가
+//   실패하면 /login 으로 보낸다.
 // ─────────────────────────────────────────────────────────────
 
-const BASE_URL = import.meta.env.VITE_API_URL || '/api'
+const BUSINESS_BASE =
+  import.meta.env.VITE_BUSINESS_SERVER_URL || 'http://localhost:8000'
+const AI_BASE =
+  import.meta.env.VITE_AI_SERVER_URL || 'http://localhost:8001'
+
+const UUID =
+  '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+
+// AI 서버로 보낼 (method, path) 패턴. 그 외는 전부 business.
+const AI_ROUTES = [
+  { method: 'POST', pattern: new RegExp(`^/steps/${UUID}/accept$`) },
+  { method: 'GET', pattern: new RegExp(`^/steps/${UUID}/sidepanel-stream$`) },
+  { method: 'GET', pattern: new RegExp(`^/steps/${UUID}$`) },
+  { method: 'POST', pattern: new RegExp(`^/projects/${UUID}/design-export$`) },
+]
+
+function pickBaseUrl(method, path) {
+  const m = (method || 'GET').toUpperCase()
+  const isAi = AI_ROUTES.some((r) => r.method === m && r.pattern.test(path))
+  return isAi ? AI_BASE : BUSINESS_BASE
+}
+
+// path 를 절대 URL 로 변환. fetch (SSE 등) 직접 호출에 사용.
+export function resolveApiUrl(method, path) {
+  return `${pickBaseUrl(method, path)}${path}`
+}
 
 function getCsrfToken() {
   return document.cookie
@@ -24,11 +50,9 @@ let refreshPromise = null
 
 function refreshTokens() {
   if (!refreshPromise) {
-    // 별도 axios 인스턴스로 호출 — 글로벌 instance 의 인터셉터를 거치지 않음(무한 루프 방지)
     refreshPromise = axios
-      .post(`${BASE_URL}/auth/refresh`, null, { withCredentials: true })
+      .post(`${BUSINESS_BASE}/auth/refresh`, null, { withCredentials: true })
       .finally(() => {
-        // 다음 만료 시 새 promise 생성될 수 있도록 비움
         refreshPromise = null
       })
   }
@@ -37,14 +61,22 @@ function refreshTokens() {
 
 function redirectToLogin() {
   if (typeof window === 'undefined') return
-  // 이미 로그인 페이지에 있으면 무한 루프 방지
   const path = window.location.pathname
   if (path === '/login' || path === '/' || path.startsWith('/shared/')) return
   window.location.href = '/login'
 }
 
-export function createApi(baseURL = BASE_URL) {
-  const instance = axios.create({ baseURL, withCredentials: true })
+function attachRouting(instance) {
+  instance.interceptors.request.use((config) => {
+    config.baseURL = pickBaseUrl(config.method, config.url)
+    return config
+  })
+}
+
+export function createApi() {
+  const instance = axios.create({ withCredentials: true })
+
+  attachRouting(instance)
 
   // CSRF 헤더 부착
   instance.interceptors.request.use((config) => {
@@ -66,18 +98,17 @@ export function createApi(baseURL = BASE_URL) {
       const original = err.config
       const status = err.response?.status
 
-      // 1) refresh 자체가 실패한 경우 — 무한 루프 방지
+      // refresh 자체가 실패 — 무한 루프 방지
       if (original?.url?.endsWith('/auth/refresh')) {
         redirectToLogin()
         return Promise.reject(err.response?.data?.error ?? err)
       }
 
-      // 2) 401 응답 — refresh 후 원래 요청 재시도 (한 번만)
+      // 401 응답 — refresh 후 원래 요청 한 번 재시도
       if (status === 401 && original && !original._retry) {
         original._retry = true
         try {
           await refreshTokens()
-          // refresh 성공 시 새 csrf 토큰이 쿠키로 내려왔으므로 헤더 갱신
           const newCsrf = getCsrfToken()
           if (newCsrf && original.headers) {
             original.headers['X-CSRF-Token'] = newCsrf
@@ -97,8 +128,9 @@ export function createApi(baseURL = BASE_URL) {
 }
 
 // 인증 없이 동작하는 read-only 클라이언트 (share 페이지용)
-export function createPublicApi(baseURL = BASE_URL) {
-  const instance = axios.create({ baseURL, withCredentials: true })
+export function createPublicApi() {
+  const instance = axios.create({ withCredentials: true })
+  attachRouting(instance)
   instance.interceptors.response.use(
     (res) => res.data?.data,
     (err) => Promise.reject(err.response?.data?.error ?? err)

--- a/frontend/src/api/_client.js
+++ b/frontend/src/api/_client.js
@@ -38,11 +38,34 @@ export function resolveApiUrl(method, path) {
   return `${pickBaseUrl(method, path)}${path}`
 }
 
-function getCsrfToken() {
-  return document.cookie
-    .split('; ')
-    .find((row) => row.startsWith('csrf_token='))
-    ?.split('=')[1]
+// cross-site 셋업에서 JS 가 csrf 쿠키를 읽을 수 없으므로,
+// 백엔드가 /auth/me, /auth/refresh 응답 body 로 내려준 값을
+// sessionStorage 에 보관해 헤더로 부착한다.
+const CSRF_STORAGE_KEY = 'csrf_token'
+
+export function getCsrfToken() {
+  try {
+    return sessionStorage.getItem(CSRF_STORAGE_KEY) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function setCsrfToken(token) {
+  if (!token) return
+  try {
+    sessionStorage.setItem(CSRF_STORAGE_KEY, token)
+  } catch {
+    /* sessionStorage 불가 환경 — 무시 */
+  }
+}
+
+export function clearCsrfToken() {
+  try {
+    sessionStorage.removeItem(CSRF_STORAGE_KEY)
+  } catch {
+    /* */
+  }
 }
 
 // 동시 다발의 401 을 한 번의 refresh 로 합치기 위한 단일 promise.
@@ -52,6 +75,12 @@ function refreshTokens() {
   if (!refreshPromise) {
     refreshPromise = axios
       .post(`${BUSINESS_BASE}/auth/refresh`, null, { withCredentials: true })
+      .then((res) => {
+        // 새 csrf_token 을 응답 body 에서 받아 sessionStorage 갱신
+        const newCsrf = res?.data?.data?.csrf_token
+        if (newCsrf) setCsrfToken(newCsrf)
+        return res
+      })
       .finally(() => {
         refreshPromise = null
       })
@@ -93,7 +122,14 @@ export function createApi() {
 
   // 응답: envelope unwrap + 401 자동 refresh & retry
   instance.interceptors.response.use(
-    (res) => res.data?.data,
+    (res) => {
+      const data = res.data?.data
+      // /auth/me 응답에 포함된 csrf_token 을 자동으로 sessionStorage 에 저장
+      if (data && typeof data === 'object' && data.csrf_token) {
+        setCsrfToken(data.csrf_token)
+      }
+      return data
+    },
     async (err) => {
       const original = err.config
       const status = err.response?.status

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,6 +1,13 @@
-import { createApi } from './_client'
+import { clearCsrfToken, createApi } from './_client'
 
 const api = createApi()
 
 export const getMe = () => api.get('/auth/me')
-export const logout = () => api.post('/auth/logout')
+
+export const logout = async () => {
+  try {
+    return await api.post('/auth/logout')
+  } finally {
+    clearCsrfToken()
+  }
+}

--- a/frontend/src/api/exports.js
+++ b/frontend/src/api/exports.js
@@ -66,34 +66,41 @@ function getStatusCode(err) {
 }
 
 /**
- * Design Export 스트림 생성/재개.
+ * Design Export 생성 트리거. POST 응답까지 await 한 뒤 결과 반환.
  *
- * @param {string} projectId
- * @param {string[]} selectedStepIds  selected step ids — resumeJobId 가 있으면 무시됨
- * @param {object} [opts]
- * @param {string} [opts.resumeJobId]  기존 job_id 로 재개 (POST 생략, 폴링만 시작)
+ * @returns {Promise<{jobId?: string, error?: {code: string|null, status: number|null}}>}
  */
-export function createDesignExportStream(projectId, selectedStepIds, opts = {}) {
+export async function startDesignExport(projectId, selectedStepIds) {
+  const jobId = generateJobId()
+  try {
+    await api.post(`/projects/${projectId}/design-export-start`, {
+      job_id: jobId,
+      selected_step_ids: selectedStepIds,
+    })
+    saveDesignExportJobId(projectId, jobId)
+    return { jobId }
+  } catch (err) {
+    return {
+      error: {
+        code: err?.code ?? null,
+        status: getStatusCode(err),
+      },
+    }
+  }
+}
+
+/**
+ * Design Export 폴링 스트림. job_id 는 외부에서 주입.
+ * - 새 다운로드: startDesignExport() 로 얻은 jobId 전달
+ * - 새로고침 후 재개: getDesignExportJobId() 로 얻은 jobId 전달
+ */
+export function createDesignExportStream(projectId, jobId) {
   let timeoutId = null
   let aborted = false
 
   return {
     start({ onComplete, onError } = {}) {
       aborted = false
-      const jobId = opts.resumeJobId || generateJobId()
-
-      if (!opts.resumeJobId) {
-        // 새 job — localStorage 에 기록 + 트리거 POST
-        saveDesignExportJobId(projectId, jobId)
-        api
-          .post(`/projects/${projectId}/design-export-start`, {
-            job_id: jobId,
-            selected_step_ids: selectedStepIds,
-          })
-          .catch(() => {
-            // 사전검증 실패(rate limit / 빈 selection 등) 가능 — 폴링이 곧 알아냄.
-          })
-      }
 
       let interval = MIN_POLL_MS
       let quietCount = 0

--- a/frontend/src/api/exports.js
+++ b/frontend/src/api/exports.js
@@ -1,13 +1,6 @@
-import { createApi, resolveApiUrl } from './_client'
+import { createApi, getCsrfToken, resolveApiUrl } from './_client'
 
 const api = createApi()
-
-function getCsrfToken() {
-  return document.cookie
-    .split('; ')
-    .find((row) => row.startsWith('csrf_token='))
-    ?.split('=')[1]
-}
 
 // 1) 사전 조회 — accept된 RS 목록
 export const getAcceptedRequiredSteps = (projectId) =>

--- a/frontend/src/api/exports.js
+++ b/frontend/src/api/exports.js
@@ -1,19 +1,17 @@
-import { createApi } from './_client'
+import { createApi, resolveApiUrl } from './_client'
 
-const api = createApi()                                          // Business (/api)
-const AI_BASE = import.meta.env.VITE_AI_URL || '/ai'
+const api = createApi()
 
 function getCsrfToken() {
   return document.cookie
     .split('; ')
-    .find(row => row.startsWith('csrf_token='))
+    .find((row) => row.startsWith('csrf_token='))
     ?.split('=')[1]
 }
 
 // 1) 사전 조회 — accept된 RS 목록
 export const getAcceptedRequiredSteps = (projectId) =>
   api.get(`/projects/${projectId}/accepted-required-steps`)
-  // 응답 envelope unwrap 후: { required_steps: [{ step_id, name, stage_sequence }, ...] }
 
 // 2) design-export SSE
 export function createDesignExportStream(projectId, selectedStepIds) {
@@ -26,12 +24,13 @@ export function createDesignExportStream(projectId, selectedStepIds) {
       ;(async () => {
         try {
           const csrf = getCsrfToken()
-          const res = await fetch(`${AI_BASE}/projects/${projectId}/design-export`, {
+          const url = resolveApiUrl('POST', `/projects/${projectId}/design-export`)
+          const res = await fetch(url, {
             method: 'POST',
             credentials: 'include',
             headers: {
               'Content-Type': 'application/json',
-              'Accept': 'text/event-stream',
+              Accept: 'text/event-stream',
               ...(csrf ? { 'X-CSRF-Token': csrf } : {}),
             },
             body: JSON.stringify({ selected_step_ids: selectedStepIds }),
@@ -43,7 +42,9 @@ export function createDesignExportStream(projectId, selectedStepIds) {
             try {
               const body = await res.json()
               code = body?.error?.code ?? body?.code ?? code
-            } catch { /* */ }
+            } catch {
+              /* */
+            }
             onError?.({ code, status: res.status })
             return
           }
@@ -73,7 +74,11 @@ export function createDesignExportStream(projectId, selectedStepIds) {
                 }
 
                 let data
-                try { data = JSON.parse(dataStr) } catch { data = null }
+                try {
+                  data = JSON.parse(dataStr)
+                } catch {
+                  data = null
+                }
 
                 if (currentEvent === 'complete') {
                   onComplete?.(data)

--- a/frontend/src/api/exports.js
+++ b/frontend/src/api/exports.js
@@ -1,4 +1,4 @@
-import { createApi, getCsrfToken, resolveApiUrl } from './_client'
+import { createApi } from './_client'
 
 const api = createApi()
 
@@ -6,97 +6,101 @@ const api = createApi()
 export const getAcceptedRequiredSteps = (projectId) =>
   api.get(`/projects/${projectId}/accepted-required-steps`)
 
-// 2) design-export SSE
+// ─────────────────────────────────────────────────────────────
+// Design Export — 비동기 폴링
+//
+// 1. job_id 를 클라이언트가 생성 (crypto.randomUUID).
+// 2. POST /projects/{id}/design-export-start  (fire-and-forget)
+// 3. GET /projects/{id}/design-export-jobs/{job_id} 적응형 폴링.
+// 4. is_complete 면 onComplete({markdown, filename}) 또는 onError({code}).
+//
+// abort() 는 클라이언트 폴링만 멈춤 — 백엔드 작업은 계속되지만 결과는
+// 클라이언트 입장에서 버려진다.
+// ─────────────────────────────────────────────────────────────
+const MIN_POLL_MS = 1000
+const MAX_POLL_MS = 4000
+const BACKOFF_AFTER_QUIET = 2
+
+function generateJobId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  // 폴백 — 매우 단순한 UUID v4 비슷 (보안용 아님; 식별자 용도)
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
 export function createDesignExportStream(projectId, selectedStepIds) {
-  let abortController = null
+  let timeoutId = null
+  let aborted = false
 
   return {
     start({ onComplete, onError } = {}) {
-      abortController = new AbortController()
+      aborted = false
+      const jobId = generateJobId()
 
-      ;(async () => {
+      // 생성 트리거 — 응답 안 기다림
+      api
+        .post(`/projects/${projectId}/design-export-start`, {
+          job_id: jobId,
+          selected_step_ids: selectedStepIds,
+        })
+        .catch(() => {
+          // 사전검증 실패(rate limit / 빈 selection 등) 가능 — 폴링이 곧 알아냄.
+        })
+
+      let interval = MIN_POLL_MS
+      let quietCount = 0
+      let lastStatus = null
+
+      const poll = async () => {
+        if (aborted) return
         try {
-          const csrf = getCsrfToken()
-          const url = resolveApiUrl('POST', `/projects/${projectId}/design-export`)
-          const res = await fetch(url, {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'text/event-stream',
-              ...(csrf ? { 'X-CSRF-Token': csrf } : {}),
-            },
-            body: JSON.stringify({ selected_step_ids: selectedStepIds }),
-            signal: abortController.signal,
-          })
+          const res = await api.get(
+            `/projects/${projectId}/design-export-jobs/${jobId}`
+          )
+          const { status, markdown, filename, error_code, is_complete } = res
 
-          if (!res.ok || !res.body) {
-            let code = 'DESIGN_EXPORT_FAILED'
-            try {
-              const body = await res.json()
-              code = body?.error?.code ?? body?.code ?? code
-            } catch {
-              /* */
+          if (is_complete) {
+            timeoutId = null
+            if (status === 'done') {
+              onComplete?.({ markdown, filename })
+            } else {
+              onError?.({ code: error_code || 'DESIGN_EXPORT_FAILED' })
             }
-            onError?.({ code, status: res.status })
             return
           }
 
-          const reader = res.body.getReader()
-          const decoder = new TextDecoder()
-          let buffer = ''
-          let currentEvent = null
-
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done) break
-
-            buffer += decoder.decode(value, { stream: true })
-            const lines = buffer.split('\n')
-            buffer = lines.pop() ?? ''
-
-            for (const line of lines) {
-              if (line.startsWith('event: ')) {
-                currentEvent = line.slice(7).trim()
-              } else if (line.startsWith('data: ')) {
-                const dataStr = line.slice(6)
-
-                if (currentEvent === 'keepalive') {
-                  currentEvent = null
-                  continue
-                }
-
-                let data
-                try {
-                  data = JSON.parse(dataStr)
-                } catch {
-                  data = null
-                }
-
-                if (currentEvent === 'complete') {
-                  onComplete?.(data)
-                  return
-                }
-                if (currentEvent === 'error') {
-                  onError?.(data ?? { code: 'DESIGN_EXPORT_FAILED' })
-                  return
-                }
-
-                currentEvent = null
-              } else if (line === '') {
-                currentEvent = null
-              }
+          // 진행 중 — 상태 변화 없으면 점진적으로 주기 늘림
+          if (status === lastStatus) {
+            quietCount += 1
+            if (quietCount >= BACKOFF_AFTER_QUIET) {
+              interval = Math.min(Math.round(interval * 1.5), MAX_POLL_MS)
             }
+          } else {
+            interval = MIN_POLL_MS
+            quietCount = 0
+            lastStatus = status
           }
-        } catch (err) {
-          if (err.name === 'AbortError') return
-          onError?.({ code: 'DESIGN_EXPORT_NETWORK_ERROR', message: err?.message })
+        } catch {
+          // 일시적 네트워크 오류 — 다음 사이클 재시도
         }
-      })()
+
+        if (!aborted) {
+          timeoutId = setTimeout(poll, interval)
+        }
+      }
+
+      poll() // 첫 호출은 즉시
     },
 
     abort() {
-      abortController?.abort()
+      aborted = true
+      if (timeoutId) clearTimeout(timeoutId)
+      timeoutId = null
     },
   }
 }

--- a/frontend/src/api/exports.js
+++ b/frontend/src/api/exports.js
@@ -20,6 +20,7 @@ export const getAcceptedRequiredSteps = (projectId) =>
 const MIN_POLL_MS = 1000
 const MAX_POLL_MS = 4000
 const BACKOFF_AFTER_QUIET = 2
+const MAX_TRANSIENT_FAILURES = 5
 
 function generateJobId() {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -33,28 +34,79 @@ function generateJobId() {
   })
 }
 
-export function createDesignExportStream(projectId, selectedStepIds) {
+// ─── 진행 중인 job_id 를 localStorage 에 보관 (새로고침 후 복구용) ───
+const STORAGE_KEY = (projectId) => `design_export_job:${projectId}`
+
+export function getDesignExportJobId(projectId) {
+  try {
+    return localStorage.getItem(STORAGE_KEY(projectId)) || null
+  } catch {
+    return null
+  }
+}
+
+function saveDesignExportJobId(projectId, jobId) {
+  try {
+    localStorage.setItem(STORAGE_KEY(projectId), jobId)
+  } catch {
+    /* */
+  }
+}
+
+export function clearDesignExportJobId(projectId) {
+  try {
+    localStorage.removeItem(STORAGE_KEY(projectId))
+  } catch {
+    /* */
+  }
+}
+
+function getStatusCode(err) {
+  return err?.response?.status ?? err?.status ?? null
+}
+
+/**
+ * Design Export 스트림 생성/재개.
+ *
+ * @param {string} projectId
+ * @param {string[]} selectedStepIds  selected step ids — resumeJobId 가 있으면 무시됨
+ * @param {object} [opts]
+ * @param {string} [opts.resumeJobId]  기존 job_id 로 재개 (POST 생략, 폴링만 시작)
+ */
+export function createDesignExportStream(projectId, selectedStepIds, opts = {}) {
   let timeoutId = null
   let aborted = false
 
   return {
     start({ onComplete, onError } = {}) {
       aborted = false
-      const jobId = generateJobId()
+      const jobId = opts.resumeJobId || generateJobId()
 
-      // 생성 트리거 — 응답 안 기다림
-      api
-        .post(`/projects/${projectId}/design-export-start`, {
-          job_id: jobId,
-          selected_step_ids: selectedStepIds,
-        })
-        .catch(() => {
-          // 사전검증 실패(rate limit / 빈 selection 등) 가능 — 폴링이 곧 알아냄.
-        })
+      if (!opts.resumeJobId) {
+        // 새 job — localStorage 에 기록 + 트리거 POST
+        saveDesignExportJobId(projectId, jobId)
+        api
+          .post(`/projects/${projectId}/design-export-start`, {
+            job_id: jobId,
+            selected_step_ids: selectedStepIds,
+          })
+          .catch(() => {
+            // 사전검증 실패(rate limit / 빈 selection 등) 가능 — 폴링이 곧 알아냄.
+          })
+      }
 
       let interval = MIN_POLL_MS
       let quietCount = 0
       let lastStatus = null
+      let transientFailures = 0
+
+      const stop = (kind, payload) => {
+        timeoutId = null
+        aborted = true
+        clearDesignExportJobId(projectId)
+        if (kind === 'done') onComplete?.(payload)
+        else onError?.(payload)
+      }
 
       const poll = async () => {
         if (aborted) return
@@ -62,16 +114,14 @@ export function createDesignExportStream(projectId, selectedStepIds) {
           const res = await api.get(
             `/projects/${projectId}/design-export-jobs/${jobId}`
           )
+          transientFailures = 0
+
           const { status, markdown, filename, error_code, is_complete } = res
 
           if (is_complete) {
-            timeoutId = null
-            if (status === 'done') {
-              onComplete?.({ markdown, filename })
-            } else {
-              onError?.({ code: error_code || 'DESIGN_EXPORT_FAILED' })
-            }
-            return
+            return status === 'done'
+              ? stop('done', { markdown, filename })
+              : stop('error', { code: error_code || 'DESIGN_EXPORT_FAILED' })
           }
 
           // 진행 중 — 상태 변화 없으면 점진적으로 주기 늘림
@@ -85,8 +135,17 @@ export function createDesignExportStream(projectId, selectedStepIds) {
             quietCount = 0
             lastStatus = status
           }
-        } catch {
-          // 일시적 네트워크 오류 — 다음 사이클 재시도
+        } catch (err) {
+          const code = getStatusCode(err)
+          // 4xx — 종료 신호. 더 폴링해도 의미 없음.
+          if (code !== null && code >= 400 && code < 500) {
+            return stop('error', { code: 'DESIGN_EXPORT_FAILED' })
+          }
+          // 5xx / 네트워크 오류 — 한도까지 재시도
+          transientFailures += 1
+          if (transientFailures >= MAX_TRANSIENT_FAILURES) {
+            return stop('error', { code: 'DESIGN_EXPORT_NETWORK_ERROR' })
+          }
         }
 
         if (!aborted) {
@@ -98,9 +157,12 @@ export function createDesignExportStream(projectId, selectedStepIds) {
     },
 
     abort() {
+      // 사용자가 명시적으로 취소 — 백엔드 작업은 계속되지만 클라이언트 입장에선 버려짐.
+      // localStorage 도 정리해서 새로고침 시 재개되지 않게.
       aborted = true
       if (timeoutId) clearTimeout(timeoutId)
       timeoutId = null
+      clearDesignExportJobId(projectId)
     },
   }
 }

--- a/frontend/src/api/shared.js
+++ b/frontend/src/api/shared.js
@@ -1,6 +1,5 @@
 import { createPublicApi } from './_client'
 
-// 공유 토큰 기반 read-only API — 인증 불필요, refresh 로직 불필요
 const api = createPublicApi()
 
 export const getSharedProject = (shareToken) =>

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -20,6 +20,10 @@ export const rollbackStep = (stepId) =>
 export const keepStep = (stepId, isKeep) =>
   api.post(`/steps/${stepId}/keep`, { is_keep: isKeep })
 
+// Side panel 현재 진행 상태 1회 조회 (폴링 시작 전 probe 용).
+export const getSidePanelContent = (stepId) =>
+  api.get(`/steps/${stepId}/sidepanel-content`)
+
 // ─────────────────────────────────────────────────────────────
 // Side Panel — 비동기 폴링
 //

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -24,27 +24,32 @@ export const keepStep = (stepId, isKeep) =>
 // Side Panel — 비동기 폴링
 //
 // 1. POST /steps/{id}/sidepanel-start  (fire-and-forget; 응답 안 기다림)
-// 2. 500ms 마다 GET /steps/{id}/sidepanel-content 로 누적 raw text 폴링
-// 3. content 가 늘어난 만큼만 delta 로 onChunk 호출 (UI 는 누적 표시)
-// 4. is_complete 면 onDone 또는 onError 후 폴링 중단
+// 2. GET /steps/{id}/sidepanel-content 폴링 — 적응형 주기
+//    - 새 chunk 도착 시: MIN_INTERVAL 로 빠르게 (활발한 스트리밍)
+//    - 변경 없음 누적 시: 주기를 1.5x 씩 늘려 최대 MAX_INTERVAL 까지
+//    - 변경 발생 시: 다시 MIN_INTERVAL 로 reset
+// 3. is_complete 면 onDone/onError 후 폴링 중단
 //
 // abort() 는 클라이언트 폴링만 멈춤 — 백엔드는 끝까지 실행되어 DB 에 저장됨.
 // ─────────────────────────────────────────────────────────────
-const POLL_INTERVAL_MS = 500
+const MIN_POLL_MS = 1000
+const MAX_POLL_MS = 4000
+const BACKOFF_AFTER_QUIET = 2 // 변경 없는 폴링이 N회 연속이면 주기 확대
 
 export function createSidePanelStream(stepId) {
-  let intervalId = null
+  let timeoutId = null
   let aborted = false
 
   return {
     start({ onChunk, onDone, onError }) {
       aborted = false
-      // 생성 시작 트리거 — 응답을 기다리지 않는다.
       api.post(`/steps/${stepId}/sidepanel-start`).catch(() => {
         // 시작 자체가 실패해도 폴링은 시도 — 이미 진행 중이면 폴링으로 잡힘.
       })
 
       let lastLen = 0
+      let interval = MIN_POLL_MS
+      let quietCount = 0
 
       const poll = async () => {
         if (aborted) return
@@ -53,31 +58,41 @@ export function createSidePanelStream(stepId) {
             `/steps/${stepId}/sidepanel-content`
           )
 
-          // 새로 누적된 부분만 delta 로 전달 → UI 는 기존처럼 점진 표시
-          if (typeof content === 'string' && content.length > lastLen) {
-            const delta = content.slice(lastLen)
+          const grew =
+            typeof content === 'string' && content.length > lastLen
+          if (grew) {
+            onChunk?.(content.slice(lastLen))
             lastLen = content.length
-            onChunk?.(delta)
+            interval = MIN_POLL_MS // 활발 — 빠른 폴링
+            quietCount = 0
+          } else {
+            quietCount += 1
+            if (quietCount >= BACKOFF_AFTER_QUIET) {
+              interval = Math.min(Math.round(interval * 1.5), MAX_POLL_MS)
+            }
           }
 
           if (is_complete) {
-            if (intervalId) clearInterval(intervalId)
-            intervalId = null
+            timeoutId = null
             status === 'error' ? onError?.() : onDone?.()
+            return
           }
         } catch {
-          // 일시적 네트워크 오류는 무시하고 다음 사이클에 재시도
+          // 일시적 네트워크 오류는 무시 — 다음 사이클에 재시도
+        }
+
+        if (!aborted) {
+          timeoutId = setTimeout(poll, interval)
         }
       }
 
-      intervalId = setInterval(poll, POLL_INTERVAL_MS)
       poll() // 첫 호출은 즉시
     },
 
     abort() {
       aborted = true
-      if (intervalId) clearInterval(intervalId)
-      intervalId = null
+      if (timeoutId) clearTimeout(timeoutId)
+      timeoutId = null
     },
   }
 }

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -33,8 +33,11 @@ export const getSidePanelContent = (stepId) =>
 //    - 변경 없음 누적 시: 주기를 1.5x 씩 늘려 최대 MAX_INTERVAL 까지
 //    - 변경 발생 시: 다시 MIN_INTERVAL 로 reset
 // 3. is_complete 면 onDone/onError 후 폴링 중단
-// 4. 4xx (인증/권한/존재하지 않음 등): 종료 신호로 간주 — 폴링 중단
-//    5xx / 네트워크 오류: 일시적이므로 MAX_FAILURES 까지만 재시도 후 포기
+// 4. 4xx: 종료 신호로 간주 — 폴링 중단 / 5xx·네트워크 오류: MAX 재시도 후 포기
+//
+// onChunk(content) 는 **누적된 full content** 를 전달한다 (delta 가 아님).
+// — 새로고침 후 복구 시 등에 buf 가 미리 채워져 있어도 중복 누적되지 않도록.
+// 소비자는 `b.text = content` 식으로 단순 대입하면 된다.
 //
 // abort() 는 클라이언트 폴링만 멈춤 — 백엔드는 끝까지 실행되어 DB 에 저장됨.
 // ─────────────────────────────────────────────────────────────
@@ -80,11 +83,12 @@ export function createSidePanelStream(stepId) {
 
           transientFailures = 0 // 성공 시 카운터 리셋
 
-          const grew =
-            typeof content === 'string' && content.length > lastLen
+          const text = typeof content === 'string' ? content : ''
+          const grew = text.length > lastLen
           if (grew) {
-            onChunk?.(content.slice(lastLen))
-            lastLen = content.length
+            // 누적 content 전체를 전달 (delta 가 아님)
+            onChunk?.(text)
+            lastLen = text.length
             interval = MIN_POLL_MS // 활발 — 빠른 폴링
             quietCount = 0
           } else {

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -1,7 +1,6 @@
-import { createApi } from './_client'
+import { createApi, resolveApiUrl } from './_client'
 
-const api = createApi() // Business Lambda (/api)
-const aiApi = createApi(import.meta.env.VITE_AI_URL || '/ai') // AI Lambda (/ai)
+const api = createApi()
 
 export const getStepTree = (projectId, stageId) =>
   api.get('/steps/tree', { params: { project_id: projectId, stage_id: stageId } })
@@ -10,10 +9,10 @@ export const getStepTreeBySequence = (projectId, stageSequence) =>
   api.get('/steps/tree', { params: { project_id: projectId, stage_sequence: stageSequence } })
 
 export const acceptStep = (stepId) =>
-  aiApi.post(`/steps/${stepId}/accept`)
+  api.post(`/steps/${stepId}/accept`)
 
 export const getStepDetail = (stepId) =>
-  aiApi.get(`/steps/${stepId}`)
+  api.get(`/steps/${stepId}`)
 
 export const rollbackStep = (stepId) =>
   api.post(`/steps/${stepId}/rollback`)
@@ -30,7 +29,8 @@ export function createSidePanelStream(stepId) {
 
       ;(async () => {
         try {
-          const response = await fetch(`${import.meta.env.VITE_AI_URL || '/ai'}/steps/${stepId}/sidepanel-stream`, {
+          const url = resolveApiUrl('GET', `/steps/${stepId}/sidepanel-stream`)
+          const response = await fetch(url, {
             method: 'GET',
             headers: {
               Accept: 'text/event-stream',

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -1,4 +1,4 @@
-import { createApi, resolveApiUrl } from './_client'
+import { createApi } from './_client'
 
 const api = createApi()
 
@@ -20,80 +20,64 @@ export const rollbackStep = (stepId) =>
 export const keepStep = (stepId, isKeep) =>
   api.post(`/steps/${stepId}/keep`, { is_keep: isKeep })
 
+// ─────────────────────────────────────────────────────────────
+// Side Panel — 비동기 폴링
+//
+// 1. POST /steps/{id}/sidepanel-start  (fire-and-forget; 응답 안 기다림)
+// 2. 500ms 마다 GET /steps/{id}/sidepanel-content 로 누적 raw text 폴링
+// 3. content 가 늘어난 만큼만 delta 로 onChunk 호출 (UI 는 누적 표시)
+// 4. is_complete 면 onDone 또는 onError 후 폴링 중단
+//
+// abort() 는 클라이언트 폴링만 멈춤 — 백엔드는 끝까지 실행되어 DB 에 저장됨.
+// ─────────────────────────────────────────────────────────────
+const POLL_INTERVAL_MS = 500
+
 export function createSidePanelStream(stepId) {
-  let abortController = null
+  let intervalId = null
+  let aborted = false
 
   return {
     start({ onChunk, onDone, onError }) {
-      abortController = new AbortController()
+      aborted = false
+      // 생성 시작 트리거 — 응답을 기다리지 않는다.
+      api.post(`/steps/${stepId}/sidepanel-start`).catch(() => {
+        // 시작 자체가 실패해도 폴링은 시도 — 이미 진행 중이면 폴링으로 잡힘.
+      })
 
-      ;(async () => {
+      let lastLen = 0
+
+      const poll = async () => {
+        if (aborted) return
         try {
-          const url = resolveApiUrl('GET', `/steps/${stepId}/sidepanel-stream`)
-          const response = await fetch(url, {
-            method: 'GET',
-            headers: {
-              Accept: 'text/event-stream',
-            },
-            credentials: 'include',
-            signal: abortController.signal,
-          })
+          const { status, content, is_complete } = await api.get(
+            `/steps/${stepId}/sidepanel-content`
+          )
 
-          if (!response.ok || !response.body) {
-            onError?.()
-            return
+          // 새로 누적된 부분만 delta 로 전달 → UI 는 기존처럼 점진 표시
+          if (typeof content === 'string' && content.length > lastLen) {
+            const delta = content.slice(lastLen)
+            lastLen = content.length
+            onChunk?.(delta)
           }
 
-          const reader = response.body.getReader()
-          const decoder = new TextDecoder()
-          let buffer = ''
-          let currentEvent = null
-
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done) break
-
-            buffer += decoder.decode(value, { stream: true })
-            const lines = buffer.split('\n')
-            buffer = lines.pop() ?? ''
-
-            for (const line of lines) {
-              if (line.startsWith('event: ')) {
-                currentEvent = line.slice(7).trim()
-              } else if (line.startsWith('data: ')) {
-                if (currentEvent === 'done') {
-                  onDone?.()
-                  return
-                }
-                if (currentEvent === 'error') {
-                  onError?.()
-                  return
-                }
-
-                try {
-                  const json = JSON.parse(line.slice(6))
-                  if (json.delta) onChunk?.(json.delta)
-                } catch {
-                  //
-                }
-
-                currentEvent = null
-              } else if (line === '') {
-                currentEvent = null
-              }
-            }
+          if (is_complete) {
+            if (intervalId) clearInterval(intervalId)
+            intervalId = null
+            status === 'error' ? onError?.() : onDone?.()
           }
-
-          onDone?.()
-        } catch (err) {
-          if (err.name === 'AbortError') return
-          onError?.()
+        } catch {
+          // 일시적 네트워크 오류는 무시하고 다음 사이클에 재시도
         }
-      })()
+      }
+
+      intervalId = setInterval(poll, POLL_INTERVAL_MS)
+      poll() // 첫 호출은 즉시
     },
 
     abort() {
-      abortController?.abort()
+      aborted = true
+      if (intervalId) clearInterval(intervalId)
+      intervalId = null
     },
   }
 }

--- a/frontend/src/api/step.js
+++ b/frontend/src/api/step.js
@@ -33,12 +33,20 @@ export const getSidePanelContent = (stepId) =>
 //    - 변경 없음 누적 시: 주기를 1.5x 씩 늘려 최대 MAX_INTERVAL 까지
 //    - 변경 발생 시: 다시 MIN_INTERVAL 로 reset
 // 3. is_complete 면 onDone/onError 후 폴링 중단
+// 4. 4xx (인증/권한/존재하지 않음 등): 종료 신호로 간주 — 폴링 중단
+//    5xx / 네트워크 오류: 일시적이므로 MAX_FAILURES 까지만 재시도 후 포기
 //
 // abort() 는 클라이언트 폴링만 멈춤 — 백엔드는 끝까지 실행되어 DB 에 저장됨.
 // ─────────────────────────────────────────────────────────────
 const MIN_POLL_MS = 1000
 const MAX_POLL_MS = 4000
 const BACKOFF_AFTER_QUIET = 2 // 변경 없는 폴링이 N회 연속이면 주기 확대
+const MAX_TRANSIENT_FAILURES = 5 // 5xx / 네트워크 오류 누적 한도
+
+function getStatusCode(err) {
+  // axios err 와 _client.js 응답 interceptor 가 던지는 envelope 에러 모두 대응
+  return err?.response?.status ?? err?.status ?? null
+}
 
 export function createSidePanelStream(stepId) {
   let timeoutId = null
@@ -54,6 +62,14 @@ export function createSidePanelStream(stepId) {
       let lastLen = 0
       let interval = MIN_POLL_MS
       let quietCount = 0
+      let transientFailures = 0
+
+      const stop = (kind) => {
+        timeoutId = null
+        aborted = true
+        if (kind === 'error') onError?.()
+        else onDone?.()
+      }
 
       const poll = async () => {
         if (aborted) return
@@ -61,6 +77,8 @@ export function createSidePanelStream(stepId) {
           const { status, content, is_complete } = await api.get(
             `/steps/${stepId}/sidepanel-content`
           )
+
+          transientFailures = 0 // 성공 시 카운터 리셋
 
           const grew =
             typeof content === 'string' && content.length > lastLen
@@ -77,12 +95,19 @@ export function createSidePanelStream(stepId) {
           }
 
           if (is_complete) {
-            timeoutId = null
-            status === 'error' ? onError?.() : onDone?.()
-            return
+            return stop(status === 'error' ? 'error' : 'done')
           }
-        } catch {
-          // 일시적 네트워크 오류는 무시 — 다음 사이클에 재시도
+        } catch (err) {
+          const code = getStatusCode(err)
+          // 4xx — 종료 신호. 더 폴링해도 의미 없음.
+          if (code !== null && code >= 400 && code < 500) {
+            return stop('error')
+          }
+          // 5xx / 네트워크 오류 — 한도까지 재시도, 초과 시 포기
+          transientFailures += 1
+          if (transientFailures >= MAX_TRANSIENT_FAILURES) {
+            return stop('error')
+          }
         }
 
         if (!aborted) {

--- a/frontend/src/components/canvas/DownloadNotification.jsx
+++ b/frontend/src/components/canvas/DownloadNotification.jsx
@@ -1,15 +1,16 @@
 import { motion, AnimatePresence } from 'framer-motion'
 import { HiOutlineSparkles } from 'react-icons/hi2'
-import { BsCheckCircleFill, BsXCircleFill } from 'react-icons/bs'
+import { BsCheckCircleFill, BsXCircleFill, BsExclamationCircleFill } from 'react-icons/bs'
 import { IoClose } from 'react-icons/io5'
 import styles from './DownloadNotification.module.css'
 
 /**
  * 우측 하단 다운로드 알림
- * - status: 'downloading' | 'complete' | 'error'
+ * - status: 'downloading' | 'complete' | 'error' | 'rate_limited'
  * - downloading: 진행 바 + 스피너
- * - complete: 체크 아이콘 + 완료 메시지
- * - error: X 아이콘 + 에러 메시지
+ * - complete:    체크 아이콘 + 완료 메시지
+ * - error:       X 아이콘 + 에러 메시지
+ * - rate_limited: 경고 아이콘 + 이미 진행 중 / 너무 잦은 요청 안내
  * - 사용자가 X 버튼 눌러야 닫힘
  */
 export default function DownloadNotification({ status, message, onClose }) {
@@ -18,12 +19,15 @@ export default function DownloadNotification({ status, message, onClose }) {
   const isDownloading = status === 'downloading'
   const isComplete = status === 'complete'
   const isError = status === 'error'
+  const isRateLimited = status === 'rate_limited'
 
   const defaultMessage = isDownloading
     ? '다운로드 중...'
     : isComplete
       ? '다운이 완료되었어요!'
-      : '다운로드에 실패했어요.'
+      : isRateLimited
+        ? '이미 다운로드가 진행 중이에요. 잠시 후 다시 시도해주세요.'
+        : '다운로드에 실패했어요.'
 
   return (
     <AnimatePresence>
@@ -39,6 +43,7 @@ export default function DownloadNotification({ status, message, onClose }) {
             {isDownloading && <HiOutlineSparkles className={styles.sparkleIcon} />}
             {isComplete && <BsCheckCircleFill className={styles.completeIcon} />}
             {isError && <BsXCircleFill className={styles.errorIcon} />}
+            {isRateLimited && <BsExclamationCircleFill className={styles.warnIcon} />}
           </div>
           <span className={styles.message}>{message ?? defaultMessage}</span>
           <button className={styles.closeBtn} onClick={onClose} aria-label="닫기">

--- a/frontend/src/components/canvas/DownloadNotification.module.css
+++ b/frontend/src/components/canvas/DownloadNotification.module.css
@@ -45,6 +45,12 @@
   color: #E26B6B;
 }
 
+.warnIcon {
+  width: 20px;
+  height: 20px;
+  color: #E2B048;
+}
+
 .message {
   flex: 1;
   font-size: 13.5px;

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -352,10 +352,11 @@ export default function CanvasPage() {
     buf.stream = stream
 
     stream.start({
-      onChunk: (delta) => {
+      // 폴링은 누적 content 전체를 전달 — 대입으로 처리 (중복 누적 방지)
+      onChunk: (content) => {
         const b = streamBuffers.current.get(nodeId)
         if (!b) return
-        b.text += delta
+        b.text = content
         b.onUpdate?.(b.text)
       },
       onDone: async () => {

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -20,7 +20,7 @@ import MdExportModal from '../components/canvas/MdExportModal'
 import DownloadNotification from '../components/canvas/DownloadNotification'
 
 import { getStages } from '../api/stage'
-import { getStepTree, getStepDetail, acceptStep, rollbackStep, createSidePanelStream, keepStep } from '../api/step'
+import { getStepTree, getStepDetail, acceptStep, rollbackStep, createSidePanelStream, keepStep, getSidePanelContent } from '../api/step'
 import { createShare, deleteShare, getShareStatus } from '../api/projects'
 import { createDesignExportStream } from '../api/exports'
 import { BsLink45Deg, BsCheck } from 'react-icons/bs'
@@ -654,7 +654,26 @@ export default function CanvasPage() {
     }
 
     const requestId = ++detailRequestRef.current
-    const buf = streamBuffers.current.get(node.id)
+    let buf = streamBuffers.current.get(node.id)
+
+    // 새로고침 등으로 in-memory buffer 가 유실된 경우 — 백엔드에 진행 상태 확인.
+    // streaming/pending 이면 폴링을 재개해 화면을 복구한다.
+    if (!buf && !detailCacheRef.current[node.id]) {
+      try {
+        const probe = await getSidePanelContent(node.id)
+        if (requestId !== detailRequestRef.current) return
+        if (probe.status === 'streaming' || probe.status === 'pending') {
+          startNodeStream(node.id)
+          buf = streamBuffers.current.get(node.id)
+          if (buf && probe.content) {
+            // 첫 폴링까지 기다리지 않고 누적된 raw text 를 미리 채워둠
+            buf.text = probe.content
+          }
+        }
+      } catch {
+        // probe 실패는 무시 — 아래 분기에서 자연스럽게 처리됨
+      }
+    }
 
     if (buf?.isDone) {
       setIsStreamMode(false)

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -22,7 +22,7 @@ import DownloadNotification from '../components/canvas/DownloadNotification'
 import { getStages } from '../api/stage'
 import { getStepTree, getStepDetail, acceptStep, rollbackStep, createSidePanelStream, keepStep, getSidePanelContent } from '../api/step'
 import { createShare, deleteShare, getShareStatus } from '../api/projects'
-import { createDesignExportStream, getDesignExportJobId } from '../api/exports'
+import { createDesignExportStream, getDesignExportJobId, startDesignExport } from '../api/exports'
 import { BsLink45Deg, BsCheck } from 'react-icons/bs'
 
 import { 
@@ -1170,14 +1170,31 @@ export default function CanvasPage() {
     })
   }
 
-  function handleStartExport(selectedStepIds) {
+  async function handleStartExport(selectedStepIds) {
     setMdExportOpen(false)
+
+    // 사전 체크 — 이미 진행 중인 다운로드가 있으면 새 요청 보내지 말고 안내만.
+    if (exportStreamRef.current || getDesignExportJobId(projectId)) {
+      setDownloadStatus('rate_limited')
+      return
+    }
+
     setDownloadStatus('downloading')
 
-    // 이전 스트림 정리
-    exportStreamRef.current?.abort?.()
+    // POST 트리거 — 응답까지 await 해서 429 등을 즉시 감지.
+    const result = await startDesignExport(projectId, selectedStepIds)
+    if (result.error) {
+      const { code, status } = result.error
+      if (status === 429 || code === 'DESIGN_EXPORT_RATE_LIMITED') {
+        setDownloadStatus('rate_limited')
+      } else {
+        setDownloadStatus('error')
+      }
+      return
+    }
 
-    runExportStream(createDesignExportStream(projectId, selectedStepIds))
+    // 성공 — 폴링 시작
+    runExportStream(createDesignExportStream(projectId, result.jobId))
   }
 
   // 새로고침 후에도 진행 중이던 design-export 가 있으면 자동 재개.
@@ -1189,9 +1206,7 @@ export default function CanvasPage() {
     if (!pendingJobId) return
 
     setDownloadStatus('downloading')
-    runExportStream(
-      createDesignExportStream(projectId, [], { resumeJobId: pendingJobId })
-    )
+    runExportStream(createDesignExportStream(projectId, pendingJobId))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId])
 

--- a/frontend/src/pages/CanvasPage.jsx
+++ b/frontend/src/pages/CanvasPage.jsx
@@ -22,7 +22,7 @@ import DownloadNotification from '../components/canvas/DownloadNotification'
 import { getStages } from '../api/stage'
 import { getStepTree, getStepDetail, acceptStep, rollbackStep, createSidePanelStream, keepStep, getSidePanelContent } from '../api/step'
 import { createShare, deleteShare, getShareStatus } from '../api/projects'
-import { createDesignExportStream } from '../api/exports'
+import { createDesignExportStream, getDesignExportJobId } from '../api/exports'
 import { BsLink45Deg, BsCheck } from 'react-icons/bs'
 
 import { 
@@ -1138,16 +1138,8 @@ export default function CanvasPage() {
     setDownloadStatus(null)
   }
 
-  function handleStartExport(selectedStepIds) {
-    setMdExportOpen(false)
-    setDownloadStatus('downloading')
-
-    // 이전 스트림 정리
-    exportStreamRef.current?.abort?.()
-
-    const stream = createDesignExportStream(projectId, selectedStepIds)
+  function runExportStream(stream) {
     exportStreamRef.current = stream
-
     stream.start({
       onComplete: (data) => {
         try {
@@ -1177,6 +1169,31 @@ export default function CanvasPage() {
       },
     })
   }
+
+  function handleStartExport(selectedStepIds) {
+    setMdExportOpen(false)
+    setDownloadStatus('downloading')
+
+    // 이전 스트림 정리
+    exportStreamRef.current?.abort?.()
+
+    runExportStream(createDesignExportStream(projectId, selectedStepIds))
+  }
+
+  // 새로고침 후에도 진행 중이던 design-export 가 있으면 자동 재개.
+  // localStorage 에 보관된 job_id 로 폴링만 다시 시작 (POST 생략).
+  useEffect(() => {
+    if (!projectId) return
+    if (exportStreamRef.current) return // 이미 진행 중이면 skip
+    const pendingJobId = getDesignExportJobId(projectId)
+    if (!pendingJobId) return
+
+    setDownloadStatus('downloading')
+    runExportStream(
+      createDesignExportStream(projectId, [], { resumeJobId: pendingJobId })
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId])
 
   const selectedHasChildren = edges.some((e) => e.source === selectedStep?.id)
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,10 +1,11 @@
 import styles from './LoginPage.module.css'
 import { SiGoogle, SiNaver } from 'react-icons/si'
+import { resolveApiUrl } from '../api/_client'
 
 
 export default function LoginPage() {
   function handleLogin(provider) {
-    window.location.href = `${import.meta.env.VITE_API_URL || '/api'}/auth/${provider}/login`
+    window.location.href = resolveApiUrl('GET', `/auth/${provider}/login`)
   }
 
   return (


### PR DESCRIPTION
## PR 요약
- SSE (StreamingResponse) 기반이던 Side Panel / Design Export 를 비동기 폴링 방식으로 전환. API Gateway 응답 스트리밍 미지원 한계를 우회하고, 클라이언트 연결 끊김에도 백엔드 작업이 보존되도록 개선.

## 변경 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

### API 변경
**제거**
- `GET /steps/{step_id}/sidepanel-stream`
- `POST /projects/{project_id}/design-export`

**신규 — Side Panel**
- `POST /steps/{step_id}/sidepanel-start` (AI) — 생성 트리거. 202 / 200(이미 done) / 4xx
- `GET /steps/{step_id}/sidepanel-content` (Business) — 진행 상태 폴링. 항상 200 + body status

**신규 — Design Export**
- `POST /projects/{project_id}/design-export-start` (AI) — 클라이언트 생성 `job_id` 로 시작. 202 / 200 / 429
- `GET /projects/{project_id}/design-export-jobs/{job_id}` (Business) — 진행 상태 폴링

### Sequence Diagram

**Side Panel**
```mermaid
sequenceDiagram
  participant FE as Frontend
  participant BL as Business Lambda
  participant AL as AI Lambda
  participant DB as DB

  FE->>AL: POST /sidepanel-start (fire-and-forget)
  AL->>DB: status=pending, raw=''
  loop LLM streaming
    AL->>DB: streaming_raw 누적 UPDATE
  end
  par 폴링
    FE->>BL: GET /sidepanel-content (적응형 1~4s)
    BL->>DB: SELECT streaming_raw, status
    BL-->>FE: { status, content, is_complete }
  and 백엔드 작업
    AL->>DB: mentoring/dictionary 저장, status=done
    Note over AL: 클라이언트 끊겨도 shield 로 계속 실행
  end
  FE->>BL: GET /sidepanel-content
  BL-->>FE: { is_complete: true }
  FE->>FE: 폴링 중단 + 최종 표시
```

**Design Export**
```mermaid
sequenceDiagram
  participant FE as Frontend
  participant BL as Business Lambda
  participant AL as AI Lambda
  participant DB as DB

  FE->>FE: job_id = crypto.randomUUID()
  FE->>AL: POST /design-export-start { job_id }
  alt 429
    AL-->>FE: 429
    FE->>FE: "이미 진행 중" 토스트
  else 정상
    AL->>DB: INSERT job(pending)
    AL-->>FE: 202
    FE->>FE: localStorage 저장 (새로고침 후 재개용)
    AL->>DB: UPDATE markdown, status=done
    loop 폴링 (적응형 1~4s)
      FE->>BL: GET /design-export-jobs/{job_id}
      BL-->>FE: { status, markdown }
    end
    FE->>FE: 다운로드 트리거 + localStorage 정리
  end
```

### 핵심 설계 포인트
- **클라이언트 끊김 보존**: AI Lambda 의 LLM 호출을 `asyncio.shield` + while loop 로 격리해 요청 핸들러가 cancel 되어도 invocation 유지 → DB 저장 보장
- **적응형 폴링**: 변경 없으면 1.5x 씩 주기 확대 (1s → 4s) → 평균 ~50% 요청 감소
- **세션 유지 (Design Export)**: 클라이언트가 `job_id` 생성 + `localStorage` 보관 → 새로고침 후 마운트 시 미완료 job 자동 재개

### 기타 버그 수정
1. 폴링 중 4xx 응답 시 무한 폴링 → 종료 신호로 간주해 중단
2. 다운로드 진행 중 중복 요청 시 429 발생 → 사전 차단 + `rate_limited` 토스트로 안내
3. 새로고침 복구 경로에서 `buf.text` 가 두 배로 부풀어 `JSON.parse` 실패 → 폴링 onChunk 를 delta 가 아닌 누적 content 전체 전달로 변경

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [x] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [x] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영 (해당 없음)

## 참고 사항
- DB 마이그레이션: `step_content` 에 `streaming_status`, `streaming_raw` 컬럼 추가 + `design_export_job` 테이블 신규
- 배포 시 `alembic upgrade head` 선행 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)