### PR TITLE
[#218][AI] generate 의미 중복 deterministic 후처리 — 핵심 명사 2개 겹침 검사

### DIFF
--- a/ai/services/step_generator.py
+++ b/ai/services/step_generator.py
@@ -36,6 +36,28 @@ def _collect_forbidden_names(input_data: "GenerateInput") -> "set[str]":
     return forbidden
 
 
+_INTERCHANGEABLE_SUFFIXES = frozenset({
+    "검토", "정리", "분석", "작성", "정의", "도출", "수립",
+    "명세", "명세화", "결정", "선정", "선택", "정립", "진행",
+    "평가", "점검", "식별", "매핑", "비교", "조사", "파악",
+    "확인", "구성", "설정", "수행", "구축",
+    "계획", "방안", "전략", "방향",
+})
+
+
+def _extract_content_tokens(name: str) -> "set[str]":
+    """이름에서 핵심 명사 토큰만 추출 (동사형 접미사 stopword 제외)."""
+    tokens = name.lower().split()
+    return {t for t in tokens if t not in _INTERCHANGEABLE_SUFFIXES}
+
+
+def _is_semantic_duplicate(new_name: str, forbidden_name: str) -> bool:
+    """핵심 명사 2개 이상 겹치면 의미 중복으로 판정."""
+    a = _extract_content_tokens(new_name)
+    b = _extract_content_tokens(forbidden_name)
+    return len(a & b) >= 2
+
+
 def _format_rag_context(chunks: list[RetrievedChunk]) -> str:
     """RAG 검색 결과를 프롬프트용 텍스트로 포맷팅."""
     if not chunks:
@@ -142,11 +164,19 @@ class StepGenerator:
 
         output = await self.llm.invoke(prompt, GenerateOutput, max_tokens=1024)
 
-        forbidden = _collect_forbidden_names(input_data)
-        duplicates = [
-            s.name for s in output.generated_steps
-            if _normalize_step_name(s.name) in forbidden
+        forbidden_normalized = _collect_forbidden_names(input_data)
+        forbidden_raw_names: list[str] = [input_data.current_step.name] + [
+            item.name for item in input_data.decision_history
         ]
+
+        def _has_duplicate(step_name: str) -> bool:
+            if _normalize_step_name(step_name) in forbidden_normalized:
+                return True
+            return any(
+                _is_semantic_duplicate(step_name, f) for f in forbidden_raw_names
+            )
+
+        duplicates = [s.name for s in output.generated_steps if _has_duplicate(s.name)]
         if duplicates:
             logger.warning(
                 json.dumps(
@@ -170,8 +200,7 @@ class StepGenerator:
             )
             output = await self.llm.invoke(retry_prompt, GenerateOutput, max_tokens=1024)
             still_duplicates = [
-                s.name for s in output.generated_steps
-                if _normalize_step_name(s.name) in forbidden
+                s.name for s in output.generated_steps if _has_duplicate(s.name)
             ]
             if still_duplicates:
                 logger.error(

--- a/ai/tests/test_step_generator.py
+++ b/ai/tests/test_step_generator.py
@@ -18,7 +18,12 @@ from ai.schemas.common import (
     StepInfo,
 )
 from ai.schemas.generate import GenerateInput, GenerateOutput
-from ai.services.step_generator import StepGenerator, _normalize_step_name
+from ai.services.step_generator import (
+    StepGenerator,
+    _extract_content_tokens,
+    _is_semantic_duplicate,
+    _normalize_step_name,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -505,3 +510,152 @@ class TestNormalizeStepName:
 
     def test_lowercases_english(self):
         assert _normalize_step_name("API 설계") == _normalize_step_name("api 설계")
+
+
+# ---------------------------------------------------------------------------
+# semantic 중복 탐지 및 재호출
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticDuplicateRetry:
+    @pytest.mark.asyncio
+    async def test_semantic_duplicate_with_swapped_suffix_triggers_retry(self, caplog):
+        """동사형 접미사만 바꾼 자식 ('검토' → '정리') → semantic 중복 → 재호출."""
+        inp = GenerateInput(
+            project_info=_project(),
+            current_stage=_stage(),
+            decision_history=[],
+            current_step=StepInfo(step_id="s1", name="Ncurses 라이브러리 제약 검토"),
+            current_required_step=_required_step(),
+        )
+        duplicate_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name="Ncurses 기능 제약 정리", description="literal 다름·의미 동일"),
+                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
+            ]
+        )
+        ok_output = _valid_output()
+
+        service, llm, _ = _make_service(llm_side_effect=[duplicate_output, ok_output])
+
+        with caplog.at_level(logging.WARNING, logger="ai.services.step_generator"):
+            result = await service.generate_steps(inp)
+
+        assert llm.invoke.await_count == 2
+        assert result is ok_output
+        assert any(
+            "step_generator_literal_duplicate_detected" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_semantic_duplicate_with_decision_history_triggers_retry(self, caplog):
+        """decision_history 항목과 핵심 명사 2개 겹치는 자식 → semantic 중복."""
+        inp = GenerateInput(
+            project_info=_project(),
+            current_stage=_stage(),
+            decision_history=[
+                DecisionHistoryItem(
+                    step_id="s0", name="사용자 인터뷰 진행", status="ACCEPTED"
+                ),
+            ],
+            current_step=StepInfo(step_id="s1", name="프로젝트 컨셉 정리"),
+            current_required_step=_required_step(),
+        )
+        duplicate_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name="사용자 인터뷰 계획", description="진행↔계획 swap"),
+                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
+            ]
+        )
+        ok_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="문제 사례 정리", description="문제 사례 수집"),
+                GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
+            ]
+        )
+
+        service, llm, _ = _make_service(llm_side_effect=[duplicate_output, ok_output])
+
+        with caplog.at_level(logging.WARNING, logger="ai.services.step_generator"):
+            result = await service.generate_steps(inp)
+
+        assert llm.invoke.await_count == 2
+        assert result is ok_output
+        assert any(
+            "step_generator_literal_duplicate_detected" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_one_token_overlap_does_not_trigger(self):
+        """핵심 명사 1개만 겹치면 재호출 안 함 (threshold=2)."""
+        inp = GenerateInput(
+            project_info=_project(),
+            current_stage=_stage(),
+            decision_history=[
+                DecisionHistoryItem(
+                    step_id="s0", name="사용자 인터뷰 진행", status="ACCEPTED"
+                ),
+            ],
+            current_step=StepInfo(step_id="s1", name="프로젝트 컨셉 정리"),
+            current_required_step=_required_step(),
+        )
+        # "사용자 페르소나 작성" — '사용자'만 겹침 (1개), 재호출 X
+        ok_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name="사용자 페르소나 작성", description="페르소나 1개 토큰 겹침"),
+                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
+            ]
+        )
+
+        service, llm, _ = _make_service(llm_return=ok_output)
+
+        result = await service.generate_steps(inp)
+
+        assert llm.invoke.await_count == 1
+        assert result is ok_output
+
+
+# ---------------------------------------------------------------------------
+# _extract_content_tokens / _is_semantic_duplicate 단위 테스트
+# ---------------------------------------------------------------------------
+
+
+class TestExtractContentTokens:
+    def test_filters_interchangeable_suffix(self):
+        assert _extract_content_tokens("Ncurses 라이브러리 제약 검토") == {
+            "ncurses",
+            "라이브러리",
+            "제약",
+        }
+
+    def test_filters_short_step_name(self):
+        assert _extract_content_tokens("기능 정리") == {"기능"}
+
+    def test_filters_user_interview_plan(self):
+        assert _extract_content_tokens("사용자 인터뷰 계획") == {"사용자", "인터뷰"}
+
+
+class TestIsSemanticDuplicate:
+    def test_one_token_overlap_returns_false(self):
+        # {"사용자", "페르소나"} ∩ {"사용자", "인터뷰"} = {"사용자"} (1개)
+        assert _is_semantic_duplicate("사용자 페르소나 작성", "사용자 인터뷰 진행") is False
+
+    def test_two_token_overlap_returns_true(self):
+        # {"ncurses", "라이브러리", "제약"} ∩ {"ncurses", "기능", "제약"} = 2개
+        assert (
+            _is_semantic_duplicate("Ncurses 기능 제약 정리", "Ncurses 라이브러리 제약 검토")
+            is True
+        )
+
+    def test_three_token_overlap_returns_true(self):
+        # {"ncurses", "라이브러리", "제약"} ∩ {"ncurses", "라이브러리", "제약"} = 3개
+        assert (
+            _is_semantic_duplicate("Ncurses 라이브러리 제약 정리", "Ncurses 라이브러리 제약 검토")
+            is True
+        )


### PR DESCRIPTION
## PR 요약
#214의 literal 중복 탐지를 의미 중복까지 확장. 핵심 명사 토큰 2개 이상 겹치면 의미 중복으로 판정하여 1회 재호출.


## 변경 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- `ai/services/step_generator.py`
  - `_INTERCHANGEABLE_SUFFIXES` — 동사형 접미사 30개 frozenset (검토/정리/분석/계획/방안 등)
  - `_extract_content_tokens()` — 공백 분리 후 stopword 제외, 핵심 명사 토큰 집합 반환
  - `_is_semantic_duplicate()` — 핵심 명사 ≥2개 겹치면 의미 중복 판정
  - `generate_steps()` — `_has_duplicate()`로 literal + semantic 통합. retry 인프라·logger event 이름 그대로 유지
- `ai/tests/test_step_generator.py` — 9건 추가 (TestSemanticDuplicateRetry × 3, TestExtractContentTokens × 3, TestIsSemanticDuplicate × 3)


## 체크리스트
- [ ] 로컬에서 서버 정상 구동 확인 (business / ai)
- [ ] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [ ] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
