### PR TITLE
[#223][AI] R-blocklist deterministic 차단 — 활동 가이드 나쁜 예를 코드 가드로 격상

### DIFF
--- a/ai/prompts/activity_guides.py
+++ b/ai/prompts/activity_guides.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Optional
 
 from ai.schemas.common import RequiredStepInfo
@@ -155,6 +156,35 @@ ACTIVITY_GUIDES: dict[str, str] = {
 - 좋은 예: "문제 해결 여부 점검", "요구사항 충족 확인", "사용자 시연 진행", "프로젝트 회고"
 - 나쁜 예: "추가 결함 기록" ← 6-R3 침범 / "추가 기능 구현" ← Stage 5 침범 / "결함 재현 정리" ← 6-R3 침범 / "추가 코드 작성" ← Stage 5 침범""",
 }
+
+
+_BAD_EXAMPLE_PATTERN = re.compile(r'"([^"]+?)"\s*←')
+
+
+def _normalize_step_name(name: str) -> str:
+    """공백 제거 + 소문자화. step_generator._normalize_step_name과 동일 규칙."""
+    return "".join(name.lower().split())
+
+
+def _build_blocklist_from_guides() -> dict[str, frozenset[str]]:
+    """ACTIVITY_GUIDES의 나쁜 예 라인에서 침범 이름을 추출하여 blocklist 생성."""
+    result: dict[str, frozenset[str]] = {}
+    for r_name, guide in ACTIVITY_GUIDES.items():
+        names: list[str] = []
+        for line in guide.splitlines():
+            if "나쁜 예" in line:
+                names.extend(_BAD_EXAMPLE_PATTERN.findall(line))
+                break
+        result[r_name] = frozenset(_normalize_step_name(n) for n in names)
+    return result
+
+
+ACTIVITY_BLOCKLIST: dict[str, frozenset[str]] = _build_blocklist_from_guides()
+
+
+def get_blocklist(required_step_name: str) -> frozenset[str]:
+    """현재 R의 deterministic blocklist 반환. 등록 안 된 R은 빈 frozenset."""
+    return ACTIVITY_BLOCKLIST.get(required_step_name, frozenset())
 
 
 def resolve_activity_guide(current_required_step: Optional[RequiredStepInfo]) -> str:

--- a/ai/services/step_generator.py
+++ b/ai/services/step_generator.py
@@ -12,9 +12,9 @@ from typing import Any, Optional
 
 from ai.clients.llm import LLMClient
 from ai.clients.rag import RAGClient
-from ai.prompts.activity_guides import resolve_activity_guide
+from ai.prompts.activity_guides import get_blocklist, resolve_activity_guide
 from ai.prompts.template import PromptTemplate
-from ai.schemas.common import RetrievedChunk
+from ai.schemas.common import RequiredStepInfo, RetrievedChunk
 from ai.schemas.generate import GenerateInput, GenerateOutput
 
 logger = logging.getLogger(__name__)
@@ -56,6 +56,24 @@ def _is_semantic_duplicate(new_name: str, forbidden_name: str) -> bool:
     a = _extract_content_tokens(new_name)
     b = _extract_content_tokens(forbidden_name)
     return len(a & b) >= 2
+
+
+def _has_duplicate(
+    step_name: str,
+    forbidden_normalized: "set[str]",
+    forbidden_raw_names: "list[str]",
+    current_required_step: Optional[RequiredStepInfo],
+) -> bool:
+    """literal·semantic·blocklist 3단계 중복 검사."""
+    normalized = _normalize_step_name(step_name)
+    if normalized in forbidden_normalized:
+        return True
+    if any(_is_semantic_duplicate(step_name, f) for f in forbidden_raw_names):
+        return True
+    if current_required_step is not None:
+        if normalized in get_blocklist(current_required_step.name):
+            return True
+    return False
 
 
 def _format_rag_context(chunks: list[RetrievedChunk]) -> str:
@@ -168,16 +186,26 @@ class StepGenerator:
         forbidden_raw_names: list[str] = [input_data.current_step.name] + [
             item.name for item in input_data.decision_history
         ]
+        req_step = input_data.current_required_step
 
-        def _has_duplicate(step_name: str) -> bool:
-            if _normalize_step_name(step_name) in forbidden_normalized:
-                return True
-            return any(
-                _is_semantic_duplicate(step_name, f) for f in forbidden_raw_names
-            )
+        def _check(step_name: str) -> bool:
+            return _has_duplicate(step_name, forbidden_normalized, forbidden_raw_names, req_step)
 
-        duplicates = [s.name for s in output.generated_steps if _has_duplicate(s.name)]
+        duplicates = [s.name for s in output.generated_steps if _check(s.name)]
         if duplicates:
+            blocklist = get_blocklist(req_step.name) if req_step is not None else frozenset()
+            blocklist_matches = [d for d in duplicates if _normalize_step_name(d) in blocklist]
+            if blocklist_matches:
+                logger.warning(
+                    json.dumps(
+                        {
+                            "event": "step_generator_blocklist_match",
+                            "matches": blocklist_matches,
+                            "required_step": req_step.name if req_step is not None else None,
+                        },
+                        ensure_ascii=False,
+                    )
+                )
             logger.warning(
                 json.dumps(
                     {
@@ -199,9 +227,7 @@ class StepGenerator:
                 + f"\n  - {input_data.current_step.name}\n"
             )
             output = await self.llm.invoke(retry_prompt, GenerateOutput, max_tokens=1024)
-            still_duplicates = [
-                s.name for s in output.generated_steps if _has_duplicate(s.name)
-            ]
+            still_duplicates = [s.name for s in output.generated_steps if _check(s.name)]
             if still_duplicates:
                 logger.error(
                     json.dumps(

--- a/ai/tests/test_activity_guides.py
+++ b/ai/tests/test_activity_guides.py
@@ -7,8 +7,10 @@ import re
 import pytest
 
 from ai.prompts.activity_guides import (
+    ACTIVITY_BLOCKLIST,
     ACTIVITY_GUIDES,
     _FREE_MODE_GUIDE,
+    get_blocklist,
     resolve_activity_guide,
 )
 from ai.schemas.common import RequiredStepInfo
@@ -187,7 +189,7 @@ class TestBadExampleDisambiguation:
             f"전체 화살표 {arrow_count}개 중 표준 {canonical_count}개."
         )
 
-    def test_problem_definition_blocks_user_segment_invasion(self):
+    def test_problem_definition_blocks_user_segment_invasion_bad_line(self):
         """1-R1 회귀 방지: 사용자 정의/페르소나 → 1-R2 침범 case 명시."""
         guide = ACTIVITY_GUIDES["문제/기회 정의"]
         bad_line = _extract_bad_example_line(guide)
@@ -196,3 +198,47 @@ class TestBadExampleDisambiguation:
         assert any(
             kw in bad_line for kw in ["사용자", "페르소나"]
         ), "1-R1 나쁜 예에 사용자/페르소나 침범 케이스가 명시되지 않음"
+
+
+# ---------------------------------------------------------------------------
+# ACTIVITY_BLOCKLIST — deterministic blocklist 검증
+# ---------------------------------------------------------------------------
+
+
+class TestActivityBlocklist:
+    def test_blocklist_extracted_from_bad_examples(self):
+        blocklist = get_blocklist("문제/기회 정의")
+        assert len(blocklist) > 0
+
+    def test_blocklist_contains_normalized_name(self):
+        """'타겟 사용자 정의' → 정규화 후 '타겟사용자정의'로 저장."""
+        blocklist = get_blocklist("문제/기회 정의")
+        assert "타겟사용자정의" in blocklist
+
+    def test_blocklist_normalization(self):
+        """blocklist는 공백 제거 + 소문자 형태로만 저장."""
+        for r_name in ACTIVITY_BLOCKLIST:
+            for entry in ACTIVITY_BLOCKLIST[r_name]:
+                assert " " not in entry, f"{r_name}: blocklist에 공백 포함 항목 '{entry}'"
+                assert entry == entry.lower(), f"{r_name}: 소문자화 안 된 항목 '{entry}'"
+
+    def test_unknown_r_returns_empty_frozenset(self):
+        assert get_blocklist("존재하지 않는 R") == frozenset()
+
+    def test_blocklist_covers_all_24_r(self):
+        assert len(ACTIVITY_BLOCKLIST) == 24
+        for r_name, entries in ACTIVITY_BLOCKLIST.items():
+            assert len(entries) > 0, f"{r_name}: blocklist가 비어 있음"
+
+    def test_blocklist_specific_r_1_r1(self):
+        """1-R1 회귀 케이스 4개 모두 blocklist에 포함."""
+        blocklist = get_blocklist("문제/기회 정의")
+        for normalized in [
+            "타겟사용자정의",
+            "타겟사용자페르소나",
+            "사용자행동조사",
+            "사용자페르소나작성",
+        ]:
+            assert normalized in blocklist, (
+                f"'문제/기회 정의' blocklist에 '{normalized}' 없음"
+            )

--- a/ai/tests/test_step_generator.py
+++ b/ai/tests/test_step_generator.py
@@ -21,6 +21,7 @@ from ai.schemas.generate import GenerateInput, GenerateOutput
 from ai.services.step_generator import (
     StepGenerator,
     _extract_content_tokens,
+    _has_duplicate,
     _is_semantic_duplicate,
     _normalize_step_name,
 )
@@ -99,7 +100,7 @@ def _input_without_required() -> GenerateInput:
 def _valid_output() -> GenerateOutput:
     return GenerateOutput(
         generated_steps=[
-            GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스를 조사하는 활동"),
+            GeneratedStep(name="문제 상황 정리", description="문제 상황을 정리하는 활동"),
             GeneratedStep(name="사용자 인터뷰 계획", description="타겟 사용자 인터뷰 설계"),
             GeneratedStep(name="기술 스택 비교", description="후보 기술 스택을 비교 분석"),
         ]
@@ -416,7 +417,7 @@ class TestLiteralDuplicateRetry:
         duplicate_output = GenerateOutput(
             generated_steps=[
                 GeneratedStep(name="문제 정의 정리", description="부모와 동일한 이름"),
-                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 조사"),
                 GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
             ]
         )
@@ -440,7 +441,7 @@ class TestLiteralDuplicateRetry:
         duplicate_output = GenerateOutput(
             generated_steps=[
                 GeneratedStep(name="문제 정의", description="히스토리 항목과 동일"),
-                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 조사"),
                 GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
             ]
         )
@@ -476,7 +477,7 @@ class TestLiteralDuplicateRetry:
         duplicate_output = GenerateOutput(
             generated_steps=[
                 GeneratedStep(name=dup_name, description="부모와 동일"),
-                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 조사"),
                 GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
             ]
         )
@@ -531,7 +532,7 @@ class TestSemanticDuplicateRetry:
         duplicate_output = GenerateOutput(
             generated_steps=[
                 GeneratedStep(name="Ncurses 기능 제약 정리", description="literal 다름·의미 동일"),
-                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 조사"),
                 GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
             ]
         )
@@ -566,13 +567,13 @@ class TestSemanticDuplicateRetry:
         duplicate_output = GenerateOutput(
             generated_steps=[
                 GeneratedStep(name="사용자 인터뷰 계획", description="진행↔계획 swap"),
-                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 조사"),
                 GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
             ]
         )
         ok_output = GenerateOutput(
             generated_steps=[
-                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 조사"),
                 GeneratedStep(name="문제 사례 정리", description="문제 사례 수집"),
                 GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
             ]
@@ -608,7 +609,7 @@ class TestSemanticDuplicateRetry:
         ok_output = GenerateOutput(
             generated_steps=[
                 GeneratedStep(name="사용자 페르소나 작성", description="페르소나 1개 토큰 겹침"),
-                GeneratedStep(name="경쟁 서비스 조사", description="유사 서비스 조사"),
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 조사"),
                 GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
             ]
         )
@@ -659,3 +660,103 @@ class TestIsSemanticDuplicate:
             _is_semantic_duplicate("Ncurses 라이브러리 제약 정리", "Ncurses 라이브러리 제약 검토")
             is True
         )
+
+
+# ---------------------------------------------------------------------------
+# blocklist 체크 통합 테스트
+# ---------------------------------------------------------------------------
+
+
+def _input_with_r1() -> GenerateInput:
+    """1-R1 '문제/기회 정의' 진행 중인 입력."""
+    return GenerateInput(
+        project_info=_project(),
+        current_stage=_stage(),
+        decision_history=[],
+        current_step=StepInfo(step_id="s1", name="프로젝트 시작"),
+        current_required_step=RequiredStepInfo(
+            step_id="rs-r1",
+            name="문제/기회 정의",
+            is_completed=False,
+            goal="문제 정의",
+            entry_criteria="없음",
+            fulfillment_criteria=["문제 서술", "임팩트 정의", "배경 설명", "기존 대안 한계"],
+            minimum_fulfillment_count=2,
+        ),
+    )
+
+
+class TestBlocklistMatch:
+    @pytest.mark.asyncio
+    async def test_blocklist_match_in_1_r1_triggers_retry(self, caplog):
+        """1-R1 blocklist에 있는 '타겟 사용자 정의' → 재호출 + blocklist_match 로그."""
+        duplicate_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name="타겟 사용자 정의", description="blocklist 항목"),
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 조사"),
+                GeneratedStep(name="기술 스택 비교", description="기술 후보 비교"),
+            ]
+        )
+        ok_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 정리"),
+                GeneratedStep(name="문제 상황 정리", description="문제 상황 조사"),
+                GeneratedStep(name="기존 해결책 한계 조사", description="기존 해결책 한계"),
+            ]
+        )
+
+        service, llm, _ = _make_service(llm_side_effect=[duplicate_output, ok_output])
+
+        with caplog.at_level(logging.WARNING, logger="ai.services.step_generator"):
+            result = await service.generate_steps(_input_with_r1())
+
+        assert llm.invoke.await_count == 2
+        assert result is ok_output
+        assert any(
+            "step_generator_blocklist_match" in r.message for r in caplog.records
+        )
+        assert any(
+            "step_generator_literal_duplicate_detected" in r.message for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_blocklist_match_normalized_forms_all_blocked(self):
+        """공백 변형 모두 blocklist에서 잡힘."""
+        inp = _input_with_r1()
+        forbidden_normalized: set[str] = set()
+        forbidden_raw: list[str] = [inp.current_step.name]
+        req = inp.current_required_step
+
+        for name_variant in ["타겟 사용자 정의", "타겟사용자정의", " 타겟  사용자  정의 "]:
+            assert _has_duplicate(name_variant, forbidden_normalized, forbidden_raw, req), (
+                f"'{name_variant}' 이 blocklist에서 잡히지 않음"
+            )
+
+    @pytest.mark.asyncio
+    async def test_blocklist_no_match_skips_retry(self):
+        """blocklist에 없는 정상 이름 → 1회 호출."""
+        ok_output = GenerateOutput(
+            generated_steps=[
+                GeneratedStep(name="문제 상황 정리", description="문제 정리"),
+                GeneratedStep(name="기존 해결책 한계 조사", description="기존 해결책"),
+                GeneratedStep(name="문제 임팩트 분석", description="임팩트"),
+            ]
+        )
+
+        service, llm, _ = _make_service(llm_return=ok_output)
+
+        result = await service.generate_steps(_input_with_r1())
+
+        assert llm.invoke.await_count == 1
+        assert result is ok_output
+
+    @pytest.mark.asyncio
+    async def test_blocklist_with_none_required_step(self):
+        """current_required_step=None → blocklist 체크 skip, literal/semantic만 작동."""
+        ok_output = _valid_output()
+        service, llm, _ = _make_service(llm_return=ok_output)
+
+        result = await service.generate_steps(_input_without_required())
+
+        assert llm.invoke.await_count == 1
+        assert result is ok_output


### PR DESCRIPTION
## 변경 요약
ACTIVITY_GUIDES의 "나쁜 예" 라인에서 침범 이름을 자동 추출하여 24개 R deterministic blocklist로 격상. step_generator에서 LLM 응답 후 blocklist 매치 시 #214/#218 retry 인프라 재사용하여 차단.

## 이유
#221 R 경계 disambiguation (프롬프트 가이드) 적용 후에도 production에서 누수 발생:
- 1-R1 진행 중 "타겟 사용자 정의" (1-R2 침범) 생성
- LLM 변덕으로 활동 가이드에 명시된 나쁜 예조차 무시

프롬프트 가이드는 확률적이라 100% 차단 불가 → deterministic 후처리 필요.

## 변경 내용
- `ai/prompts/activity_guides.py`
  - `_BAD_EXAMPLE_PATTERN` 정규식 — 나쁜 예 라인에서 `"이름" ←` 패턴 추출
  - `_normalize_step_name()` — 공백 제거 + 소문자화 (step_generator와 동일 규칙)
  - `_build_blocklist_from_guides()` — 모듈 로드 1회, ACTIVITY_GUIDES 나쁜 예 자동 추출
  - `ACTIVITY_BLOCKLIST` — 24개 R 키, 정규화된 frozenset
  - `get_blocklist()` — 미등록 R은 빈 frozenset
- `ai/services/step_generator.py`
  - `_has_duplicate()` 모듈 수준 함수로 격상, 3단계 검사 (literal → semantic → blocklist)
  - `step_generator_blocklist_match` 로그 이벤트 (디버깅용)
  - 기존 #214/#218 retry 인프라 그대로 재사용
- `ai/tests/test_activity_guides.py` TestActivityBlocklist (6개)
- `ai/tests/test_step_generator.py` TestBlocklistMatch (4개)

## 단일 source 자동 동기화
ACTIVITY_GUIDES dict만 수정하면 blocklist 자동 갱신 (DRY 원칙).
새 침범 케이스 발견 시 활동 가이드의 "나쁜 예" 라인에 추가하면 끝.

## 한시적 가드
점차 Generator + Validator 2-stage pipeline으로 대체 예정.

## 외부 영향
- 외부 인터페이스 변경 0
- 백엔드 / 프론트 / 인프라 / DB 변경 0
- AI 모듈 내부

## 테스트
- `pytest ai/tests/test_activity_guides.py ai/tests/test_step_generator.py` — 201/201 PASS

## 관련 PR
- #207 R별 활동 가이드 동적 주입
- #212 sub-rule (A) ACCEPTED 조상 동어 반복 차단
- #214 literal 중복 1회 재호출
- #216 project_info 자유 텍스트 anchoring 차단
- #218 의미 중복 1회 재호출 (토큰 겹침)
- #221 R 경계 disambiguation
