### PR TITLE
[#232][AI] Bedrock Direct → Anthropic Direct API 마이그레이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ layer-build/
 
 # Lambda deployment packages (built locally, not tracked)
 *.zip
+
+# 개인 비용 측정 (클라우드셸 zip)
+cost_measurement/

--- a/ai/cli_simulator.py
+++ b/ai/cli_simulator.py
@@ -2,8 +2,8 @@
 
 실행: ``python -m ai.cli_simulator``
 
-실제 Bedrock API를 호출하여 generate → accept → side_panel 흐름,
-또는 design-export 시나리오를 모사한다.
+실제 Anthropic Direct API + Bedrock KB(RAG)를 호출하여
+generate → accept → side_panel 흐름, 또는 design-export 시나리오를 모사한다.
 인메모리 상태만 유지하며 DB는 사용하지 않는다.
 """
 
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 import time
 import uuid
 from typing import Optional
 
 import boto3
+from anthropic import AsyncAnthropic
 
 from ai.clients.llm import LLMClient
 from ai.clients.rag import RAGClient
@@ -171,14 +173,23 @@ def _build_project_info() -> ProjectInfo:
     )
 
 
+def _build_anthropic_client() -> AsyncAnthropic:
+    """Anthropic Direct API용 AsyncAnthropic 클라이언트 생성.
+
+    환경변수 ANTHROPIC_API_KEY 우선, 없으면 ai_settings에서 fallback.
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY") or ai_settings.ANTHROPIC_API_KEY
+    return AsyncAnthropic(api_key=api_key)
+
+
 def _build_services() -> tuple[StepGenerator, RequiredStepJudge, SidePanelGenerator]:
-    bedrock_runtime = boto3.client("bedrock-runtime", region_name=ai_settings.AWS_REGION)
+    anthropic_client = _build_anthropic_client()
     bedrock_agent_runtime = boto3.client(
         "bedrock-agent-runtime", region_name=ai_settings.AWS_REGION
     )
 
     llm = LLMClient(
-        bedrock_client=bedrock_runtime,
+        anthropic_client=anthropic_client,
         model_id=ai_settings.MODEL_ID,
         max_tokens=ai_settings.MAX_TOKENS,
         temperature=ai_settings.TEMPERATURE,
@@ -533,9 +544,9 @@ def _design_export_detailed_input() -> DesignExportInput:
     )
 
 
-def _build_design_export_bedrock() -> object:
-    """design-export용 bedrock-runtime 클라이언트 생성."""
-    return boto3.client("bedrock-runtime", region_name=ai_settings.AWS_REGION)
+def _build_design_export_anthropic() -> AsyncAnthropic:
+    """design-export용 AsyncAnthropic 클라이언트 생성."""
+    return _build_anthropic_client()
 
 
 def _print_design_export_header(input_data: DesignExportInput) -> None:
@@ -574,15 +585,15 @@ def _print_design_export_result(result: DesignExportOutput) -> None:
 
 
 async def _run_design_export(input_data: DesignExportInput) -> None:
-    """design-export 시나리오 실행 — Bedrock 호출 + 결과 출력 (v1.4 Z+)."""
-    bedrock_runtime = _build_design_export_bedrock()
+    """design-export 시나리오 실행 — Anthropic 호출 + 결과 출력 (v1.4 Z+)."""
+    anthropic_client = _build_design_export_anthropic()
 
-    _wait("프롬프트 렌더 + Bedrock 호출 중...")
+    _wait("프롬프트 렌더 + Anthropic 호출 중...")
     t_start = time.perf_counter()
     try:
         result = await generate_design_export(
             input_data=input_data,
-            bedrock_runtime_client=bedrock_runtime,
+            anthropic_client=anthropic_client,
             model_id=ai_settings.MODEL_ID,
         )
     except OutputViolatesHonestyGuardError as exc:
@@ -599,7 +610,7 @@ async def _run_design_export(input_data: DesignExportInput) -> None:
         return
     except BedrockAPIError as exc:
         elapsed = time.perf_counter() - t_start
-        _fail(f"Bedrock API 오류  [{elapsed:.2f}s]: {exc.message}")
+        _fail(f"LLM API 오류  [{elapsed:.2f}s]: {exc.message}")
         return
     except AIGenerationFailedError as exc:
         elapsed = time.perf_counter() - t_start

--- a/ai/clients/llm.py
+++ b/ai/clients/llm.py
@@ -1,13 +1,16 @@
-"""Bedrock Claude LLM 클라이언트.
+"""Anthropic Direct API LLM 클라이언트.
 
-boto3 bedrock-runtime 클라이언트를 의존성 주입받아, 프롬프트를 호출하고
-응답을 Pydantic 스키마로 검증한다. 스키마/JSON 실패는 재시도, Bedrock API
+anthropic.AsyncAnthropic 클라이언트를 의존성 주입받아, 프롬프트를 호출하고
+응답을 Pydantic 스키마로 검증한다. 스키마/JSON 실패는 재시도, Anthropic API
 에러는 즉시 raise한다.
+
+박제: 이슈 #232 — Bedrock 호출에서 Anthropic Direct로 전환. RAG (KB)는
+bedrock-agent-runtime 그대로 유지. `BedrockAPIError` 클래스 이름은 전사
+import 호환을 위해 보존하지만 의미는 "외부 LLM API 에러"로 일반화되었다.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import time
@@ -15,7 +18,7 @@ import uuid
 from json import JSONDecodeError
 from typing import Any, AsyncIterator, Optional, TypeVar
 
-from botocore.exceptions import BotoCoreError, ClientError
+from anthropic import APIConnectionError, APIError, APIStatusError, AsyncAnthropic
 from pydantic import BaseModel, ValidationError
 
 from ai.exceptions import AIGenerationFailedError, BedrockAPIError
@@ -24,8 +27,6 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
-_ANTHROPIC_VERSION = "bedrock-2023-05-31"
-
 
 def _log(level: int, event: str, **fields: Any) -> None:
     """JSON 직렬화된 단일 라인을 표준 logging으로 emit."""
@@ -33,17 +34,32 @@ def _log(level: int, event: str, **fields: Any) -> None:
     logger.log(level, json.dumps(payload, ensure_ascii=False, default=str))
 
 
+def _sanitize_for_anthropic(text: str) -> str:
+    """Anthropic SDK(httpx)는 lone surrogate를 거부한다.
+
+    Bedrock 시절 boto3는 관용적으로 통과시켰지만, httpx는 HTTP body
+    인코딩 시 짝 안 맞는 UTF-16 surrogate (U+D800~U+DFFF)를 발견하면
+    UnicodeEncodeError를 raise한다. 정상 한국어/이모지 문자에는 영향
+    없으며, 소스 데이터에 잘못 섞인 lone surrogate만 U+FFFD로 치환한다.
+
+    박제: 이슈 #232 후속 — Anthropic Direct 전환 후 발견된 회귀.
+    원천 데이터(content/required-steps/, ai/prompts/) 안에 lone surrogate
+    가 있는 건 별도 백로그로 추적.
+    """
+    return text.encode("utf-8", errors="replace").decode("utf-8")
+
+
 class LLMClient:
-    """Bedrock Claude 호출 + Pydantic 스키마 검증 래퍼."""
+    """Anthropic AsyncAnthropic 클라이언트 + Pydantic 스키마 검증 래퍼."""
 
     def __init__(
         self,
-        bedrock_client: Any,
+        anthropic_client: AsyncAnthropic,
         model_id: str,
         max_tokens: int = 4096,
         temperature: float = 0.7,
     ) -> None:
-        self.bedrock_client = bedrock_client
+        self.anthropic_client = anthropic_client
         self.model_id = model_id
         self.max_tokens = max_tokens
         self.temperature = temperature
@@ -58,23 +74,16 @@ class LLMClient:
         """Claude를 호출하여 expected_schema로 검증된 인스턴스를 반환.
 
         - JSON 파싱 실패 / 스키마 불일치 → max_retries 까지 재시도
-        - Bedrock API 에러(ClientError, BotoCoreError) → 즉시 BedrockAPIError
+        - Anthropic API 에러(APIError, APIStatusError, APIConnectionError)
+          → 즉시 BedrockAPIError (클래스 이름은 #232 이전 호환을 위해 보존)
         - 재시도 초과 → AIGenerationFailedError (불일치 필드 details 포함)
 
         max_tokens 우선순위:
             invoke(max_tokens=X) 명시값 > self.max_tokens (생성자 값) > 생성자 기본값(4096).
-        재시도 루프 안에서는 동일 request_body(= 동일 effective_max_tokens)를 재사용한다.
+        재시도 루프 안에서는 동일 요청을 재발행한다.
         """
         correlation_id = str(uuid.uuid4())
         effective_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
-        request_body = json.dumps(
-            {
-                "anthropic_version": _ANTHROPIC_VERSION,
-                "max_tokens": effective_max_tokens,
-                "temperature": self.temperature,
-                "messages": [{"role": "user", "content": prompt}],
-            }
-        )
 
         _log(
             logging.INFO,
@@ -91,14 +100,13 @@ class LLMClient:
 
         for attempt in range(max_retries + 1):
             try:
-                response = await asyncio.to_thread(
-                    self.bedrock_client.invoke_model,
-                    modelId=self.model_id,
-                    body=request_body,
-                    contentType="application/json",
-                    accept="application/json",
+                message = await self.anthropic_client.messages.create(
+                    model=self.model_id,
+                    max_tokens=effective_max_tokens,
+                    temperature=self.temperature,
+                    messages=[{"role": "user", "content": _sanitize_for_anthropic(prompt)}],
                 )
-            except (ClientError, BotoCoreError) as exc:
+            except (APIConnectionError, APIStatusError, APIError) as exc:
                 error_details = {
                     "correlation_id": correlation_id,
                     "model_id": self.model_id,
@@ -108,14 +116,12 @@ class LLMClient:
                 }
                 _log(logging.ERROR, "llm_bedrock_api_error", **error_details)
                 raise BedrockAPIError(
-                    message="Bedrock API 호출에 실패했습니다.",
+                    message="LLM API 호출에 실패했습니다.",
                     details=error_details,
                 ) from exc
 
             try:
-                raw = response["body"].read()
-                envelope = json.loads(raw)
-                text = envelope["content"][0]["text"]
+                text = message.content[0].text
                 stripped = text.strip()
                 if stripped.startswith("```"):
                     lines = stripped.splitlines()
@@ -156,7 +162,7 @@ class LLMClient:
                     errors=exc.errors(),
                 )
                 continue
-            except (KeyError, IndexError, TypeError) as exc:
+            except (AttributeError, IndexError, TypeError) as exc:
                 last_error = {
                     "type": "malformed_response",
                     "message": str(exc),
@@ -200,24 +206,15 @@ class LLMClient:
         prompt: str,
         max_tokens: Optional[int] = None,
     ) -> AsyncIterator[str]:
-        """Bedrock Claude 스트리밍 호출. content_block_delta의 text만 yield.
+        """Anthropic Claude 스트리밍 호출. text_stream의 텍스트 청크를 yield.
 
         - Pydantic 검증 없음. 재시도 없음.
         - max_tokens 우선순위: 인자 > self.max_tokens > 생성자 기본값 (invoke와 동일).
-        - ClientError/BotoCoreError → BedrockAPIError로 래핑하여 re-raise.
-        - JSON decode 실패 청크는 log warning 후 skip (스트림 전체는 계속).
+        - APIError 계열 → BedrockAPIError로 래핑하여 re-raise.
         - 응답이 코드 펜스(```json...``` 또는 ```...```)로 감싸인 경우 자동으로 벗겨낸다.
         """
         correlation_id = str(uuid.uuid4())
         effective_max_tokens = max_tokens if max_tokens is not None else self.max_tokens
-        request_body = json.dumps(
-            {
-                "anthropic_version": _ANTHROPIC_VERSION,
-                "max_tokens": effective_max_tokens,
-                "temperature": self.temperature,
-                "messages": [{"role": "user", "content": prompt}],
-            }
-        )
 
         _log(
             logging.INFO,
@@ -231,29 +228,7 @@ class LLMClient:
         start = time.perf_counter()
         total_chunks = 0
 
-        try:
-            response = await asyncio.to_thread(
-                self.bedrock_client.invoke_model_with_response_stream,
-                modelId=self.model_id,
-                body=request_body,
-                contentType="application/json",
-            )
-        except (ClientError, BotoCoreError) as exc:
-            elapsed = time.perf_counter() - start
-            error_details = {
-                "correlation_id": correlation_id,
-                "model_id": self.model_id,
-                "error_type": type(exc).__name__,
-                "error": str(exc),
-                "elapsed_s": round(elapsed, 3),
-            }
-            _log(logging.ERROR, "llm_invoke_stream_failed", **error_details)
-            raise BedrockAPIError(
-                message="Bedrock 스트리밍 호출에 실패했습니다.",
-                details=error_details,
-            ) from exc
-
-        # Opening fence prefixes Bedrock may prepend to JSON output.
+        # Opening fence prefixes Claude may prepend to JSON output.
         _FENCE_PREFIXES = ("```json\n", "```json\r\n", "```\n", "```\r\n")
         # Must be ≥ len("\n```") = 4 to catch the longest trailing fence.
         _TAIL_BUFFER_SIZE = 4
@@ -263,75 +238,56 @@ class LLMClient:
         pending = ""          # pre-flush accumulator
         tail_buffer = ""      # sliding window for trailing-fence detection
 
-        _SENTINEL = object()
         try:
-            event_iter = iter(response["body"])
-            while True:
-                event = await asyncio.to_thread(next, event_iter, _SENTINEL)
-                if event is _SENTINEL:
-                    break
-                chunk_bytes = event.get("chunk", {}).get("bytes") if isinstance(event, dict) else None
-                if not chunk_bytes:
-                    # MagicMock 기반 이벤트는 dict가 아닐 수 있어 getattr fallback.
-                    chunk_obj = getattr(event, "get", lambda _k, _d=None: None)("chunk", {})
-                    chunk_bytes = chunk_obj.get("bytes") if isinstance(chunk_obj, dict) else None
-                if not chunk_bytes:
-                    continue
-                try:
-                    payload = json.loads(chunk_bytes.decode("utf-8"))
-                except (JSONDecodeError, UnicodeDecodeError) as exc:
-                    _log(
-                        logging.WARNING,
-                        "llm_invoke_stream_chunk_skipped",
-                        correlation_id=correlation_id,
-                        reason=type(exc).__name__,
-                    )
-                    continue
-                if payload.get("type") != "content_block_delta":
-                    continue
-                text = payload.get("delta", {}).get("text", "")
-                if not text:
-                    continue
+            async with self.anthropic_client.messages.stream(
+                model=self.model_id,
+                max_tokens=effective_max_tokens,
+                temperature=self.temperature,
+                messages=[{"role": "user", "content": _sanitize_for_anthropic(prompt)}],
+            ) as stream:
+                async for text in stream.text_stream:
+                    if not text:
+                        continue
 
-                total_chunks += 1
+                    total_chunks += 1
 
-                if not first_flush:
-                    pending += text
-                    stripped_p = pending.lstrip()
-                    ready = False
-                    if not stripped_p.startswith("`"):
-                        # Definitely not a fence — flush immediately (TTFT优先)
-                        ready = True
-                    elif len(stripped_p) >= 3 and not stripped_p.startswith("```"):
-                        # Starts with ` or `` but not ``` — not a fence
-                        ready = True
-                    elif stripped_p.startswith("```") and ("\n" in pending or len(pending) >= 200):
-                        # Confirmed fence opening; wait for the newline that ends the fence line
-                        ready = True
-                    if ready:
-                        matched = None
-                        for prefix in _FENCE_PREFIXES:
-                            if stripped_p.startswith(prefix):
-                                matched = prefix
-                                break
-                        if matched:
-                            fence_active = True
-                            leading_ws = len(pending) - len(stripped_p)
-                            tail_buffer = pending[leading_ws + len(matched):]
-                        else:
-                            tail_buffer = pending
-                        first_flush = True
-                        pending = ""
-                else:
-                    tail_buffer += text
+                    if not first_flush:
+                        pending += text
+                        stripped_p = pending.lstrip()
+                        ready = False
+                        if not stripped_p.startswith("`"):
+                            # Definitely not a fence — flush immediately (TTFT优先)
+                            ready = True
+                        elif len(stripped_p) >= 3 and not stripped_p.startswith("```"):
+                            # Starts with ` or `` but not ``` — not a fence
+                            ready = True
+                        elif stripped_p.startswith("```") and ("\n" in pending or len(pending) >= 200):
+                            # Confirmed fence opening; wait for the newline that ends the fence line
+                            ready = True
+                        if ready:
+                            matched = None
+                            for prefix in _FENCE_PREFIXES:
+                                if stripped_p.startswith(prefix):
+                                    matched = prefix
+                                    break
+                            if matched:
+                                fence_active = True
+                                leading_ws = len(pending) - len(stripped_p)
+                                tail_buffer = pending[leading_ws + len(matched):]
+                            else:
+                                tail_buffer = pending
+                            first_flush = True
+                            pending = ""
+                    else:
+                        tail_buffer += text
 
-                # Yield safe portion; keep last _TAIL_BUFFER_SIZE chars for trailing-fence check.
-                if first_flush and len(tail_buffer) > _TAIL_BUFFER_SIZE:
-                    safe = tail_buffer[:-_TAIL_BUFFER_SIZE]
-                    tail_buffer = tail_buffer[-_TAIL_BUFFER_SIZE:]
-                    if safe:
-                        yield safe
-        except (ClientError, BotoCoreError) as exc:
+                    # Yield safe portion; keep last _TAIL_BUFFER_SIZE chars for trailing-fence check.
+                    if first_flush and len(tail_buffer) > _TAIL_BUFFER_SIZE:
+                        safe = tail_buffer[:-_TAIL_BUFFER_SIZE]
+                        tail_buffer = tail_buffer[-_TAIL_BUFFER_SIZE:]
+                        if safe:
+                            yield safe
+        except (APIConnectionError, APIStatusError, APIError) as exc:
             elapsed = time.perf_counter() - start
             error_details = {
                 "correlation_id": correlation_id,
@@ -342,7 +298,7 @@ class LLMClient:
             }
             _log(logging.ERROR, "llm_invoke_stream_failed", **error_details)
             raise BedrockAPIError(
-                message="Bedrock 스트리밍 수신 중 오류가 발생했습니다.",
+                message="LLM 스트리밍 호출에 실패했습니다.",
                 details=error_details,
             ) from exc
 

--- a/ai/config.py
+++ b/ai/config.py
@@ -15,9 +15,10 @@ class AISettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
-    AWS_REGION: str = "us-east-1"
-    MODEL_ID: str = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    AWS_REGION: str = "us-east-1"  # RAG (Bedrock KB) 용도로 유지
+    MODEL_ID: str = "claude-haiku-4-5-20251001"  # Anthropic Direct API 형식
     KB_ID: str = ""
+    ANTHROPIC_API_KEY: str = ""
     MAX_TOKENS: int = 4096
     TEMPERATURE: float = 0.7
 

--- a/ai/latency_simulator.py
+++ b/ai/latency_simulator.py
@@ -3,7 +3,8 @@
 실행: ``python -m ai.latency_simulator [--runs N] [--output PATH] [--baseline]``
 
 Stage 1 R1("문제/기회 정의") 고정 fixture 입력으로 Pipeline 1회(또는 N회)를
-실제 Bedrock에 대해 실행하고, stage별/call별 wall-clock elapsed를 기록한다.
+실제 Anthropic Direct API + Bedrock KB(RAG)에 대해 실행하고,
+stage별/call별 wall-clock elapsed를 기록한다.
 
 Pipeline 구조:
     Stage A — judge ∥ generate (asyncio.gather)
@@ -19,6 +20,7 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import sys
 import time
 import uuid
@@ -27,6 +29,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Dict, List, Optional, Tuple
 
 import boto3
+from anthropic import AsyncAnthropic
 
 from ai.clients.llm import LLMClient
 from ai.clients.rag import RAGClient
@@ -154,13 +157,14 @@ def _build_side_panel_input(generated: GeneratedStep) -> SidePanelInput:
 
 
 def _build_services() -> Tuple[StepGenerator, RequiredStepJudge, SidePanelGenerator]:
-    bedrock_runtime = boto3.client("bedrock-runtime", region_name=ai_settings.AWS_REGION)
+    api_key = os.environ.get("ANTHROPIC_API_KEY") or ai_settings.ANTHROPIC_API_KEY
+    anthropic_client = AsyncAnthropic(api_key=api_key)
     bedrock_agent_runtime = boto3.client(
         "bedrock-agent-runtime", region_name=ai_settings.AWS_REGION
     )
 
     llm = LLMClient(
-        bedrock_client=bedrock_runtime,
+        anthropic_client=anthropic_client,
         model_id=ai_settings.MODEL_ID,
         max_tokens=ai_settings.MAX_TOKENS,
         temperature=ai_settings.TEMPERATURE,

--- a/ai/pyproject.toml
+++ b/ai/pyproject.toml
@@ -1,9 +1,10 @@
 [project]
 name = "poco-ai"
 version = "0.1.0"
-description = "Poco AI Orchestrator — Bedrock Claude 기반 독립 AI 모듈"
+description = "Poco AI Orchestrator — Anthropic Direct API + Bedrock KB 기반 독립 AI 모듈"
 requires-python = ">=3.13"
 dependencies = [
+    "anthropic>=0.40.0,<1.0.0",
     "boto3>=1.35.0,<2.0.0",
     "pydantic>=2.10.0,<3.0.0",
     "pydantic-settings>=2.5.0,<3.0.0",

--- a/ai/services/__init__.py
+++ b/ai/services/__init__.py
@@ -1,13 +1,15 @@
 """ai/services — generate, accept, side_panel, design_export 오케스트레이터.
 
 백엔드(Lambda)가 호출하는 5개 public async 함수를 노출한다.
-백엔드는 IAM Role 기반으로 boto3 클라이언트를 미리 만들어 주입하며,
-이 모듈은 LLMClient/RAGClient를 wrapping해 실제 시나리오 서비스를 구동한다.
+백엔드는 AsyncAnthropic 클라이언트를 미리 만들어 주입하며 (Anthropic Direct
+API · 이슈 #232), RAG는 여전히 IAM Role 기반 bedrock-agent-runtime
+클라이언트를 사용한다. 이 모듈은 LLMClient/RAGClient를 wrapping해 실제
+시나리오 서비스를 구동한다.
 
 설계 원칙:
 - backend 의존성(FastAPI, SQLAlchemy 등) 없음
 - AI Dataset Spec v3 입출력 계약 준수
-- pre-configured boto3 클라이언트를 받아 그대로 사용 (재생성 금지)
+- pre-configured 클라이언트를 받아 그대로 사용 (재생성 금지)
 
 Data Source 필터링:
 - 단일 KB 안에 DOJ와 Custom Data Source가 함께 있으므로, 각 검색에 해당
@@ -21,6 +23,8 @@ Data Source 필터링:
 from __future__ import annotations
 
 from typing import Any, AsyncIterator, Optional
+
+from anthropic import AsyncAnthropic
 
 from ai.clients.llm import LLMClient
 from ai.clients.rag import RAGClient
@@ -36,7 +40,7 @@ from ai.services.step_generator import StepGenerator
 
 async def generate_steps(
     input_data: GenerateInput,
-    bedrock_runtime_client: Any,
+    anthropic_client: AsyncAnthropic,
     bedrock_agent_client: Any,
     model_id: str,
     kb_id: str,
@@ -47,7 +51,7 @@ async def generate_steps(
     doj_data_source_id가 주어지면 DOJ Data Source로 검색을 제한한다.
     None이면 KB 전체에서 검색한다(하위 호환).
     """
-    llm = LLMClient(bedrock_client=bedrock_runtime_client, model_id=model_id)
+    llm = LLMClient(anthropic_client=anthropic_client, model_id=model_id)
     rag = RAGClient(bedrock_agent_client=bedrock_agent_client, kb_id=kb_id)
     service = StepGenerator(
         llm=llm, rag=rag, doj_data_source_id=doj_data_source_id
@@ -57,21 +61,21 @@ async def generate_steps(
 
 async def judge_required_step(
     input_data: AcceptInput,
-    bedrock_runtime_client: Any,
+    anthropic_client: AsyncAnthropic,
     model_id: str,
 ) -> AcceptOutput:
     """accept 시나리오 — 필수 Step 충족 여부 판단.
 
     RAG를 사용하지 않으므로 Data Source ID 인자가 없다.
     """
-    llm = LLMClient(bedrock_client=bedrock_runtime_client, model_id=model_id)
+    llm = LLMClient(anthropic_client=anthropic_client, model_id=model_id)
     service = RequiredStepJudge(llm=llm)
     return await service.judge_required_step(input_data)
 
 
 async def generate_side_panel(
     input_data: SidePanelInput,
-    bedrock_runtime_client: Any,
+    anthropic_client: AsyncAnthropic,
     bedrock_agent_client: Any,
     model_id: str,
     kb_id: str,
@@ -83,7 +87,7 @@ async def generate_side_panel(
     doj/custom_data_source_id가 주어지면 각 Data Source로 검색을 분리한다.
     None이면 KB 전체에서 검색한다(하위 호환).
     """
-    llm = LLMClient(bedrock_client=bedrock_runtime_client, model_id=model_id)
+    llm = LLMClient(anthropic_client=anthropic_client, model_id=model_id)
     rag = RAGClient(bedrock_agent_client=bedrock_agent_client, kb_id=kb_id)
     service = SidePanelGenerator(
         llm=llm,
@@ -120,16 +124,16 @@ async def generate_side_panel_stream(
 
 async def generate_design_export(
     input_data: DesignExportInput,
-    bedrock_runtime_client: Any,
+    anthropic_client: AsyncAnthropic,
     model_id: str,
 ) -> DesignExportOutput:
     """design-export 시나리오 — Poco 사고 궤적 .md 본문 생성.
 
     백엔드가 RDS에서 모은 Project_Info + 선택된 Required_Step 영역의
-    진행 데이터를 받아, Bedrock Claude Haiku 4.5 동기 호출로 .md 본문을
+    진행 데이터를 받아, Anthropic Claude Haiku 4.5 동기 호출로 .md 본문을
     생성한다. RAG 미사용 (Req 15.5).
     """
-    llm = LLMClient(bedrock_client=bedrock_runtime_client, model_id=model_id)
+    llm = LLMClient(anthropic_client=anthropic_client, model_id=model_id)
     service = DesignExportGenerator(llm=llm)
     return await service.generate_design_export(input_data)
 

--- a/ai/tests/test_config.py
+++ b/ai/tests/test_config.py
@@ -11,22 +11,25 @@ class TestAISettings:
     def test_default_values(self):
         settings = AISettings(_env_file=None)
         assert settings.AWS_REGION == "us-east-1"
-        assert settings.MODEL_ID == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        assert settings.MODEL_ID == "claude-haiku-4-5-20251001"
         assert settings.KB_ID == ""
+        assert settings.ANTHROPIC_API_KEY == ""
         assert settings.MAX_TOKENS == 4096
         assert settings.TEMPERATURE == 0.7
 
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv("AWS_REGION", "us-west-2")
-        monkeypatch.setenv("MODEL_ID", "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+        monkeypatch.setenv("MODEL_ID", "claude-haiku-4-5-20251001")
         monkeypatch.setenv("KB_ID", "kb-test-123")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
         monkeypatch.setenv("MAX_TOKENS", "2048")
         monkeypatch.setenv("TEMPERATURE", "0.3")
 
         settings = AISettings(_env_file=None)
         assert settings.AWS_REGION == "us-west-2"
-        assert settings.MODEL_ID == "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        assert settings.MODEL_ID == "claude-haiku-4-5-20251001"
         assert settings.KB_ID == "kb-test-123"
+        assert settings.ANTHROPIC_API_KEY == "sk-ant-test-key"
         assert settings.MAX_TOKENS == 2048
         assert settings.TEMPERATURE == pytest.approx(0.3)
 

--- a/ai/tests/test_llm_client.py
+++ b/ai/tests/test_llm_client.py
@@ -1,18 +1,17 @@
-"""ai/clients/llm.py 단위 테스트."""
+"""ai/clients/llm.py 단위 테스트 — Anthropic Direct API 기반 (이슈 #232)."""
 
-import io
 import json
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from botocore.exceptions import ClientError
+from anthropic import APIStatusError
 from pydantic import BaseModel
 
 from ai.clients.llm import LLMClient
 from ai.exceptions import AIErrorCode, AIGenerationFailedError, BedrockAPIError
 
-MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+MODEL_ID = "claude-haiku-4-5-20251001"
 
 
 class _Schema(BaseModel):
@@ -22,34 +21,46 @@ class _Schema(BaseModel):
     score: int
 
 
-def _make_response(text_payload: str) -> dict:
-    """Bedrock invoke_model 응답 형태를 모방한 dict."""
-    envelope = {"content": [{"type": "text", "text": text_payload}]}
-    return {"body": io.BytesIO(json.dumps(envelope).encode("utf-8"))}
+def _make_message(text_payload: str) -> MagicMock:
+    """Anthropic messages.create 응답 형태를 모방."""
+    msg = MagicMock()
+    msg.content = [MagicMock(text=text_payload)]
+    return msg
 
 
-def _valid_response() -> dict:
-    return _make_response(json.dumps({"answer": "ok", "score": 42}))
+def _valid_response() -> MagicMock:
+    return _make_message(json.dumps({"answer": "ok", "score": 42}))
 
 
-def _malformed_json_response() -> dict:
-    return _make_response("{not valid json")
+def _malformed_json_response() -> MagicMock:
+    return _make_message("{not valid json")
 
 
-def _schema_violation_response() -> dict:
+def _schema_violation_response() -> MagicMock:
     # answer가 누락 → ValidationError 발생
-    return _make_response(json.dumps({"score": 1}))
+    return _make_message(json.dumps({"score": 1}))
+
+
+def _make_api_status_error(message: str = "rate limited", status: int = 429) -> APIStatusError:
+    """anthropic.APIStatusError 인스턴스를 생성."""
+    response = MagicMock()
+    response.status_code = status
+    return APIStatusError(message=message, response=response, body={"error": {"message": message}})
 
 
 @pytest.fixture
-def bedrock_mock() -> MagicMock:
-    return MagicMock()
+def anthropic_mock() -> MagicMock:
+    """AsyncAnthropic mock — messages.create를 AsyncMock으로 노출."""
+    mock = MagicMock()
+    mock.messages = MagicMock()
+    mock.messages.create = AsyncMock()
+    return mock
 
 
 @pytest.fixture
-def client(bedrock_mock: MagicMock) -> LLMClient:
+def client(anthropic_mock: MagicMock) -> LLMClient:
     return LLMClient(
-        bedrock_client=bedrock_mock,
+        anthropic_client=anthropic_mock,
         model_id=MODEL_ID,
         max_tokens=128,
         temperature=0.5,
@@ -59,9 +70,9 @@ def client(bedrock_mock: MagicMock) -> LLMClient:
 class TestInvokeSuccess:
     @pytest.mark.asyncio
     async def test_invoke_returns_validated_instance(
-        self, client: LLMClient, bedrock_mock: MagicMock
+        self, client: LLMClient, anthropic_mock: MagicMock
     ):
-        bedrock_mock.invoke_model.return_value = _valid_response()
+        anthropic_mock.messages.create.return_value = _valid_response()
 
         result = await client.invoke("hello", _Schema)
 
@@ -71,29 +82,25 @@ class TestInvokeSuccess:
 
     @pytest.mark.asyncio
     async def test_invoke_passes_correct_request_body(
-        self, client: LLMClient, bedrock_mock: MagicMock
+        self, client: LLMClient, anthropic_mock: MagicMock
     ):
-        bedrock_mock.invoke_model.return_value = _valid_response()
+        anthropic_mock.messages.create.return_value = _valid_response()
 
         await client.invoke("질문 내용", _Schema)
 
-        call_kwargs = bedrock_mock.invoke_model.call_args.kwargs
-        assert call_kwargs["modelId"] == MODEL_ID
-        assert call_kwargs["contentType"] == "application/json"
-
-        body = json.loads(call_kwargs["body"])
-        assert body["anthropic_version"] == "bedrock-2023-05-31"
-        assert body["max_tokens"] == 128
-        assert body["temperature"] == 0.5
-        assert body["messages"] == [{"role": "user", "content": "질문 내용"}]
+        call_kwargs = anthropic_mock.messages.create.call_args.kwargs
+        assert call_kwargs["model"] == MODEL_ID
+        assert call_kwargs["max_tokens"] == 128
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["messages"] == [{"role": "user", "content": "질문 내용"}]
 
 
 class TestInvokeRetryOnRetryableErrors:
     @pytest.mark.asyncio
     async def test_json_decode_error_then_success(
-        self, client: LLMClient, bedrock_mock: MagicMock
+        self, client: LLMClient, anthropic_mock: MagicMock
     ):
-        bedrock_mock.invoke_model.side_effect = [
+        anthropic_mock.messages.create.side_effect = [
             _malformed_json_response(),
             _valid_response(),
         ]
@@ -101,13 +108,13 @@ class TestInvokeRetryOnRetryableErrors:
         result = await client.invoke("p", _Schema, max_retries=2)
 
         assert result.answer == "ok"
-        assert bedrock_mock.invoke_model.call_count == 2
+        assert anthropic_mock.messages.create.call_count == 2
 
     @pytest.mark.asyncio
     async def test_validation_error_then_success(
-        self, client: LLMClient, bedrock_mock: MagicMock
+        self, client: LLMClient, anthropic_mock: MagicMock
     ):
-        bedrock_mock.invoke_model.side_effect = [
+        anthropic_mock.messages.create.side_effect = [
             _schema_violation_response(),
             _valid_response(),
         ]
@@ -115,15 +122,15 @@ class TestInvokeRetryOnRetryableErrors:
         result = await client.invoke("p", _Schema, max_retries=2)
 
         assert result.answer == "ok"
-        assert bedrock_mock.invoke_model.call_count == 2
+        assert anthropic_mock.messages.create.call_count == 2
 
 
 class TestInvokeRetryExhaustion:
     @pytest.mark.asyncio
     async def test_schema_mismatch_three_attempts_then_fails(
-        self, client: LLMClient, bedrock_mock: MagicMock
+        self, client: LLMClient, anthropic_mock: MagicMock
     ):
-        bedrock_mock.invoke_model.side_effect = [
+        anthropic_mock.messages.create.side_effect = [
             _schema_violation_response(),
             _schema_violation_response(),
             _schema_violation_response(),
@@ -133,7 +140,7 @@ class TestInvokeRetryExhaustion:
             await client.invoke("p", _Schema, max_retries=2)
 
         # max_retries=2 → 1 + 2 = 3회 호출
-        assert bedrock_mock.invoke_model.call_count == 3
+        assert anthropic_mock.messages.create.call_count == 3
         err = exc_info.value
         assert err.code == AIErrorCode.AI_GENERATION_FAILED
         assert err.details["max_retries"] == 2
@@ -144,9 +151,9 @@ class TestInvokeRetryExhaustion:
 
     @pytest.mark.asyncio
     async def test_json_decode_error_exhausts_retries(
-        self, client: LLMClient, bedrock_mock: MagicMock
+        self, client: LLMClient, anthropic_mock: MagicMock
     ):
-        bedrock_mock.invoke_model.side_effect = [
+        anthropic_mock.messages.create.side_effect = [
             _malformed_json_response(),
             _malformed_json_response(),
             _malformed_json_response(),
@@ -155,31 +162,26 @@ class TestInvokeRetryExhaustion:
         with pytest.raises(AIGenerationFailedError) as exc_info:
             await client.invoke("p", _Schema, max_retries=2)
 
-        assert bedrock_mock.invoke_model.call_count == 3
+        assert anthropic_mock.messages.create.call_count == 3
         assert exc_info.value.details["last_error"]["type"] == "json_decode_error"
 
 
 class TestBedrockApiErrorImmediate:
     @pytest.mark.asyncio
-    async def test_client_error_raises_immediately_without_retry(
-        self, client: LLMClient, bedrock_mock: MagicMock
+    async def test_api_error_raises_immediately_without_retry(
+        self, client: LLMClient, anthropic_mock: MagicMock
     ):
-        client_error = ClientError(
-            error_response={
-                "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}
-            },
-            operation_name="InvokeModel",
-        )
-        bedrock_mock.invoke_model.side_effect = client_error
+        api_error = _make_api_status_error("Rate exceeded", status=429)
+        anthropic_mock.messages.create.side_effect = api_error
 
         with pytest.raises(BedrockAPIError) as exc_info:
             await client.invoke("p", _Schema, max_retries=2)
 
         # 재시도 없음 — 정확히 1회만 호출
-        assert bedrock_mock.invoke_model.call_count == 1
+        assert anthropic_mock.messages.create.call_count == 1
         err = exc_info.value
         assert err.code == AIErrorCode.BEDROCK_API_ERROR
-        assert err.details["error_type"] == "ClientError"
+        assert err.details["error_type"] == "APIStatusError"
         assert "correlation_id" in err.details
 
 
@@ -188,10 +190,10 @@ class TestCorrelationIdLogging:
     async def test_correlation_id_present_in_start_and_success_logs(
         self,
         client: LLMClient,
-        bedrock_mock: MagicMock,
+        anthropic_mock: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ):
-        bedrock_mock.invoke_model.return_value = _valid_response()
+        anthropic_mock.messages.create.return_value = _valid_response()
 
         with caplog.at_level(logging.INFO, logger="ai.clients.llm"):
             await client.invoke("p", _Schema)
@@ -214,12 +216,11 @@ class TestCorrelationIdLogging:
     async def test_correlation_id_in_error_logs(
         self,
         client: LLMClient,
-        bedrock_mock: MagicMock,
+        anthropic_mock: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ):
-        bedrock_mock.invoke_model.side_effect = ClientError(
-            error_response={"Error": {"Code": "AccessDenied", "Message": "no"}},
-            operation_name="InvokeModel",
+        anthropic_mock.messages.create.side_effect = _make_api_status_error(
+            "no", status=403
         )
 
         with caplog.at_level(logging.INFO, logger="ai.clients.llm"):
@@ -238,9 +239,9 @@ class TestCorrelationIdLogging:
 
     @pytest.mark.asyncio
     async def test_correlation_id_unique_per_invocation(
-        self, client: LLMClient, bedrock_mock: MagicMock, caplog: pytest.LogCaptureFixture
+        self, client: LLMClient, anthropic_mock: MagicMock, caplog: pytest.LogCaptureFixture
     ):
-        bedrock_mock.invoke_model.side_effect = lambda **_: _valid_response()
+        anthropic_mock.messages.create.side_effect = lambda **_: _valid_response()
 
         with caplog.at_level(logging.INFO, logger="ai.clients.llm"):
             await client.invoke("p1", _Schema)
@@ -258,10 +259,10 @@ class TestCorrelationIdLogging:
     async def test_retry_logs_include_attempt_and_correlation_id(
         self,
         client: LLMClient,
-        bedrock_mock: MagicMock,
+        anthropic_mock: MagicMock,
         caplog: pytest.LogCaptureFixture,
     ):
-        bedrock_mock.invoke_model.side_effect = [
+        anthropic_mock.messages.create.side_effect = [
             _schema_violation_response(),
             _valid_response(),
         ]

--- a/ai/tests/test_llm_client_max_tokens_priority.py
+++ b/ai/tests/test_llm_client_max_tokens_priority.py
@@ -5,13 +5,12 @@
     2) LLMClient(max_tokens=Y) 생성자 값
     3) LLMClient 생성자 기본값 (4096)
 
-bedrock_client.invoke_model을 mock하여 request body의 max_tokens 필드를
-JSON 파싱 후 assert한다.
+anthropic_client.messages.create을 mock하여 호출 kwargs의 max_tokens
+필드를 직접 assert한다 (이슈 #232).
 """
 
-import io
 import json
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import BaseModel
@@ -19,7 +18,7 @@ from pydantic import BaseModel
 from ai.clients.llm import LLMClient
 
 
-MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+MODEL_ID = "claude-haiku-4-5-20251001"
 
 
 class _Schema(BaseModel):
@@ -28,60 +27,62 @@ class _Schema(BaseModel):
     answer: str
 
 
-def _valid_response() -> dict:
-    envelope = {"content": [{"type": "text", "text": json.dumps({"answer": "ok"})}]}
-    return {"body": io.BytesIO(json.dumps(envelope).encode("utf-8"))}
+def _valid_response() -> MagicMock:
+    msg = MagicMock()
+    msg.content = [MagicMock(text=json.dumps({"answer": "ok"}))]
+    return msg
 
 
-def _captured_max_tokens(bedrock_mock: MagicMock) -> int:
-    """invoke_model 호출의 body에서 max_tokens 값을 꺼낸다."""
-    body_str = bedrock_mock.invoke_model.call_args.kwargs["body"]
-    payload = json.loads(body_str)
-    return payload["max_tokens"]
+def _make_anthropic_mock() -> MagicMock:
+    mock = MagicMock()
+    mock.messages = MagicMock()
+    mock.messages.create = AsyncMock(return_value=_valid_response())
+    return mock
+
+
+def _captured_max_tokens(anthropic_mock: MagicMock) -> int:
+    """messages.create 호출의 max_tokens kwarg 값을 꺼낸다."""
+    return anthropic_mock.messages.create.call_args.kwargs["max_tokens"]
 
 
 class TestInvokeMaxTokensPriority:
     @pytest.mark.asyncio
     async def test_explicit_invoke_max_tokens_wins_over_constructor(self) -> None:
-        """invoke(max_tokens=X)를 명시하면 생성자 값을 무시하고 X가 body에 들어간다."""
-        bedrock = MagicMock()
-        bedrock.invoke_model.return_value = _valid_response()
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID, max_tokens=4096)
+        """invoke(max_tokens=X)를 명시하면 생성자 값을 무시하고 X가 들어간다."""
+        anthropic = _make_anthropic_mock()
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID, max_tokens=4096)
 
         await client.invoke("p", _Schema, max_tokens=512)
 
-        assert _captured_max_tokens(bedrock) == 512
+        assert _captured_max_tokens(anthropic) == 512
 
     @pytest.mark.asyncio
     async def test_omitted_invoke_max_tokens_uses_constructor_value(self) -> None:
-        """invoke(max_tokens=None) 기본 생략 시 생성자에서 받은 값이 body에 들어간다."""
-        bedrock = MagicMock()
-        bedrock.invoke_model.return_value = _valid_response()
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID, max_tokens=2048)
+        """invoke(max_tokens=None) 기본 생략 시 생성자에서 받은 값이 들어간다."""
+        anthropic = _make_anthropic_mock()
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID, max_tokens=2048)
 
         await client.invoke("p", _Schema)
 
-        assert _captured_max_tokens(bedrock) == 2048
+        assert _captured_max_tokens(anthropic) == 2048
 
     @pytest.mark.asyncio
     async def test_constructor_default_4096_fallback(self) -> None:
-        """LLMClient(..., max_tokens=4096) 기본값이 생성자 생략 시 body에 들어간다."""
-        bedrock = MagicMock()
-        bedrock.invoke_model.return_value = _valid_response()
+        """LLMClient(..., max_tokens=4096) 기본값이 생성자 생략 시 들어간다."""
+        anthropic = _make_anthropic_mock()
         # max_tokens 인자를 생략하면 생성자 기본값 4096이 self.max_tokens가 된다.
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID)
 
         await client.invoke("p", _Schema)
 
-        assert _captured_max_tokens(bedrock) == 4096
+        assert _captured_max_tokens(anthropic) == 4096
 
     @pytest.mark.asyncio
     async def test_invoke_max_tokens_overrides_even_non_default_constructor(self) -> None:
         """생성자가 1024여도 invoke(max_tokens=256) 명시값이 이긴다."""
-        bedrock = MagicMock()
-        bedrock.invoke_model.return_value = _valid_response()
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID, max_tokens=1024)
+        anthropic = _make_anthropic_mock()
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID, max_tokens=1024)
 
         await client.invoke("p", _Schema, max_tokens=256)
 
-        assert _captured_max_tokens(bedrock) == 256
+        assert _captured_max_tokens(anthropic) == 256

--- a/ai/tests/test_llm_client_property.py
+++ b/ai/tests/test_llm_client_property.py
@@ -1,8 +1,7 @@
-"""hypothesis 기반 LLMClient property 테스트."""
+"""hypothesis 기반 LLMClient property 테스트 — Anthropic Direct API 기반 (이슈 #232)."""
 
-import io
 import json
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from hypothesis import given, settings
@@ -83,27 +82,29 @@ def test_side_panel_output_roundtrip(output: SidePanelOutput):
 # ---------------------------------------------------------------------------
 
 
-def _schema_mismatch_bedrock_mock() -> MagicMock:
-    """invoke_model이 항상 빈 dict {}를 content[0].text로 반환하는 mock."""
+def _schema_mismatch_anthropic_mock() -> MagicMock:
+    """messages.create가 항상 빈 dict {}를 content[0].text로 반환하는 mock."""
 
     def _response(**_):
-        envelope = {"content": [{"type": "text", "text": json.dumps({})}]}
-        return {"body": io.BytesIO(json.dumps(envelope).encode())}
+        msg = MagicMock()
+        msg.content = [MagicMock(text=json.dumps({}))]
+        return msg
 
     mock = MagicMock()
-    mock.invoke_model.side_effect = _response
+    mock.messages = MagicMock()
+    mock.messages.create = AsyncMock(side_effect=_response)
     return mock
 
 
 @settings(max_examples=100)
 @given(st.data())
 def test_schema_mismatch_retry_count_and_failure(data):
-    bedrock_mock = _schema_mismatch_bedrock_mock()
-    client = LLMClient(bedrock_client=bedrock_mock, model_id="test-model")
+    anthropic_mock = _schema_mismatch_anthropic_mock()
+    client = LLMClient(anthropic_client=anthropic_mock, model_id="test-model")
 
     import asyncio
 
     with pytest.raises(AIGenerationFailedError):
         asyncio.run(client.invoke("{}", GenerateOutput, max_retries=2))
 
-    assert bedrock_mock.invoke_model.call_count == 3
+    assert anthropic_mock.messages.create.call_count == 3

--- a/ai/tests/test_llm_client_stream.py
+++ b/ai/tests/test_llm_client_stream.py
@@ -1,39 +1,62 @@
-"""ai/clients/llm.py LLMClient.invoke_stream 단위 테스트."""
+"""ai/clients/llm.py LLMClient.invoke_stream 단위 테스트 — Anthropic Direct API (이슈 #232)."""
 
-import json
-import logging
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
-from botocore.exceptions import ClientError
+from anthropic import APIStatusError
 
 from ai.clients.llm import LLMClient
 from ai.exceptions import BedrockAPIError
 
-MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+MODEL_ID = "claude-haiku-4-5-20251001"
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers — anthropic.messages.stream context manager mock
 # ---------------------------------------------------------------------------
 
 
-def _delta_event(text: str) -> dict:
-    payload = {"type": "content_block_delta", "delta": {"text": text}}
-    return {"chunk": {"bytes": json.dumps(payload).encode("utf-8")}}
+class _FakeTextStream:
+    """anthropic stream.text_stream 모방 — async iterator로 청크를 yield."""
+
+    def __init__(self, chunks: list, delay: float = 0.0) -> None:
+        self._chunks = list(chunks)
+        self._delay = delay
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> str:
+        if not self._chunks:
+            raise StopAsyncIteration
+        if self._delay > 0:
+            await asyncio.sleep(self._delay)
+        return self._chunks.pop(0)
 
 
-def _non_delta_event() -> dict:
-    payload = {"type": "message_start"}
-    return {"chunk": {"bytes": json.dumps(payload).encode("utf-8")}}
+class _FakeStreamContext:
+    """anthropic.messages.stream(...) 반환값 모방 — async context manager."""
+
+    def __init__(self, chunks: list, delay: float = 0.0) -> None:
+        self.text_stream = _FakeTextStream(chunks, delay=delay)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
 
 
-def _invalid_chunk_event() -> dict:
-    return {"chunk": {"bytes": b"{not valid json"}}
-
-
-def _stream_response(events: list) -> dict:
-    return {"body": iter(events)}
+def _make_anthropic_mock(chunks_list_or_factory) -> MagicMock:
+    """chunks_list_or_factory가 list면 단일 스트림, callable이면 매 호출마다 새 컨텍스트."""
+    mock = MagicMock()
+    mock.messages = MagicMock()
+    if callable(chunks_list_or_factory):
+        mock.messages.stream = MagicMock(side_effect=chunks_list_or_factory)
+    else:
+        mock.messages.stream = MagicMock(return_value=_FakeStreamContext(chunks_list_or_factory))
+    return mock
 
 
 async def _collect(agen) -> list:
@@ -41,12 +64,6 @@ async def _collect(agen) -> list:
     async for chunk in agen:
         result.append(chunk)
     return result
-
-
-def _make_bedrock_mock(events: list) -> MagicMock:
-    bedrock = MagicMock()
-    bedrock.invoke_model_with_response_stream.return_value = _stream_response(events)
-    return bedrock
 
 
 # ---------------------------------------------------------------------------
@@ -57,15 +74,9 @@ def _make_bedrock_mock(events: list) -> MagicMock:
 class TestInvokeStream:
     @pytest.mark.asyncio
     async def test_invoke_stream_yields_chunks(self) -> None:
-        """delta event → 텍스트 yield, non-delta event는 건너뜀."""
-        events = [
-            _non_delta_event(),
-            _delta_event("A"),
-            _delta_event("B"),
-            _delta_event("C"),
-        ]
-        bedrock = _make_bedrock_mock(events)
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
+        """text_stream의 청크가 (tail-buffer batching 후) 그대로 yield된다."""
+        anthropic = _make_anthropic_mock(["A", "B", "C"])
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID)
 
         chunks = await _collect(client.invoke_stream("prompt"))
 
@@ -76,40 +87,45 @@ class TestInvokeStream:
     async def test_invoke_stream_max_tokens_priority(self) -> None:
         """invoke_stream max_tokens 3단 우선순위 검증."""
 
-        def _captured_max_tokens(bedrock: MagicMock) -> int:
-            body_str = bedrock.invoke_model_with_response_stream.call_args.kwargs["body"]
-            return json.loads(body_str)["max_tokens"]
+        def _captured_max_tokens(anthropic: MagicMock) -> int:
+            return anthropic.messages.stream.call_args.kwargs["max_tokens"]
 
         # Case 1: 명시값 > 생성자 값
-        bedrock1 = _make_bedrock_mock([])
-        client1 = LLMClient(bedrock_client=bedrock1, model_id=MODEL_ID, max_tokens=4096)
+        anthropic1 = _make_anthropic_mock([])
+        client1 = LLMClient(anthropic_client=anthropic1, model_id=MODEL_ID, max_tokens=4096)
         await _collect(client1.invoke_stream("p", max_tokens=512))
-        assert _captured_max_tokens(bedrock1) == 512
+        assert _captured_max_tokens(anthropic1) == 512
 
         # Case 2: 생성자 값 사용 (invoke_stream max_tokens 생략)
-        bedrock2 = _make_bedrock_mock([])
-        client2 = LLMClient(bedrock_client=bedrock2, model_id=MODEL_ID, max_tokens=2048)
+        anthropic2 = _make_anthropic_mock([])
+        client2 = LLMClient(anthropic_client=anthropic2, model_id=MODEL_ID, max_tokens=2048)
         await _collect(client2.invoke_stream("p"))
-        assert _captured_max_tokens(bedrock2) == 2048
+        assert _captured_max_tokens(anthropic2) == 2048
 
         # Case 3: 생성자 기본값 4096 폴백
-        bedrock3 = _make_bedrock_mock([])
-        client3 = LLMClient(bedrock_client=bedrock3, model_id=MODEL_ID)
+        anthropic3 = _make_anthropic_mock([])
+        client3 = LLMClient(anthropic_client=anthropic3, model_id=MODEL_ID)
         await _collect(client3.invoke_stream("p"))
-        assert _captured_max_tokens(bedrock3) == 4096
+        assert _captured_max_tokens(anthropic3) == 4096
 
     @pytest.mark.asyncio
-    async def test_invoke_stream_raises_bedrock_api_error_on_client_error(
+    async def test_invoke_stream_raises_bedrock_api_error_on_api_error(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """invoke_model_with_response_stream ClientError → BedrockAPIError."""
-        bedrock = MagicMock()
-        bedrock.invoke_model_with_response_stream.side_effect = ClientError(
-            {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}},
-            "InvokeModelWithResponseStream",
+        """messages.stream APIStatusError → BedrockAPIError."""
+        response = MagicMock()
+        response.status_code = 429
+        api_error = APIStatusError(
+            message="Rate exceeded",
+            response=response,
+            body={"error": {"message": "Rate exceeded"}},
         )
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
+        anthropic = MagicMock()
+        anthropic.messages = MagicMock()
+        anthropic.messages.stream = MagicMock(side_effect=api_error)
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID)
 
+        import logging
         with caplog.at_level(logging.ERROR):
             with pytest.raises(BedrockAPIError):
                 await _collect(client.invoke_stream("prompt"))
@@ -117,51 +133,14 @@ class TestInvokeStream:
         assert any("llm_invoke_stream_failed" in r.message for r in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_invoke_stream_skips_invalid_chunks(self) -> None:
-        """invalid JSON 청크는 skip하고 스트림 계속."""
-        events = [
-            _delta_event("A"),
-            _invalid_chunk_event(),
-            _delta_event("B"),
-        ]
-        bedrock = _make_bedrock_mock(events)
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
-
-        chunks = await _collect(client.invoke_stream("prompt"))
-
-        assert "".join(chunks) == "AB"
-
-    @pytest.mark.asyncio
     async def test_invoke_stream_does_not_block_event_loop(self) -> None:
         """두 stream을 gather로 돌렸을 때 직렬화되지 않는다."""
-        import asyncio
-        import time as _time
+        # 매 호출마다 새 스트림 컨텍스트를 만들어야 한다 (text_stream이 일회용 iterator라서).
+        def _factory(**_kwargs):
+            return _FakeStreamContext([f"c{i}" for i in range(5)], delay=0.05)
 
-        class _SlowIterable:
-            def __init__(self, events, delay=0.05):
-                self._events = events
-                self._delay = delay
-                self._i = 0
-
-            def __iter__(self):
-                return self
-
-            def __next__(self):
-                if self._i >= len(self._events):
-                    raise StopIteration
-                _time.sleep(self._delay)
-                e = self._events[self._i]
-                self._i += 1
-                return e
-
-        events = [_delta_event(f"c{i}") for i in range(5)]
-
-        bedrock = MagicMock()
-        bedrock.invoke_model_with_response_stream.side_effect = [
-            {"body": _SlowIterable(events)},
-            {"body": _SlowIterable(events)},
-        ]
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID, max_tokens=256)
+        anthropic = _make_anthropic_mock(_factory)
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID, max_tokens=256)
 
         async def _first_chunk_time(agen):
             start = asyncio.get_event_loop().time()
@@ -175,49 +154,37 @@ class TestInvokeStream:
 
         # Tail-buffer delays first yield by ~3 events (3 * 0.05 = 0.15s).
         # Serialized: t2 >= 5 * 0.05 + 3 * 0.05 = 0.40s. Async: t2 ~= 0.15s.
-        assert t2 < 0.2, f"두 번째 stream이 직렬화됨: t1={t1:.3f}s, t2={t2:.3f}s"
+        assert t2 < 0.25, f"두 번째 stream이 직렬화됨: t1={t1:.3f}s, t2={t2:.3f}s"
 
     @pytest.mark.asyncio
     async def test_invoke_stream_strips_json_fence(self) -> None:
         """```json ... ``` 코드 펜스를 벗겨내고 내용만 yield."""
-        events = [
-            _delta_event("```json\n"),
-            _delta_event('{"a": '),
-            _delta_event("1}"),
-            _delta_event("\n```"),
-        ]
-        bedrock = _make_bedrock_mock(events)
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
+        chunks = ["```json\n", '{"a": ', "1}", "\n```"]
+        anthropic = _make_anthropic_mock(chunks)
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID)
 
-        chunks = await _collect(client.invoke_stream("prompt"))
+        result = await _collect(client.invoke_stream("prompt"))
 
-        assert "".join(chunks) == '{"a": 1}'
+        assert "".join(result) == '{"a": 1}'
 
     @pytest.mark.asyncio
     async def test_invoke_stream_strips_plain_fence(self) -> None:
         """``` ... ``` (언어 없는) 코드 펜스를 벗겨내고 내용만 yield."""
-        events = [
-            _delta_event("```\n"),
-            _delta_event('{"a": 1}'),
-            _delta_event("\n```"),
-        ]
-        bedrock = _make_bedrock_mock(events)
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
+        chunks = ["```\n", '{"a": 1}', "\n```"]
+        anthropic = _make_anthropic_mock(chunks)
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID)
 
-        chunks = await _collect(client.invoke_stream("prompt"))
+        result = await _collect(client.invoke_stream("prompt"))
 
-        assert "".join(chunks) == '{"a": 1}'
+        assert "".join(result) == '{"a": 1}'
 
     @pytest.mark.asyncio
     async def test_invoke_stream_no_fence_passthrough(self) -> None:
         """펜스 없는 응답은 내용이 변형 없이 yield된다."""
-        events = [
-            _delta_event('{"a"'),
-            _delta_event(": 1}"),
-        ]
-        bedrock = _make_bedrock_mock(events)
-        client = LLMClient(bedrock_client=bedrock, model_id=MODEL_ID)
+        chunks = ['{"a"', ": 1}"]
+        anthropic = _make_anthropic_mock(chunks)
+        client = LLMClient(anthropic_client=anthropic, model_id=MODEL_ID)
 
-        chunks = await _collect(client.invoke_stream("prompt"))
+        result = await _collect(client.invoke_stream("prompt"))
 
-        assert "".join(chunks) == '{"a": 1}'
+        assert "".join(result) == '{"a": 1}'

--- a/ai/tests/test_logging_property.py
+++ b/ai/tests/test_logging_property.py
@@ -1,13 +1,12 @@
-"""hypothesis 기반 LLMClient 로깅 property 테스트.
+"""hypothesis 기반 LLMClient 로깅 property 테스트 (이슈 #232).
 
 Property 8: 요청별 correlation_id 일관성
 """
 
 import asyncio
-import io
 import json
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -16,13 +15,17 @@ from ai.clients.llm import LLMClient
 from ai.schemas.accept import AcceptOutput
 
 
-def _make_bedrock_mock(payload: dict) -> MagicMock:
-    """주어진 payload를 Bedrock 응답 형식으로 반환하는 mock (호출마다 새 BytesIO)."""
-    envelope = {"content": [{"type": "text", "text": json.dumps(payload)}]}
-    raw = json.dumps(envelope).encode()
+def _make_anthropic_mock(payload: dict) -> MagicMock:
+    """주어진 payload를 Anthropic 응답 형식으로 반환하는 mock (호출마다 새 메시지)."""
+
+    def _response(**_):
+        msg = MagicMock()
+        msg.content = [MagicMock(text=json.dumps(payload))]
+        return msg
 
     mock = MagicMock()
-    mock.invoke_model.side_effect = lambda **_: {"body": io.BytesIO(raw)}
+    mock.messages = MagicMock()
+    mock.messages.create = AsyncMock(side_effect=_response)
     return mock
 
 
@@ -69,8 +72,8 @@ def _capture_logs(client: LLMClient) -> tuple[list[dict], list[dict]]:
 @given(st.data())
 def test_correlation_id_consistency(_data):
     valid_payload = {"is_current_required_step_completed": True}
-    bedrock_mock = _make_bedrock_mock(valid_payload)
-    client = LLMClient(bedrock_client=bedrock_mock, model_id="test-model")
+    anthropic_mock = _make_anthropic_mock(valid_payload)
+    client = LLMClient(anthropic_client=anthropic_mock, model_id="test-model")
 
     logs1, logs2 = _capture_logs(client)
 

--- a/ai/tests/test_orchestrator.py
+++ b/ai/tests/test_orchestrator.py
@@ -1,15 +1,14 @@
-"""ai/services/__init__.py 오케스트레이터 단위 테스트.
+"""ai/services/__init__.py 오케스트레이터 단위 테스트 — Anthropic Direct API (이슈 #232).
 
-3개 public async 함수가 boto3 클라이언트를 받아 올바른 LLM/RAG 와이어링을
-수행하고 적절한 Pydantic 출력을 반환하는지 검증한다.
+3개 public async 함수가 AsyncAnthropic + bedrock-agent-runtime 클라이언트를 받아
+올바른 LLM/RAG 와이어링을 수행하고 적절한 Pydantic 출력을 반환하는지 검증한다.
 """
 
 from __future__ import annotations
 
-import io
 import json
 from typing import Any, Optional
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -111,17 +110,22 @@ def _side_panel_input() -> SidePanelInput:
 
 
 # ---------------------------------------------------------------------------
-# Bedrock mock factories
+# Mock factories
 # ---------------------------------------------------------------------------
 
 
-def _bedrock_runtime_mock(payload: dict) -> MagicMock:
-    """invoke_model이 주어진 payload를 Claude 응답 형식으로 반환하는 mock."""
-    envelope = {"content": [{"type": "text", "text": json.dumps(payload, ensure_ascii=False)}]}
-    raw = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+def _anthropic_mock(payload: dict) -> MagicMock:
+    """messages.create가 주어진 payload를 Claude 응답 형식으로 반환하는 mock."""
+    text_payload = json.dumps(payload, ensure_ascii=False)
+
+    def _response(**_):
+        msg = MagicMock()
+        msg.content = [MagicMock(text=text_payload)]
+        return msg
 
     mock = MagicMock()
-    mock.invoke_model.side_effect = lambda **_: {"body": io.BytesIO(raw)}
+    mock.messages = MagicMock()
+    mock.messages.create = AsyncMock(side_effect=_response)
     return mock
 
 
@@ -179,12 +183,12 @@ def _valid_side_panel_payload() -> dict:
 class TestGenerateSteps:
     @pytest.mark.asyncio
     async def test_returns_generate_output(self):
-        runtime = _bedrock_runtime_mock(_valid_generate_payload())
+        runtime = _anthropic_mock(_valid_generate_payload())
         agent = _bedrock_agent_mock([{"text": "DOJ 청크", "score": 0.9}])
 
         result = await generate_steps(
             input_data=_generate_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
@@ -195,29 +199,29 @@ class TestGenerateSteps:
         assert result.generated_steps[0].name == "Step 1"
 
     @pytest.mark.asyncio
-    async def test_uses_provided_model_id_in_invoke_model(self):
-        runtime = _bedrock_runtime_mock(_valid_generate_payload())
+    async def test_uses_provided_model_id(self):
+        runtime = _anthropic_mock(_valid_generate_payload())
         agent = _bedrock_agent_mock()
 
         await generate_steps(
             input_data=_generate_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
         )
 
-        kwargs = runtime.invoke_model.call_args.kwargs
-        assert kwargs["modelId"] == _MODEL_ID
+        kwargs = runtime.messages.create.call_args.kwargs
+        assert kwargs["model"] == _MODEL_ID
 
     @pytest.mark.asyncio
     async def test_uses_provided_kb_id_in_retrieve(self):
-        runtime = _bedrock_runtime_mock(_valid_generate_payload())
+        runtime = _anthropic_mock(_valid_generate_payload())
         agent = _bedrock_agent_mock()
 
         await generate_steps(
             input_data=_generate_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
@@ -230,20 +234,20 @@ class TestGenerateSteps:
     @pytest.mark.asyncio
     async def test_rag_failure_is_non_fatal(self):
         # RAG가 예외를 던져도 LLM 호출은 진행되어야 한다 (RAGClient가 [] 반환)
-        runtime = _bedrock_runtime_mock(_valid_generate_payload())
+        runtime = _anthropic_mock(_valid_generate_payload())
         agent = MagicMock()
         agent.retrieve.side_effect = RuntimeError("KB 다운")
 
         result = await generate_steps(
             input_data=_generate_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
         )
 
         assert isinstance(result, GenerateOutput)
-        runtime.invoke_model.assert_called_once()
+        runtime.messages.create.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -254,11 +258,11 @@ class TestGenerateSteps:
 class TestJudgeRequiredStep:
     @pytest.mark.asyncio
     async def test_returns_accept_output_true(self):
-        runtime = _bedrock_runtime_mock({"is_current_required_step_completed": True})
+        runtime = _anthropic_mock({"is_current_required_step_completed": True})
 
         result = await judge_required_step(
             input_data=_accept_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             model_id=_MODEL_ID,
         )
 
@@ -267,11 +271,11 @@ class TestJudgeRequiredStep:
 
     @pytest.mark.asyncio
     async def test_returns_accept_output_false(self):
-        runtime = _bedrock_runtime_mock({"is_current_required_step_completed": False})
+        runtime = _anthropic_mock({"is_current_required_step_completed": False})
 
         result = await judge_required_step(
             input_data=_accept_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             model_id=_MODEL_ID,
         )
 
@@ -280,22 +284,22 @@ class TestJudgeRequiredStep:
 
     @pytest.mark.asyncio
     async def test_uses_provided_model_id(self):
-        runtime = _bedrock_runtime_mock({"is_current_required_step_completed": True})
+        runtime = _anthropic_mock({"is_current_required_step_completed": True})
 
         await judge_required_step(
             input_data=_accept_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             model_id=_MODEL_ID,
         )
 
-        kwargs = runtime.invoke_model.call_args.kwargs
-        assert kwargs["modelId"] == _MODEL_ID
+        kwargs = runtime.messages.create.call_args.kwargs
+        assert kwargs["model"] == _MODEL_ID
 
     @pytest.mark.asyncio
     async def test_skip_when_current_required_step_is_none(self):
         # current_required_step=None → LLM 호출 없이 즉시 False 반환
         runtime = MagicMock()
-        runtime.invoke_model = MagicMock()
+        # (auto-created via MagicMock attribute access)
 
         input_data = AcceptInput(
             project_info=_project(),
@@ -308,13 +312,13 @@ class TestJudgeRequiredStep:
 
         result = await judge_required_step(
             input_data=input_data,
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             model_id=_MODEL_ID,
         )
 
         assert isinstance(result, AcceptOutput)
         assert result.is_current_required_step_completed is False
-        runtime.invoke_model.assert_not_called()
+        runtime.messages.create.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -325,12 +329,12 @@ class TestJudgeRequiredStep:
 class TestGenerateSidePanel:
     @pytest.mark.asyncio
     async def test_returns_side_panel_output(self):
-        runtime = _bedrock_runtime_mock(_valid_side_panel_payload())
+        runtime = _anthropic_mock(_valid_side_panel_payload())
         agent = _bedrock_agent_mock([{"text": "DOJ 청크", "score": 0.9}])
 
         result = await generate_side_panel(
             input_data=_side_panel_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
@@ -343,30 +347,30 @@ class TestGenerateSidePanel:
 
     @pytest.mark.asyncio
     async def test_uses_provided_model_id_and_kb_id(self):
-        runtime = _bedrock_runtime_mock(_valid_side_panel_payload())
+        runtime = _anthropic_mock(_valid_side_panel_payload())
         agent = _bedrock_agent_mock()
 
         await generate_side_panel(
             input_data=_side_panel_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
         )
 
-        assert runtime.invoke_model.call_args.kwargs["modelId"] == _MODEL_ID
+        assert runtime.messages.create.call_args.kwargs["model"] == _MODEL_ID
         # search_doj + search_custom 모두 같은 KB ID 사용
         for call in agent.retrieve.call_args_list:
             assert call.kwargs["knowledgeBaseId"] == _KB_ID
 
     @pytest.mark.asyncio
     async def test_calls_both_doj_and_custom_kb(self):
-        runtime = _bedrock_runtime_mock(_valid_side_panel_payload())
+        runtime = _anthropic_mock(_valid_side_panel_payload())
         agent = _bedrock_agent_mock()
 
         await generate_side_panel(
             input_data=_side_panel_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
@@ -399,30 +403,30 @@ class TestDeliveryInterface:
     @pytest.mark.asyncio
     async def test_all_three_functions_return_correct_output_types(self):
         """3개 public 함수의 입출력 스키마 검증."""
-        runtime_gen = _bedrock_runtime_mock(_valid_generate_payload())
+        runtime_gen = _anthropic_mock(_valid_generate_payload())
         agent_gen = _bedrock_agent_mock()
         gen_result = await generate_steps(
             input_data=_generate_input(),
-            bedrock_runtime_client=runtime_gen,
+            anthropic_client=runtime_gen,
             bedrock_agent_client=agent_gen,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
         )
         assert isinstance(gen_result, GenerateOutput)
 
-        runtime_acc = _bedrock_runtime_mock({"is_current_required_step_completed": True})
+        runtime_acc = _anthropic_mock({"is_current_required_step_completed": True})
         acc_result = await judge_required_step(
             input_data=_accept_input(),
-            bedrock_runtime_client=runtime_acc,
+            anthropic_client=runtime_acc,
             model_id=_MODEL_ID,
         )
         assert isinstance(acc_result, AcceptOutput)
 
-        runtime_sp = _bedrock_runtime_mock(_valid_side_panel_payload())
+        runtime_sp = _anthropic_mock(_valid_side_panel_payload())
         agent_sp = _bedrock_agent_mock()
         sp_result = await generate_side_panel(
             input_data=_side_panel_input(),
-            bedrock_runtime_client=runtime_sp,
+            anthropic_client=runtime_sp,
             bedrock_agent_client=agent_sp,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
@@ -431,19 +435,19 @@ class TestDeliveryInterface:
 
     @pytest.mark.asyncio
     async def test_injected_mock_clients_are_actually_called(self):
-        """의존성 주입 패턴 동작 확인 — 주입한 mock의 invoke_model/retrieve가 호출되어야 한다."""
-        runtime = _bedrock_runtime_mock(_valid_generate_payload())
+        """의존성 주입 패턴 동작 확인 — 주입한 mock의 messages.create/retrieve가 호출되어야 한다."""
+        runtime = _anthropic_mock(_valid_generate_payload())
         agent = _bedrock_agent_mock()
 
         await generate_steps(
             input_data=_generate_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
         )
 
-        runtime.invoke_model.assert_called_once()
+        runtime.messages.create.assert_called_once()
         agent.retrieve.assert_called_once()
 
     def test_orchestrator_files_no_backend_imports(self):
@@ -482,12 +486,12 @@ class TestDataSourceIdPropagation:
 
     @pytest.mark.asyncio
     async def test_generate_steps_passes_doj_id_to_retrieve(self):
-        runtime = _bedrock_runtime_mock(_valid_generate_payload())
+        runtime = _anthropic_mock(_valid_generate_payload())
         agent = _bedrock_agent_mock([{"text": "DOJ 청크", "score": 0.9}])
 
         await generate_steps(
             input_data=_generate_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
@@ -503,12 +507,12 @@ class TestDataSourceIdPropagation:
 
     @pytest.mark.asyncio
     async def test_generate_steps_without_id_omits_filter(self):
-        runtime = _bedrock_runtime_mock(_valid_generate_payload())
+        runtime = _anthropic_mock(_valid_generate_payload())
         agent = _bedrock_agent_mock()
 
         await generate_steps(
             input_data=_generate_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
@@ -520,12 +524,12 @@ class TestDataSourceIdPropagation:
 
     @pytest.mark.asyncio
     async def test_generate_side_panel_passes_both_ids(self):
-        runtime = _bedrock_runtime_mock(_valid_side_panel_payload())
+        runtime = _anthropic_mock(_valid_side_panel_payload())
         agent = _bedrock_agent_mock()
 
         await generate_side_panel(
             input_data=_side_panel_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,
@@ -546,12 +550,12 @@ class TestDataSourceIdPropagation:
 
     @pytest.mark.asyncio
     async def test_generate_side_panel_without_ids_omits_filters(self):
-        runtime = _bedrock_runtime_mock(_valid_side_panel_payload())
+        runtime = _anthropic_mock(_valid_side_panel_payload())
         agent = _bedrock_agent_mock()
 
         await generate_side_panel(
             input_data=_side_panel_input(),
-            bedrock_runtime_client=runtime,
+            anthropic_client=runtime,
             bedrock_agent_client=agent,
             model_id=_MODEL_ID,
             kb_id=_KB_ID,

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,12 +5,15 @@ DB_PASSWORD=postgres
 DB_NAME=pocodb
 DB_PORT=5432
 
-# AWS Config
+# AWS Config — RAG (Bedrock KB) 만 유지. LLM 호출은 Anthropic Direct (#232).
 AWS_REGION=us-east-1
-BEDROCK_MODEL_ID=anthropic.claude-3-5-sonnet-20241022-v2:0
+BEDROCK_MODEL_ID=claude-haiku-4-5-20251001
 BEDROCK_KB_ID=
 BEDROCK_DOJ_DATA_SOURCE_ID=
 BEDROCK_CUSTOM_DATA_SOURCE_ID=
+
+# Anthropic Direct API (LLM 호출 — #232)
+ANTHROPIC_API_KEY=
 
 # JWT Config (Lambda A 발급, A/B 모두 검증)
 JWT_SECRET_KEY=

--- a/backend/app/ai/services/orchestrator.py
+++ b/backend/app/ai/services/orchestrator.py
@@ -1,6 +1,8 @@
 import boto3
 from typing import AsyncIterator
 
+from anthropic import AsyncAnthropic
+
 from app.core.config import settings
 from app.core.logging import get_logger
 from ai import generate_steps, judge_required_step, generate_side_panel, generate_side_panel_stream, generate_design_export
@@ -9,7 +11,9 @@ from ai.clients.rag import RAGClient
 
 logger = get_logger(__name__)
 
-bedrock_runtime = boto3.client("bedrock-runtime", region_name="us-east-1")
+# Anthropic Direct API client (LLM 호출 전용 — 이슈 #232).
+anthropic_client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
+# RAG는 여전히 Bedrock KB (bedrock-agent-runtime) 그대로 유지.
 bedrock_agent = boto3.client("bedrock-agent-runtime", region_name="us-east-1")
 
 
@@ -17,7 +21,7 @@ async def call_accept(input_data):
     logger.debug("ai: invoking accept (judge_required_step)")
     try:
         return await judge_required_step(
-            input_data, bedrock_runtime, settings.BEDROCK_MODEL_ID
+            input_data, anthropic_client, settings.BEDROCK_MODEL_ID
         )
     except Exception:
         logger.error("ai: accept invocation failed", exc_info=True)
@@ -29,7 +33,7 @@ async def call_generate(input_data):
     try:
         return await generate_steps(
             input_data,
-            bedrock_runtime,
+            anthropic_client,
             bedrock_agent,
             settings.BEDROCK_MODEL_ID,
             settings.BEDROCK_KB_ID,
@@ -45,7 +49,7 @@ async def call_side_panel(input_data):
     try:
         return await generate_side_panel(
             input_data,
-            bedrock_runtime,
+            anthropic_client,
             bedrock_agent,
             settings.BEDROCK_MODEL_ID,
             settings.BEDROCK_KB_ID,
@@ -58,7 +62,7 @@ async def call_side_panel(input_data):
 
 
 async def call_side_panel_stream(input_data) -> AsyncIterator[str]:
-    llm = LLMClient(bedrock_client=bedrock_runtime, model_id=settings.BEDROCK_MODEL_ID)
+    llm = LLMClient(anthropic_client=anthropic_client, model_id=settings.BEDROCK_MODEL_ID)
     rag = RAGClient(bedrock_agent_client=bedrock_agent, kb_id=settings.BEDROCK_KB_ID)
     async for chunk in generate_side_panel_stream(
         input_data,
@@ -76,7 +80,7 @@ async def call_design_export(input_data):
     try:
         return await generate_design_export(
             input_data,
-            bedrock_runtime,
+            anthropic_client,
             settings.BEDROCK_MODEL_ID,
         )
     except Exception:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -16,12 +16,15 @@ class Settings(BaseSettings):
     DB_PORT: int = 5432
     DB_SSL: bool = False
 
-    # AWS
+    # AWS — RAG (Bedrock KB)는 그대로 유지. LLM은 Anthropic Direct로 전환 (#232).
     AWS_REGION: str = "ap-northeast-2"
-    BEDROCK_MODEL_ID: str = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    BEDROCK_MODEL_ID: str = "claude-haiku-4-5-20251001"  # Anthropic Direct API 형식
     BEDROCK_KB_ID: str = ""
     BEDROCK_DOJ_DATA_SOURCE_ID: str = ""
     BEDROCK_CUSTOM_DATA_SOURCE_ID: str = ""
+
+    # Anthropic Direct API
+    ANTHROPIC_API_KEY: str = ""
 
     # JWT
     JWT_SECRET_KEY: str = "change-me"


### PR DESCRIPTION
## PR 요약
- LLM 호출 백엔드: Bedrock Direct invoke → Anthropic Direct API
- 모델 동일: `claude-haiku-4-5-20251001`
- RAG (Bedrock KB) 미변경 — `bedrock-agent-runtime` 그대로

## 변경 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 설정/환경 변경
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
1. anthropic SDK 의존성 + ANTHROPIC_API_KEY 슬롯 추가
2. LLMClient invoke/invoke_stream Anthropic Direct로 교체 + lone surrogate sanitize
3. services 시그니처 sweep + 시뮬레이터 빌더 갱신
4. backend orchestrator AsyncAnthropic 적용 (RAG는 bedrock-agent-runtime 유지)
5. 테스트 mock 일괄 교체 (Bedrock invoke_model → Anthropic messages.create)

## 체크리스트
- [x] 로컬에서 서버 정상 구동 확인 (business / ai)
- [x] 관련 API 정상 응답 확인
- [ ] DB 마이그레이션 필요 시 `alembic revision --autogenerate` 수행
- [ ] 불필요한 코드 및 주석 제거
- [x] .env에 새 환경변수 추가 시 .env.example에도 반영

## 참고 사항
- `ai/clients/rag.py` — Bedrock KB Retrieve 그대로
- `ai/prompts/`, `content/required-steps/`, `ai/schemas/` — 휴리스틱 가드·콘텐츠 보존
- `cost_measurement/` — 기존 Bedrock 측정 도구 격리 (.gitignore에 추가)
- `BedrockAPIError` 클래스명 — 호환성 유지 (의미 일반화는 백로그)