### PR TITLE
[#214][AI] generate literal 중복 deterministic 후처리 — 1회 재호출

### DIFF
--- a/ai/services/step_generator.py
+++ b/ai/services/step_generator.py
@@ -23,6 +23,19 @@ _SCENARIO = "generate"
 _NONE_LABEL = "없음"
 
 
+def _normalize_step_name(name: str) -> str:
+    """이름 정규화: 공백 모두 제거 + 소문자화. literal 중복 비교용."""
+    return "".join(name.lower().split())
+
+
+def _collect_forbidden_names(input_data: "GenerateInput") -> "set[str]":
+    """금지 이름 집합: 직전 부모 + decision_history 모든 항목."""
+    forbidden = {_normalize_step_name(input_data.current_step.name)}
+    for item in input_data.decision_history:
+        forbidden.add(_normalize_step_name(item.name))
+    return forbidden
+
+
 def _format_rag_context(chunks: list[RetrievedChunk]) -> str:
     """RAG 검색 결과를 프롬프트용 텍스트로 포맷팅."""
     if not chunks:
@@ -127,4 +140,48 @@ class StepGenerator:
             )
         )
 
-        return await self.llm.invoke(prompt, GenerateOutput, max_tokens=1024)
+        output = await self.llm.invoke(prompt, GenerateOutput, max_tokens=1024)
+
+        forbidden = _collect_forbidden_names(input_data)
+        duplicates = [
+            s.name for s in output.generated_steps
+            if _normalize_step_name(s.name) in forbidden
+        ]
+        if duplicates:
+            logger.warning(
+                json.dumps(
+                    {
+                        "event": "step_generator_literal_duplicate_detected",
+                        "duplicates": duplicates,
+                        "retrying": True,
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            retry_prompt = prompt + (
+                "\n\n# ★★ 재시도 — 절대 금지 ★★\n"
+                "이전 시도에서 다음 이름이 동어 반복으로 폐기되었다.\n"
+                "이번 응답에서는 아래 이름과 literal 동일하거나 의미 동일한 Step을\n"
+                "**절대** 생성하지 마라:\n"
+                + "\n".join(f"  - {name}" for name in duplicates)
+                + "\n\n금지 이름 목록 (참고):\n"
+                + "\n".join(f"  - {item.name}" for item in input_data.decision_history)
+                + f"\n  - {input_data.current_step.name}\n"
+            )
+            output = await self.llm.invoke(retry_prompt, GenerateOutput, max_tokens=1024)
+            still_duplicates = [
+                s.name for s in output.generated_steps
+                if _normalize_step_name(s.name) in forbidden
+            ]
+            if still_duplicates:
+                logger.error(
+                    json.dumps(
+                        {
+                            "event": "step_generator_literal_duplicate_after_retry",
+                            "duplicates": still_duplicates,
+                        },
+                        ensure_ascii=False,
+                    )
+                )
+
+        return output

--- a/ai/tests/test_step_generator.py
+++ b/ai/tests/test_step_generator.py
@@ -1,6 +1,7 @@
 """ai/services/step_generator.py 단위 테스트."""
 
 import json
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -17,7 +18,7 @@ from ai.schemas.common import (
     StepInfo,
 )
 from ai.schemas.generate import GenerateInput, GenerateOutput
-from ai.services.step_generator import StepGenerator
+from ai.services.step_generator import StepGenerator, _normalize_step_name
 
 
 # ---------------------------------------------------------------------------
@@ -396,3 +397,111 @@ class TestIntegration:
 
         with pytest.raises(AIGenerationFailedError):
             await service.generate_steps(_input_with_required())
+
+
+# ---------------------------------------------------------------------------
+# literal 중복 탐지 및 재호출
+# ---------------------------------------------------------------------------
+
+
+class TestLiteralDuplicateRetry:
+    @pytest.mark.asyncio
+    async def test_literal_duplicate_with_parent_triggers_retry(self, caplog):
+        """직전 부모 이름과 literal 동일한 자식 → 1회 재호출, 최종 output 정상."""
+        duplicate_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name="문제 정의 정리", description="부모와 동일한 이름"),
+                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
+            ]
+        )
+        ok_output = _valid_output()
+
+        service, llm, _ = _make_service(llm_side_effect=[duplicate_output, ok_output])
+
+        with caplog.at_level(logging.WARNING, logger="ai.services.step_generator"):
+            result = await service.generate_steps(_input_with_required())
+
+        assert llm.invoke.await_count == 2
+        assert result is ok_output
+        assert any(
+            "step_generator_literal_duplicate_detected" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_literal_duplicate_with_decision_history_triggers_retry(self, caplog):
+        """decision_history 항목과 literal 동일한 자식 → 1회 재호출."""
+        duplicate_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name="문제 정의", description="히스토리 항목과 동일"),
+                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
+            ]
+        )
+        ok_output = _valid_output()
+
+        service, llm, _ = _make_service(llm_side_effect=[duplicate_output, ok_output])
+
+        with caplog.at_level(logging.WARNING, logger="ai.services.step_generator"):
+            result = await service.generate_steps(_input_with_required())
+
+        assert llm.invoke.await_count == 2
+        assert result is ok_output
+        assert any(
+            "step_generator_literal_duplicate_detected" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_skips_retry(self):
+        """중복 없음 → LLM 정확히 1회만 호출."""
+        ok_output = _valid_output()
+        service, llm, _ = _make_service(llm_return=ok_output)
+
+        result = await service.generate_steps(_input_with_required())
+
+        assert llm.invoke.await_count == 1
+        assert result is ok_output
+
+    @pytest.mark.asyncio
+    async def test_duplicate_persists_after_retry_logs_error(self, caplog):
+        """재호출 후에도 중복이면 error 로그 후 그대로 반환."""
+        dup_name = "문제 정의 정리"
+        duplicate_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name=dup_name, description="부모와 동일"),
+                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
+            ]
+        )
+
+        service, llm, _ = _make_service(llm_return=duplicate_output)
+
+        with caplog.at_level(logging.ERROR, logger="ai.services.step_generator"):
+            result = await service.generate_steps(_input_with_required())
+
+        assert llm.invoke.await_count == 2
+        assert isinstance(result, GenerateOutput)
+        assert any(
+            "step_generator_literal_duplicate_after_retry" in r.message
+            for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# _normalize_step_name 단위 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeStepName:
+    def test_strips_spaces_and_lowercases(self):
+        assert _normalize_step_name("호환성 요구사항") == _normalize_step_name("호환성요구사항")
+        assert _normalize_step_name("호환성  요구사항") == _normalize_step_name("호환성요구사항")
+
+    def test_same_name_different_spacing(self):
+        result = _normalize_step_name("주요 기능 상세 정의")
+        assert result == "주요기능상세정의"
+
+    def test_lowercases_english(self):
+        assert _normalize_step_name("API 설계") == _normalize_step_name("api 설계")


### PR DESCRIPTION
## 변경 요약
LLM이 응답한 자식 Step 이름이 직전 부모 또는 `decision_history`의 ACCEPTED 항목과 literal 동일하면 augmented prompt로 1회 재호출하는 deterministic 가드 추가.

## 동기
사용자 트리에서 literal 동어 반복 발생:
- 부모 `7704b055` "호환성 요구사항" (ACCEPTED) → 자식 `146d4d2f` "호환성 요구사항" (READY)

#212에서 추가한 sub-rule (A)는 프롬프트 레벨 가드라 확률적. attention drift 시 누수 발생.
deterministic 후처리 1단계가 필요.

## 변경 내용
- `ai/services/step_generator.py`
  - `_normalize_step_name()` — 공백 제거 + 소문자화 (literal 비교용)
  - `_collect_forbidden_names()` — 직전 부모 + decision_history 모든 항목 정규화 집합
  - `generate_steps()` — 1차 LLM 호출 → 중복 탐지 → 1회 재호출 (augmented prompt에 금지 목록 명시) → loud error 로그
- `ai/tests/test_step_generator.py` — 7건 추가 (TestLiteralDuplicateRetry × 4, TestNormalizeStepName × 3)

## 차단 범위
| 케이스 | 차단 |
|---|---|
| Literal 동일 (부모 = 자식, 조상 = 자손) | deterministic, 99.99%+ |
| 의미 동일 ("주요 기능 정의" vs "주요 기능 정리") | sub-rule (A) (#212)에 위임 |

## 비용
- 정상 케이스 (99%+): 추가 호출 0
- 중복 발생 시: LLM 1회 더 호출 (~3초 추가)

## 외부 영향
- 외부 인터페이스 변경 0 (반환 타입 GenerateOutput 그대로)
- 백엔드 / 프론트 / 인프라 / DB 변경 0
- AI 모듈 내부만, 단일 서비스 파일 + 테스트

## 테스트
- `pytest ai/tests/test_step_generator.py` — 24/24 PASS

## 관련 PR
- #207 R별 활동 가이드 동적 주입
- #212 decision_history ACCEPTED 조상 동어 반복 차단 (sub-rule A)